### PR TITLE
Update EGLL (Heathrow) profile to new format

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -171,6 +171,7 @@ id = "EGCC_A_DEL"
 prefixes = ["EGCC"]
 frequency = "199.998"
 facility_type = "DEL"
+profile_id = "EG-North_LAG"
 
 [[positions]]
 id = "EGCC_P_GND"
@@ -653,6 +654,7 @@ id = "EGKK_A_DEL"
 prefixes = ["EGKK"]
 frequency = "199.998"
 facility_type = "DEL"
+profile_id = "EGKK"
 
 [[positions]]
 id = "EGKK_P_GND"
@@ -799,6 +801,7 @@ id = "EGLL_A_DEL"
 prefixes = ["EGLL"]
 frequency = "199.998"
 facility_type = "DEL"
+profile_id = "EGLL"
 
 [[positions]]
 id = "EGLL_P_GND"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -143,6 +143,12 @@ frequency = "121.705"
 facility_type = "DEL"
 
 [[positions]]
+id = "EGCC_A_DEL"
+prefixes = ["EGCC"]
+frequency = "199.998"
+facility_type = "DEL"
+
+[[positions]]
 id = "EGCC_P_GND"
 prefixes = ["EGCC"]
 frequency = "130.650"
@@ -551,6 +557,12 @@ frequency = "121.955"
 facility_type = "DEL"
 
 [[positions]]
+id = "EGKK_A_DEL"
+prefixes = ["EGKK"]
+frequency = "199.998"
+facility_type = "DEL"
+
+[[positions]]
 id = "EGKK_P_GND"
 prefixes = ["EGKK"]
 frequency = "134.230"
@@ -668,6 +680,12 @@ facility_type = "GND"
 id = "EGLL_DEL"
 prefixes = ["EGLL"]
 frequency = "121.980"
+facility_type = "DEL"
+
+[[positions]]
+id = "EGLL_A_DEL"
+prefixes = ["EGLL"]
+frequency = "199.998"
 facility_type = "DEL"
 
 [[positions]]

--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -138,10 +138,6 @@
             "station_id": "EGLL_DEL"
           },
           {
-            "label": ["GMP", "Assist"],
-            "station_id": "EGLL_A_DEL"
-          },
-          {
             "label": ["AIR", "North"],
             "station_id": "EGLL_N_TWR"
           },
