### PR TITLE
fix: ensure consistent facility type for EG and VH positions

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -254,7 +254,7 @@ profile_id = "EG-Swanwick_Military"
 id = "EGDY_GND"
 prefixes = ["EGDY"]
 frequency = "122.100"
-facility_type = "TWR"
+facility_type = "GND"
 profile_id = "EG-Swanwick_Military"
 
 [[positions]]

--- a/dataset/VH/positions.json
+++ b/dataset/VH/positions.json
@@ -207,7 +207,7 @@
       "id": "VHHH_E_DEP",
       "prefixes": ["VHHH"],
       "frequency": "133.825",
-      "facility_type": "APP",
+      "facility_type": "DEP",
       "profile_id": "VHHK"
     },
     {


### PR DESCRIPTION
@vacs-project/dataset-maintainers-eg @vacs-project/dataset-maintainers-vh See [this message](https://discord.com/channels/1433202495978733815/1442067509795754014/1479960996041720009) and below on Discord: since we parse the facility type from the VATSIM callsign instead of selected "Facility" in EuroScope/controller clients, these two positions from your dataset would fail to match when someones logs onto them.

I'll add a validator to the dataset tools to catch this issue soon.