### PR TITLE
chore: release vacs-data v0.2.0

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "vacs-data-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "vacs-data-diagnostics",
@@ -515,14 +515,14 @@ dependencies = [
 
 [[package]]
 name = "vacs-data-diagnostics"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "vacs-data-importer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "console",
  "encoding_rs",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "vacs-data-validator"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "console",
  "vacs-data-diagnostics",

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
  "anstream",
  "anstyle",
@@ -232,9 +232,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "once_cell"
@@ -280,9 +280,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rustversion"
@@ -547,7 +547,7 @@ dependencies = [
 [[package]]
 name = "vacs-protocol"
 version = "1.1.0"
-source = "git+https://github.com/MorpheusXAUT/vacs?branch=v2#fc588ebd0689f4e04e471b449e466594092fa452"
+source = "git+https://github.com/MorpheusXAUT/vacs?branch=v2#26421ebeb2dc6bc4d0f5ac44b971e4312c7c95d7"
 dependencies = [
  "serde",
  "serde_json",
@@ -557,7 +557,7 @@ dependencies = [
 [[package]]
 name = "vacs-vatsim"
 version = "0.2.1"
-source = "git+https://github.com/MorpheusXAUT/vacs?branch=v2#fc588ebd0689f4e04e471b449e466594092fa452"
+source = "git+https://github.com/MorpheusXAUT/vacs?branch=v2#26421ebeb2dc6bc4d0f5ac44b971e4312c7c95d7"
 dependencies = [
  "regex",
  "serde",
@@ -651,6 +651,6 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "zmij"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1966f8ac2c1f76987d69a74d0e0f929241c10e78136434e3be70ff7f58f64214"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["cli", "diagnostics", "importer", "validator"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/MorpheusXAUT/vacs-data"


### PR DESCRIPTION
includes updates `vacs-*` crates for subpage validations