@@ -151,6 +147,10 @@
           },
           {
             "label": []
+          },
+          {
+            "label": ["GMP", "Assist"],
+            "station_id": "EGLL_A_DEL"
           },
           {
             "label": []

--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -3,41 +3,322 @@
   "type": "Tabbed",
   "tabs": [
     {
-      "label": "Heathrow",
+      "label": "ADC",
       "page": {
-        "rows": 10,
-        "client_page": {
-          "include": [
-            "EGLL*",
-            "EGKK_*APP",
-            "THAMES*",
-            "EGLC_*",
-            "EGLF_*APP",
-            "EGLW*",
-            "LON_M*",
-            "LON_E*",
-            "LON_C*",
-            "LON_D*",
-            "LON_H*",
-            "LON_S*",
-            "LON_O*",
-            "LON_SC*",
-            "LON_CTR",
-            "LON__CTR",
-            "LTC_N*",
-            "LTC_S*",
-            "LTC_E*",
-            "LTC_M*",
-            "LTC_CTR",
-            "LTC__CTR",
-            "EGTT_*",
-            "UK_*"
-          ],
-          "exclude": ["EGLC_*GND"],
-          "priority": ["*_FMP", "*_APP", "*_TWR", "*_GND", "*_DEL", "*_CTR"],
-          "frequencies": "HideAll",
-          "grouping": "None"
-        }
+        "rows": 4,
+        "keys": [
+          {
+            "label": ["GMP"],
+            "station_id": "EGLL_DEL"
+          },
+          {
+            "label": ["GMC 1"],
+            "station_id": "EGLL_1_GND"
+          },
+          {
+            "label": ["GMC 2"],
+            "station_id": "EGLL_2_GND"
+          },
+          {
+            "label": ["GMC 3"],
+            "station_id": "EGLL_3_GND"
+          },
+          {
+            "label": ["PLN"],
+            "station_id": "EGLL_P_GND"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["AIR", "North"],
+            "station_id": "EGLL_N_TWR"
+          },
+          {
+            "label": ["AIR", "South"],
+            "station_id": "EGLL_S_TWR"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["TC", "SVFR"],
+            "station_id": "EGLC_APP"
+          },
+          {
+            "label": ["FIN"],
+            "station_id": "EGLL_F_APP"
+          },
+          {
+            "label": ["INT", "North"],
+            "station_id": "EGLL_N_APP"
+          },
+          {
+            "label": ["INT", "South"],
+            "station_id": "EGLL_S_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["WU", "APP"],
+            "station_id": "EGWU_APP"
+          },
+          {
+            "label": ["Solent", "RAD"],
+            "station_id": "SOLENT_APP"
+          },
+          {
+            "label": ["TC", "NW"],
+            "station_id": "LTC_NW_CTR"
+          },
+          {
+            "label": ["TC", "SW"],
+            "station_id": "LTC_SW_CTR"
+          },
+          {
+            "label": ["TC", "Essex"],
+            "station_id": "EGSS_APP"
+          },
+          {
+            "label": ["TC", "Farnboro"],
+            "station_id": "EGLF_APP"
+          },
+          {
+            "label": ["TC", "NE"],
+            "station_id": "LTC_NE_CTR"
+          },
+          {
+            "label": ["TC", "SE"],
+            "station_id": "LTC_SE_CTR"
+          },
+          {
+            "label": ["TC", "Thames"],
+            "station_id": "THAMES_APP"
+          },
+          {
+            "label": ["TC", "Gatwick"],
+            "station_id": "EGKK_APP"
+          }
+        ]
+      }
+    },
+    {
+      "label": "APC",
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": ["GMP"],
+            "station_id": "EGLL_DEL"
+          },
+          {
+            "label": ["GMC 1"],
+            "station_id": "EGLL_1_GND"
+          },
+          {
+            "label": ["GMC 2"],
+            "station_id": "EGLL_2_GND"
+          },
+          {
+            "label": ["GMC 3"],
+            "station_id": "EGLL_3_GND"
+          },
+          {
+            "label": ["AIR", "North"],
+            "station_id": "EGLL_N_TWR"
+          },
+          {
+            "label": ["AIR", "South"],
+            "station_id": "EGLL_S_TWR"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["London", "Heliport"],
+            "station_id": "EGLW_TWR"
+          },
+          {
+            "label": ["TC", "NW"],
+            "station_id": "LTC_NW_CTR"
+          },
+          {
+            "label": ["TC", "SW"],
+            "station_id": "LTC_SW_CTR"
+          },
+          {
+            "label": ["FIN"],
+            "station_id": "EGLL_F_APP"
+          },
+          {
+            "label": ["TC", "SVFR"],
+            "station_id": "EGLC_APP"
+          },
+          {
+            "label": ["TC", "NE"],
+            "station_id": "LTC_NE_CTR"
+          },
+          {
+            "label": ["TC", "SE"],
+            "station_id": "LTC_SE_CTR"
+          },
+          {
+            "label": ["INT", "North"],
+            "station_id": "EGLL_N_APP"
+          },
+          {
+            "label": ["INT", "South"],
+            "station_id": "EGLL_S_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["WU", "APP"],
+            "station_id": "EGWU_APP"
+          },
+          {
+            "label": ["LF", "RAD"],
+            "station_id": "EGLF_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["WU", "AIR"],
+            "station_id": "EGWU_TWR"
+          },
+          {
+            "label": ["LF", "LARS"],
+            "station_id": "EGLF_L_APP"
+          },
+          {
+            "label": ["TC", "Essex"],
+            "station_id": "EGSS_APP"
+          },
+          {
+            "label": ["TC", "Thames"],
+            "station_id": "THAMES_APP"
+          },
+          {
+            "label": ["TC", "Gatwick"],
+            "station_id": "EGKK_APP"
+          },
+          {
+            "label": ["Solent", "RAD"],
+            "station_id": "SOLENT_APP"
+          }
+        ]
+      }
+    },
+    {
+      "label": ["SUP", "Flow"],
+      "page": {
+        "rows": 2,
+        "keys": [
+          {
+            "label": ["UK", "FMP"],
+            "station_id": "UK_FMP"
+          },
+          {
+            "label": ["LTC", "FMP"],
+            "station_id": "LTC_FMP"
+          },
+          {
+            "label": ["UK", "FMP", "2"],
+            "station_id": "UK_A_FMP"
+          },
+          {
+            "label": ["UK", "FMP", "3"],
+            "station_id": "UK_B_FMP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["LAC", "Group", "Supvisr"],
+            "station_id": "LON_GS_CTR"
+          },
+          {
+            "label": ["LTC", "Group", "Supvisr"],
+            "station_id": "LTC_GS_CTR"
+          },
+          {
+            "label": ["MAN", "Group", "Supvisr"],
+            "station_id": "MAN_GS_CTR"
+          },
+          {
+            "label": ["MAN", "FMP"],
+            "station_id": "MAN_FMP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["STC", "FMP"],
+            "station_id": "STC_FMP"
+          },
+          {
+            "label": ["ScAC", "Group", "Supvisr"],
+            "station_id": "SCO_GS_CTR"
+          },
+          {
+            "label": ["STC", "Group", "Supvisr"],
+            "station_id": "STC_GS_CTR"
+          }
+        ]
       }
     }
   ]

