### PR TITLE
feat: add json output option to importer

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "vacs-data-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "vacs-data-diagnostics",
@@ -539,14 +539,14 @@ dependencies = [
 
 [[package]]
 name = "vacs-data-diagnostics"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "console",
 ]
 
 [[package]]
 name = "vacs-data-importer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "console",
  "encoding_rs",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "vacs-data-validator"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "console",
  "vacs-data-diagnostics",

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -411,7 +411,22 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d7e18e3dd1d31e0ee5e863a8091ffec2fcc271636586042452b656a22c8ee1"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -427,10 +442,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.7+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
 dependencies = [
  "winnow",
 ]
@@ -529,7 +553,7 @@ dependencies = [
  "encoding_rs_io",
  "serde",
  "serde_json",
- "toml",
+ "toml 1.0.0+spec-1.1.0",
  "vacs-data-diagnostics",
  "vacs-protocol",
  "vacs-vatsim",
@@ -563,7 +587,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "toml",
+ "toml 0.9.11+spec-1.1.0",
  "tracing",
  "vacs-protocol",
 ]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -17,7 +17,7 @@ encoding_rs_io = "0.1.7"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
-toml = { version = "0.9.11", features = ["serde"] }
+toml = { version = "1.0.0", features = ["serde"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "json"] }
 vacs-data-diagnostics = { path = "./diagnostics" }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["cli", "diagnostics", "importer", "validator"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/MorpheusXAUT/vacs-data"

--- a/tools/cli/src/cli.rs
+++ b/tools/cli/src/cli.rs
@@ -13,7 +13,7 @@ pub struct Cli {
     #[arg(short, long)]
     pub quiet: bool,
 
-    /// Logging output format
+    /// Logging output format. Supported: human, github
     #[arg(long, default_value_t = LogFormat::Human)]
     pub log_format: LogFormat,
 
@@ -65,6 +65,10 @@ pub enum ImportCommand {
         #[arg(short, long)]
         output: Option<PathBuf>,
 
+        /// Format to use for output files. Supported: toml, json
+        #[arg(short, long, default_value_t = vacs_data_importer::OutputFormat::Toml)]
+        format: vacs_data_importer::OutputFormat,
+
         /// Overwrite existing files
         #[arg(long, conflicts_with = "merge")]
         overwrite: bool,
@@ -91,6 +95,10 @@ pub enum ImportCommand {
         /// Output directory
         #[arg(short, long)]
         output: Option<PathBuf>,
+
+        /// Format to use for output files. Supported: toml, json
+        #[arg(short, long, default_value_t = vacs_data_importer::OutputFormat::Toml)]
+        format: vacs_data_importer::OutputFormat,
 
         /// Prefixes to filter positions by
         #[arg(short, long, value_name = "PREFIX")]

--- a/tools/cli/src/cli.rs
+++ b/tools/cli/src/cli.rs
@@ -28,9 +28,10 @@ pub struct Cli {
 #[derive(Debug, Subcommand)]
 pub enum Command {
     /// Run validations on the whole dataset
+    #[command(arg_required_else_help = true)]
     Validate {
-        /// Dataset root to validate (positional). Defaults to repo dataset/ if found, else "."
-        #[arg(value_name = "INPUT")]
+        /// Dataset root to validate (positional).
+        #[arg(value_name = "INPUT", required_unless_present = "input")]
         input_pos: Option<PathBuf>,
 
         /// Dataset root to validate
@@ -48,13 +49,14 @@ pub enum Command {
 #[derive(Debug, Subcommand)]
 pub enum ImportCommand {
     /// Import data from the VATglasses project, converting it to vacs dataset format
+    #[command(arg_required_else_help = true)]
     Vatglasses {
         /// Input JSON file (positional)
-        #[arg(value_name = "INPUT")]
+        #[arg(value_name = "INPUT", required_unless_present = "input")]
         input_pos: Option<PathBuf>,
 
         /// Output directory (positional)
-        #[arg(value_name = "OUTPUT")]
+        #[arg(value_name = "OUTPUT", required_unless_present = "output")]
         output_pos: Option<PathBuf>,
 
         /// Input JSON file
@@ -79,13 +81,14 @@ pub enum ImportCommand {
     },
 
     /// Import data from an EuroScope sectorfile, converting it to vacs dataset format
+    #[command(arg_required_else_help = true)]
     Euroscope {
         /// Input JSON file (positional)
-        #[arg(value_name = "INPUT")]
+        #[arg(value_name = "INPUT", required_unless_present = "input")]
         input_pos: Option<PathBuf>,
 
         /// Output directory (positional)
-        #[arg(value_name = "OUTPUT")]
+        #[arg(value_name = "OUTPUT", required_unless_present = "output")]
         output_pos: Option<PathBuf>,
 
         /// Input JSON file

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -2,7 +2,6 @@ mod cli;
 
 use crate::cli::{Cli, Command, ImportCommand};
 use clap::Parser;
-use vacs_data_diagnostics::log;
 
 pub fn main() {
     let cli = Cli::parse();
@@ -10,10 +9,7 @@ pub fn main() {
 
     match cli.cmd {
         Command::Validate { input_pos, input } => {
-            let Some(input) = input.or(input_pos) else {
-                log::error("Missing input path. Either provide INPUT or use --i/--input.");
-                std::process::exit(2);
-            };
+            let input = input.or(input_pos).unwrap();
 
             if vacs_data_validator::validate(&input).is_err() {
                 std::process::exit(1);
@@ -31,14 +27,8 @@ pub fn main() {
                     format,
                 },
         } => {
-            let Some(input) = input.or(input_pos) else {
-                log::error("Missing input path. Either provide INPUT or use --i/--input.");
-                std::process::exit(2);
-            };
-            let Some(output) = output.or(output_pos) else {
-                log::error("Missing output path. Either provide OUTPUT or use --o/--output.");
-                std::process::exit(2);
-            };
+            let input = input.or(input_pos).unwrap();
+            let output = output.or(output_pos).unwrap();
 
             if vacs_data_importer::vatglasses::parse(&input, &output, overwrite, merge, format)
                 .is_err()
@@ -59,20 +49,14 @@ pub fn main() {
                     format,
                 },
         } => {
-            let Some(input) = input.or(input_pos) else {
-                log::error("Missing input path. Either provide INPUT or use --i/--input.");
-                std::process::exit(2);
-            };
-            let Some(output) = output.or(output_pos) else {
-                log::error("Missing output path. Either provide OUTPUT or use --o/--output.");
-                std::process::exit(2);
-            };
+            let input = input.or(input_pos).unwrap();
+            let output = output.or(output_pos).unwrap();
             let prefixes = prefixes.unwrap_or_default();
 
             if vacs_data_importer::euroscope::parse(
                 &input, &output, &prefixes, overwrite, merge, format,
             )
-                .is_err()
+            .is_err()
             {
                 std::process::exit(1);
             }

--- a/tools/cli/src/main.rs
+++ b/tools/cli/src/main.rs
@@ -28,6 +28,7 @@ pub fn main() {
                     output,
                     overwrite,
                     merge,
+                    format,
                 },
         } => {
             let Some(input) = input.or(input_pos) else {
@@ -39,7 +40,9 @@ pub fn main() {
                 std::process::exit(2);
             };
 
-            if vacs_data_importer::vatglasses::parse(&input, &output, overwrite, merge).is_err() {
+            if vacs_data_importer::vatglasses::parse(&input, &output, overwrite, merge, format)
+                .is_err()
+            {
                 std::process::exit(1);
             }
         }
@@ -53,6 +56,7 @@ pub fn main() {
                     prefixes,
                     overwrite,
                     merge,
+                    format,
                 },
         } => {
             let Some(input) = input.or(input_pos) else {
@@ -65,7 +69,9 @@ pub fn main() {
             };
             let prefixes = prefixes.unwrap_or_default();
 
-            if vacs_data_importer::euroscope::parse(&input, &output, &prefixes, overwrite, merge)
+            if vacs_data_importer::euroscope::parse(
+                &input, &output, &prefixes, overwrite, merge, format,
+            )
                 .is_err()
             {
                 std::process::exit(1);

--- a/tools/importer/src/format.rs
+++ b/tools/importer/src/format.rs
@@ -1,0 +1,62 @@
+use serde::Serialize;
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputFormat {
+    #[default]
+    Toml,
+    Json,
+}
+
+impl OutputFormat {
+    #[must_use]
+    pub const fn variants() -> &'static [&'static str] {
+        &["toml", "json"]
+    }
+}
+
+impl fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OutputFormat::Toml => write!(f, "toml"),
+            OutputFormat::Json => write!(f, "json"),
+        }
+    }
+}
+
+impl FromStr for OutputFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "toml" => Ok(OutputFormat::Toml),
+            "json" => Ok(OutputFormat::Json),
+            _ => Err(format!(
+                "Invalid output format: {}. Supported formats: {}",
+                s,
+                Self::variants().join(", ")
+            )),
+        }
+    }
+}
+
+impl OutputFormat {
+    #[must_use]
+    pub const fn ext(&self) -> &'static str {
+        match self {
+            OutputFormat::Toml => "toml",
+            OutputFormat::Json => "json",
+        }
+    }
+}
+
+pub fn serialize<T: Serialize>(
+    value: &T,
+    format: OutputFormat,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match format {
+        OutputFormat::Toml => Ok(toml::to_string_pretty(value)?),
+        OutputFormat::Json => Ok(serde_json::to_string_pretty(value)?),
+    }
+}

--- a/tools/importer/src/lib.rs
+++ b/tools/importer/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod euroscope;
+pub mod format;
 pub mod vatglasses;
+
+pub use format::OutputFormat;
 
 use std::path::{Path, PathBuf};
 use vacs_data_diagnostics::log;


### PR DESCRIPTION
Both `import` commands now have an `-f`/`-format` option, allowing you to create `json` output files as well.