### PR TITLE
docs: update schema and docs to allow multi-line labels for all types

### DIFF
--- a/docs/dataset/profiles.md
+++ b/docs/dataset/profiles.md
@@ -139,7 +139,7 @@ Represents a single callable button.
 
 | Field        | Type                                  | Required | Description                                                                                                               |
 | :----------- | :------------------------------------ | :------- | :------------------------------------------------------------------------------------------------------------------------ |
-| `label`      | Array of strings                      | Yes      | Multi-line label (up to 3 lines). Can be empty array for blank keys.                                                      |
+| `label`      | String or Array of strings            | Yes      | Multi-line label (up to 3 lines). Can be empty string or empty array for blank keys.                                      |
 | `station_id` | String                                | No       | Station ID to call when pressed. Mutually exclusive with `page`. If neither is specified, the button will be disabled.    |
 | `page`       | [DirectAccessPage](#directaccesspage) | No       | Subpage to open when pressed. Mutually exclusive with `station_id`. If neither is specified, the button will be disabled. |
 
@@ -149,10 +149,10 @@ Represents a single callable button.
 
 Represents a single tab in a tabbed profile.
 
-| Field   | Type                                  | Required | Description                           |
-| :------ | :------------------------------------ | :------- | :------------------------------------ |
-| `label` | String                                | Yes      | Tab name displayed in the interface.  |
-| `page`  | [DirectAccessPage](#directaccesspage) | Yes      | The page containing the grid of keys. |
+| Field   | Type                                  | Required | Description                                                                  |
+| :------ | :------------------------------------ | :------- | :--------------------------------------------------------------------------- |
+| `label` | String or Array of strings            | Yes      | Multi-line tab name (1-3 lines, cannot be empty) displayed in the interface. |
+| `page`  | [DirectAccessPage](#directaccesspage) | Yes      | The page containing the grid of keys.                                        |
 
 ## Geo Profile Components
 
@@ -201,7 +201,7 @@ A clickable button that can trigger a direct access page or call a station.
 
 | Field   | Type                                  | Required | Description                                                |
 | :------ | :------------------------------------ | :------- | :--------------------------------------------------------- |
-| `label` | Array of strings                      | Yes      | Multi-line label (1-3 lines, cannot be empty).             |
+| `label` | String or Array of strings            | Yes      | Multi-line label (1-3 lines, cannot be empty).             |
 | `size`  | Number                                | Yes      | Button size (> 0). Controls relative sizing in the layout. |
 | `page`  | [DirectAccessPage](#directaccesspage) | No       | Optional nested page to display when button is pressed.    |
 
@@ -232,6 +232,7 @@ The following validation rules apply:
   - All size values (`height`, `width`) must match pattern `^\d+(%|rem)$`
   - All numeric values (padding, gap, size, thickness) must be appropriate to their type (non-negative or positive)
 - Labels:
+  - Can be provided as a single string or an array of strings
   - Can have up to 3 lines
   - Geo button labels must have at least 1 line
   - Direct access key labels can be empty (for blank keys)

--- a/docs/schemas/profiles.schema.json
+++ b/docs/schemas/profiles.schema.json
@@ -26,6 +26,10 @@
         "type": "string"
       }
     },
+    "LabelStringOrLines": {
+      "description": "Label that can be either a single string or an array of strings (lines).",
+      "oneOf": [{ "type": "string" }, { "$ref": "#/$defs/LabelLines" }]
+    },
     "FlexDirection": {
       "type": "string",
       "enum": ["row", "col"]
@@ -100,7 +104,7 @@
       "additionalProperties": false,
       "required": ["label"],
       "properties": {
-        "label": { "$ref": "#/$defs/LabelLines" },
+        "label": { "$ref": "#/$defs/LabelStringOrLines" },
         "station_id": { "$ref": "#/$defs/StationId" },
         "page": { "$ref": "#/$defs/DirectAccessPage" }
       },
@@ -133,7 +137,19 @@
       "additionalProperties": false,
       "required": ["label", "page"],
       "properties": {
-        "label": { "type": "string", "minLength": 1 },
+        "label": {
+          "allOf": [
+            { "$ref": "#/$defs/LabelStringOrLines" },
+            {
+              "if": { "type": "array" },
+              "then": { "minItems": 1 }
+            },
+            {
+              "if": { "type": "string" },
+              "then": { "minLength": 1 }
+            }
+          ]
+        },
         "page": { "$ref": "#/$defs/DirectAccessPage" }
       }
     },
@@ -144,7 +160,17 @@
       "properties": {
         "label": {
           "description": "Geo page button labels must be non-empty and cannot exceed 3 lines.",
-          "allOf": [{ "$ref": "#/$defs/LabelLines" }, { "minItems": 1 }]
+          "allOf": [
+            { "$ref": "#/$defs/LabelStringOrLines" },
+            {
+              "if": { "type": "array" },
+              "then": { "minItems": 1 }
+            },
+            {
+              "if": { "type": "string" },
+              "then": { "minLength": 1 }
+            }
+          ]
         },
         "size": {
           "$ref": "#/$defs/PositiveNumber"

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 [[package]]
 name = "vacs-protocol"
 version = "1.1.0"
-source = "git+https://github.com/MorpheusXAUT/vacs?branch=v2#d4dedeb2fa18d320a799fa310cf74c0ff4257745"
+source = "git+https://github.com/MorpheusXAUT/vacs?branch=v2#5336e4d2af83de97c031c7f9ff0ba95c7b241866"
 dependencies = [
  "serde",
  "serde_json",
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "vacs-vatsim"
 version = "0.2.1"
-source = "git+https://github.com/MorpheusXAUT/vacs?branch=v2#d4dedeb2fa18d320a799fa310cf74c0ff4257745"
+source = "git+https://github.com/MorpheusXAUT/vacs?branch=v2#5336e4d2af83de97c031c7f9ff0ba95c7b241866"
 dependencies = [
  "regex",
  "serde",


### PR DESCRIPTION
`Tab` labels may now also contain up to 3 lines, but **must** always have at least one (non-empty) line