--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -138,18 +138,6 @@
             "station_id": "EGLL_DEL"
           },
           {
-            "label": ["GMC 1"],
-            "station_id": "EGLL_1_GND"
-          },
-          {
-            "label": ["GMC 2"],
-            "station_id": "EGLL_2_GND"
-          },
-          {
-            "label": ["GMC 3"],
-            "station_id": "EGLL_3_GND"
-          },
-          {
             "label": ["GMP", "Assist"],
             "station_id": "EGLL_A_DEL"
           },
@@ -160,6 +148,15 @@
           {
             "label": ["AIR", "South"],
             "station_id": "EGLL_S_TWR"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
           },
           {
             "label": []

--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -53,7 +53,7 @@
           },
           {
             "label": ["TC", "SVFR"],
-            "station_id": "EGLC_APP"
+            "station_id": "EGLL-CTR-TC_SVFR"
           },
           {
             "label": ["FIN"],
@@ -191,7 +191,7 @@
           },
           {
             "label": ["TC", "SVFR"],
-            "station_id": "EGLC_APP"
+            "station_id": "EGLL-CTR-TC_SVFR"
           },
           {
             "label": ["TC", "NE"],

--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -24,11 +24,12 @@
             "station_id": "EGLL_3_GND"
           },
           {
-            "label": ["PLN"],
-            "station_id": "EGLL_P_GND"
+            "label": ["GMP", "Assist"],
+            "station_id": "EGLL_A_DEL"
           },
           {
-            "label": []
+            "label": ["PLN"],
+            "station_id": "EGLL_P_GND"
           },
           {
             "label": ["AIR", "North"],
@@ -149,15 +150,16 @@
             "station_id": "EGLL_3_GND"
           },
           {
+            "label": ["GMP", "Assist"],
+            "station_id": "EGLL_A_DEL"
+          },
+          {
             "label": ["AIR", "North"],
             "station_id": "EGLL_N_TWR"
           },
           {
             "label": ["AIR", "South"],
             "station_id": "EGLL_S_TWR"
-          },
-          {
-            "label": []
           },
           {
             "label": []

--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -319,6 +319,31 @@
           }
         ]
       }
