### PR TITLE
EPKK DIR fix

### DIFF
--- a/dataset/EP/stations.toml
+++ b/dataset/EP/stations.toml
@@ -560,7 +560,6 @@ controlled_by = [
 [[stations]]
 id = "EPKK_DIR"
 controlled_by = [
-  "EPKK_TWR",
   "EPKK_KK_APP",
   "EPKK_E_APP",
   "EPKK_APP",


### PR DESCRIPTION
Removed 'EPKK_TWR' from the controlled_by list for EPKK_DIR station.