+    },
+    {
+      "label": ["Other", "direct", "call"],
+      "page": {
+        "rows": 10,
+        "client_page": {
+          "include": [
+            "SOLENT*",
+            "THAMES*",
+            "ESSEX*",
+            "NAT_*",
+            "LON_*",
+            "LTC_*",
+            "SCO_*",
+            "STC_*",
+            "MAN_*",
+            "EG*_*",
+            "UK_*"
+          ],
+          "exclude": ["EGLL_*", "LTC_NW_*", "LTC_NE_*", "LTC_SW_*", "LTC_SE_*"],
+          "priority": ["*_FMP", "*_CTR", "*_APP", "*_TWR", "*_GND", "*_DEL"],
+          "frequencies": "HideAll",
+          "grouping": "None"
+        }
+      }
     }
   ]
 }

--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -106,7 +106,7 @@
             "station_id": "EGSS_APP"
           },
           {
-            "label": ["TC", "Farnboro"],
+            "label": ["LF", "RAD"],
             "station_id": "EGLF_APP"
           },
           {

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -1,8 +1,56 @@
-# LAG includes underlying TC positions
+####################
+# SUP/FLOW
+####################
+
+[[stations]]
+id = "UK_FMP"
+controlled_by = ["UK_FMP"]
+
+[[stations]]
+id = "UK_A_FMP"
+controlled_by = ["UK_A_FMP"]
+
+[[stations]]
+id = "UK_B_FMP"
+controlled_by = ["UK_B_FMP"]
+
+[[stations]]
+id = "MAN_FMP"
+controlled_by = ["MAN_FMP"]
+
+[[stations]]
+id = "LTC_FMP"
+controlled_by = ["LTC_FMP"]
+
+[[stations]]
+id = "STC_FMP"
+controlled_by = ["STC_FMP"]
+
+[[stations]]
+id = "LON_GS_CTR"
+controlled_by = ["LON_GS_CTR"]
+
+[[stations]]
+id = "LTC_GS_CTR"
+controlled_by = ["LTC_GS_CTR"]
+
+[[stations]]
+id = "SCO_GS_CTR"
+controlled_by = ["SCO_GS_CTR"]
+
+[[stations]]
+id = "STC_GS_CTR"
+controlled_by = ["STC_GS_CTR"]
+
+[[stations]]
+id = "MAN_GS_CTR"
+controlled_by = ["MAN_GS_CTR"]
 
 ####################
 # LAC POSITIONS
 ####################
+
+# LAG includes underlying TC positions
 
 [[stations]]
 id = "LON_CTR"
@@ -632,3 +680,149 @@ controlled_by = ["EGVV_D_CTR"]
 ####################
 # AERODROMES
 ####################
+
+[[stations]]
+id = "EGKK_APP"
+parent_id = "LTC_SW_CTR"
+controlled_by = ["EGKK_APP", "EGKK_F_APP"]
+
+[[stations]]
+id = "EGLC_GND"
+parent_id = "EGLC_TWR"
+controlled_by = ["EGLC_GND"]
+
+[[stations]]
+id = "EGLC_TWR"
+parent_id = "EGLC_APP"
+controlled_by = ["EGLC_TWR"]
+
+[[stations]]
+id = "EGLC_APP"
+parent_id = "THAMES_APP"
+controlled_by = ["EGLC_APP"]
+
+[[stations]]
+id = "EGLD_I_TWR"
+controlled_by = ["EGLD_I_TWR"]
+
+[[stations]]
+id = "EGLF_APP"
+parent_id = "LTC_SW_CTR"
+controlled_by = ["EGLF_APP", "EGLF_F_APP", "EGLF_L_APP"]
+
+[[stations]]
+id = "EGLF_F_APP"
+parent_id = "EGLF_APP"
+controlled_by = ["EGLF_F_APP"]
+
+[[stations]]
+id = "EGLF_L_APP"
+parent_id = "EGLF_APP"
+controlled_by = ["EGLF_L_APP"]
+
+[[stations]]
+id = "EGLL_DEL"
+parent_id = "EGLL_2_GND"
+controlled_by = ["EGLL_DEL"]
+
+[[stations]]
+id = "EGLL_P_GND"
+parent_id = "EGLL_DEL"
+controlled_by = ["EGLL_P_GND"]
+
+[[stations]]
+id = "EGLL_1_GND"
+parent_id = "EGLL_N_TWR"
+controlled_by = ["EGLL_1_GND", "EGLL_2_GND", "EGLL_3_GND"]
+
+[[stations]]
+id = "EGLL_2_GND"
+parent_id = "EGLL_S_TWR"
+controlled_by = ["EGLL_2_GND", "EGLL_1_GND", "EGLL_3_GND"]
+
+[[stations]]
+id = "EGLL_3_GND"
+parent_id = "EGLL_N_TWR"
+controlled_by = ["EGLL_3_GND", "EGLL_1_GND", "EGLL_2_GND"]
+
+[[stations]]
+id = "EGLL_S_TWR"
+parent_id = "EGLL_N_APP"
+controlled_by = ["EGLL_S_TWR", "EGLL_N_TWR"]
+
+[[stations]]
+id = "EGLL_N_TWR"
+parent_id = "EGLL_S_TWR"
+controlled_by = ["EGLL_N_TWR"]
+
+[[stations]]
+id = "EGLL_N_APP"
+parent_id = "LTC_SE_CTR"
+controlled_by = ["EGLL_N_APP", "EGLL_S_APP", "EGLL_F_APP"]
+
+[[stations]]
+id = "EGLL_S_APP"
+parent_id = "EGLL_N_APP"
+controlled_by = ["EGLL_S_APP"]
+
+[[stations]]
+id = "EGLL_F_APP"
+parent_id = "EGLL_N_APP"
+controlled_by = ["EGLL_F_APP"]
+
+[[stations]]
+id = "EGLM_R_TWR"
+controlled_by = ["EGLM_R_TWR"]
+
+[[stations]]
+id = "EGLW_TWR"
+parent_id = "EGLL_N_APP"
+controlled_by = ["EGLW_TWR", "EGLC_APP", "THAMES_APP", "LTC_SE_CTR", "LTC_S_CTR", "LTC_CTR", "LON_DL_CTR", "LON_D_CTR", "LON_S_CTR", "LON_SC_CTR", "LON_CTR"]
+
+[[stations]]
+id = "EGSS_APP"
+parent_id = "LTC_NL_CTR"
+controlled_by = ["EGSS_APP", "EGSS_F_APP", "ESSEX_APP"]
+
+[[stations]]
+id = "EGTF_R_TWR"
+controlled_by = ["EGTF_R_TWR"]
+
+[[stations]]
+id = "EGWU_GND"
+parent_id = "EGWU_TWR"
+controlled_by = ["EGWU_GND"]
+
+[[stations]]
+id = "EGWU_TWR"
+parent_id = "EGWU_APP"
+controlled_by = ["EGWU_TWR", "EGWU_F_APP", "EGWU_P_APP"]
+
+[[stations]]
+id = "EGWU_APP"
+parent_id = "EGLL_N_APP"
+controlled_by = ["EGWU_APP", "EGVV_D_CTR", "EGVV_W_CTR", "EGVV_CTR"]
+
+[[stations]]
+id = "EGWU_F_APP"
+parent_id = "EGWU_APP"
+controlled_by = ["EGWU_F_APP"]
+
+[[stations]]
+id = "EGWU_P_APP"
+parent_id = "EGWU_F_APP"
+controlled_by = ["EGWU_P_APP"]
+
+[[stations]]
+id = "ESSEX_APP"
+controlled_by = ["ESSEX_APP"]
+
+[[stations]]
+id = "SOLENT_APP"
+parent_id = "LON_HW_CTR"
+controlled_by = ["SOLENT_APP"]
+
+[[stations]]
+id = "THAMES_APP"
+parent_id = "LTC_SE_CTR"
+controlled_by = ["THAMES_APP"]

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -781,7 +781,7 @@ controlled_by = ["EGLM_R_TWR"]
 
 [[stations]]
 id = "EGLW_TWR"
-parent_id = "EGLL-CTR-SVFR"
+parent_id = "EGLL-CTR-TC_SVFR"
 controlled_by = ["EGLW_TWR"]
 
 [[stations]]

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -781,8 +781,8 @@ controlled_by = ["EGLM_R_TWR"]
 
 [[stations]]
 id = "EGLW_TWR"
-parent_id = "EGLL_N_APP"
-controlled_by = ["EGLW_TWR", "EGLC_APP", "THAMES_APP", "LTC_SE_CTR", "LTC_S_CTR", "LTC_CTR", "LON_DL_CTR", "LON_D_CTR", "LON_S_CTR", "LON_SC_CTR", "LON_CTR"]
+parent_id = "EGLL-CTR-SVFR"
+controlled_by = ["EGLW_TWR"]
 
 [[stations]]
 id = "EGSS_APP"
@@ -831,3 +831,9 @@ controlled_by = ["SOLENT_APP"]
 id = "THAMES_APP"
 parent_id = "LTC_SE_CTR"
 controlled_by = ["THAMES_APP"]
+
+# Position inserted for correct top-down TC SFVR *within* the London CTR (not within the London City CTR/CTA)
+[[stations]]
+id = "EGLL-CTR-TC_SVFR"
+parent_id = "EGLL_N_APP"
+controlled_by = ["EGLC_APP", "THAMES_APP", "LTC_SE_CTR", "LTC_S_CTR", "LTC_CTR", "LON_DL_CTR", "LON_D_CTR", "LON_S_CTR", "LON_SC_CTR", "LON_CTR"]

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -726,6 +726,11 @@ parent_id = "EGLL_2_GND"
 controlled_by = ["EGLL_DEL"]
 
 [[stations]]
+id = "EGLL_A_DEL"
+parent_id = "EGLL_DEL"
+controlled_by = ["EGLL_A_DEL"]
+
+[[stations]]
 id = "EGLL_P_GND"
 parent_id = "EGLL_DEL"
 controlled_by = ["EGLL_P_GND"]

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -836,4 +836,15 @@ controlled_by = ["THAMES_APP"]
 [[stations]]
 id = "EGLL-CTR-TC_SVFR"
 parent_id = "EGLL_N_APP"
-controlled_by = ["EGLC_APP", "THAMES_APP", "LTC_SE_CTR", "LTC_S_CTR", "LTC_CTR", "LON_DL_CTR", "LON_D_CTR", "LON_S_CTR", "LON_SC_CTR", "LON_CTR"]
+controlled_by = [
+  "EGLC_APP",
+  "THAMES_APP",
+  "LTC_SE_CTR",
+  "LTC_S_CTR",
+  "LTC_CTR",
+  "LON_DL_CTR",
+  "LON_D_CTR",
+  "LON_S_CTR",
+  "LON_SC_CTR",
+  "LON_CTR",
+]


### PR DESCRIPTION
Updates the Heathrow (EGLL) profile to the new format.

## Views

There are 4 views, ADC, APC, SUP/Flow, and other direct call, somewhat specific to their role (though still accounting for the potential requirement for top-down operation), with whitespace added for visual clarity. A potential future enhancement is changing this to a GEO layout to remove blank buttons and enlarge important stations.

Other direct call is not intended for day-to-day use, but rather for unusual situations (e.g. EGLL_GND has an aircraft calling from Gatwick, and wants to talk to EGKK_GND to see if it is there (true story)), and should not be used regularly.
Some education may be needed to to ensure controllers understand that the buttons resolve to the correct top-down owner.

<img width="1695" height="1478" alt="image" src="https://github.com/user-attachments/assets/37dc1da2-b11d-4498-8ee3-45f1ed966429" />

<img width="1692" height="1480" alt="image" src="https://github.com/user-attachments/assets/4c1ecde2-43e0-4413-86fc-bec473315433" />

<img width="1694" height="1477" alt="image" src="https://github.com/user-attachments/assets/90405b5c-b030-4524-a969-ca378cd5b4af" />

<img width="1692" height="1480" alt="image" src="https://github.com/user-attachments/assets/38eead41-6070-4914-9a65-d35b1c0db5e7" />

