### PR TITLE
Add EGGW/SC/SS profile

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -353,35 +353,35 @@ id = "EGGW_APP"
 prefixes = ["EGGW"]
 frequency = "129.550"
 facility_type = "APP"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGGW_F_APP"
 prefixes = ["EGGW"]
 frequency = "128.750"
 facility_type = "APP"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGGW_TWR"
 prefixes = ["EGGW"]
 frequency = "132.555"
 facility_type = "TWR"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGGW_GND"
 prefixes = ["EGGW"]
 frequency = "121.755"
 facility_type = "GND"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGGW_DEL"
 prefixes = ["EGGW"]
 frequency = "121.885"
 facility_type = "DEL"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGHC_TWR"
@@ -1396,21 +1396,21 @@ id = "EGSC_APP"
 prefixes = ["EGSC"]
 frequency = "120.965"
 facility_type = "APP"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGSC_A_APP"
 prefixes = ["EGSC"]
 frequency = "120.965"
 facility_type = "APP"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGSC_TWR"
 prefixes = ["EGSC"]
 frequency = "125.905"
 facility_type = "TWR"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGSH_APP"
@@ -1438,42 +1438,42 @@ id = "ESSEX_APP"
 prefixes = ["ESSEX"]
 frequency = "120.625"
 facility_type = "APP"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGSS_APP"
 prefixes = ["EGSS"]
 frequency = "120.625"
 facility_type = "APP"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGSS_F_APP"
 prefixes = ["EGSS"]
 frequency = "136.200"
 facility_type = "APP"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGSS_TWR"
 prefixes = ["EGSS"]
 frequency = "123.805"
 facility_type = "TWR"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGSS_GND"
 prefixes = ["EGSS"]
 frequency = "121.730"
 facility_type = "GND"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGSS_DEL"
 prefixes = ["EGSS"]
 frequency = "121.955"
 facility_type = "DEL"
-profile_id = "EG-Central_LAG"
+profile_id = "ESSEX"
 
 [[positions]]
 id = "EGSY_TWR"

--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -319,31 +319,6 @@
           }
         ]
       }
-    },
-    {
-      "label": ["Other", "direct", "call"],
-      "page": {
-        "rows": 10,
-        "client_page": {
-          "include": [
-            "SOLENT*",
-            "THAMES*",
-            "ESSEX*",
-            "NAT_*",
-            "LON_*",
-            "LTC_*",
-            "SCO_*",
-            "STC_*",
-            "MAN_*",
-            "EG*_*",
-            "UK_*"
-          ],
-          "exclude": ["EGLL_*", "LTC_NW_*", "LTC_NE_*", "LTC_SW_*", "LTC_SE_*"],
-          "priority": ["*_FMP", "*_CTR", "*_APP", "*_TWR", "*_GND", "*_DEL"],
-          "frequencies": "HideAll",
-          "grouping": "None"
-        }
-      }
     }
   ]
 }

--- a/dataset/EG/profiles/ESSEX.json
+++ b/dataset/EG/profiles/ESSEX.json
@@ -140,7 +140,93 @@
         "rows": 4,
         "keys": [
           {
+            "label": ["GMP"],
+            "station_id": "EGSS_DEL"
+          },
+          {
+            "label": ["GMC"],
+            "station_id": "EGSS_GND"
+          },
+          {
+            "label": ["AIR"],
+            "station_id": "EGSS_TWR"
+          },
+          {
             "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["FIN"],
+            "station_id": "EGSS_F_APP"
+          },
+          {
+            "label": ["INT"],
+            "station_id": "EGSS_APP"
+          },
+          {
+            "label": ["CO INT"],
+            "station_id": "ESSEX_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["SC", "APP"],
+            "station_id": "EGSC_APP"
+          },
+          {
+            "label": ["BB", "RAD"],
+            "station_id": "EGBB_APP"
+          },
+          {
+            "label": ["NX", "RAD"],
+            "station_id": "EGNX_APP"
+          },
+          {
+            "label": ["TC", "NW"],
+            "station_id": "LTC_NW_CTR"
+          },
+          {
+            "label": ["TC", "SW"],
+            "station_id": "LTC_SW_CTR"
+          },
+          {
+            "label": ["TC", "Luton"],
+            "station_id": "EGGW_APP"
+          },
+          {
+            "label": ["TC", "Heathrow"],
+            "station_id": "EGLL_N_APP"
+          },
+          {
+            "label": ["TC", "NE"],
+            "station_id": "LTC_NE_CTR"
+          },
+          {
+            "label": ["TC", "SE"],
+            "station_id": "LTC_SE_CTR"
+          },
+          {
+            "label": ["TC", "Thames"],
+            "station_id": "THAMES_APP"
+          },
+          {
+            "label": ["TC", "Gatwick"],
+            "station_id": "EGKK_APP"
           }
         ]
       }

--- a/dataset/EG/profiles/ESSEX.json
+++ b/dataset/EG/profiles/ESSEX.json
@@ -232,12 +232,102 @@
       }
     },
     {
-      "label": ["TC", "ESSEX"],
+      "label": ["APC"],
       "page": {
         "rows": 4,
         "keys": [
           {
+            "label": ["GW", "INT"],
+            "station_id": "EGGW_APP"
+          },
+          {
+            "label": ["GW", "FIN"],
+            "station_id": "EGGW_F_APP"
+          },
+          {
+            "label": ["GW", "AIR"],
+            "station_id": "EGGW_TWR"
+          },
+          {
+            "label": ["GW", "GMP"],
+            "station_id": "EGGW_DEL"
+          },
+          {
+            "label": ["SS", "INT"],
+            "station_id": "EGSS_APP"
+          },
+          {
+            "label": ["SS", "FIN"],
+            "station_id": "EGSS_F_APP"
+          },
+          {
+            "label": ["SS", "AIR"],
+            "station_id": "EGSS_TWR"
+
+          },
+          {
+            "label": ["SS", "GMP"],
+            "station_id": "EGSS_DEL"
+          },
+          {
+            "label": ["SC", "RAD"],
+            "station_id": "EGSC_APP"
+          },
+          {
+            "label": ["SC", "APC"],
+            "station_id": "EGSC_A_APP"
+          },
+          {
+            "label": ["SC", "AIR"],
+            "station_id": "EGSC_TWR"
+          },
+          {
             "label": []
+          },
+          {
+            "label": ["CO INT"],
+            "station_id": "ESSEX_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["TC", "NW"],
+            "station_id": "LTC_NW_CTR"
+          },
+          {
+            "label": ["TC", "NE"],
+            "station_id": "LTC_NE_CTR"
+          },
+          {
+            "label": ["UL", "APP"],
+            "station_id": "EGUL_APP"
+          },
+          {
+            "label": ["LF", "LARS"],
+            "station_id": "EGLF_L_APP"
+          },
+          {
+            "label": ["TC", "SW"],
+            "station_id": "LTC_SW_CTR"
+          },
+          {
+            "label": ["TC", "SE"],
+            "station_id": "LTC_SE_CTR"
+          },
+          {
+            "label": ["TC", "Thames"],
+            "station_id": "THAMES_APP"
+          },
+          {
+            "label": ["Duxford", "Info"],
+            "station_id": "EGSU_I_TWR"
           }
         ]
       }

--- a/dataset/EG/profiles/ESSEX.json
+++ b/dataset/EG/profiles/ESSEX.json
@@ -263,7 +263,6 @@
           {
             "label": ["SS", "AIR"],
             "station_id": "EGSS_TWR"
-
           },
           {
             "label": ["SS", "GMP"],

--- a/dataset/EG/profiles/ESSEX.json
+++ b/dataset/EG/profiles/ESSEX.json
@@ -397,31 +397,6 @@
           }
         ]
       }
-    },
-    {
-      "label": ["Other", "direct", "call"],
-      "page": {
-        "rows": 10,
-        "client_page": {
-          "include": [
-            "SOLENT*",
-            "THAMES*",
-            "ESSEX*",
-            "NAT_*",
-            "LON_*",
-            "LTC_*",
-            "SCO_*",
-            "STC_*",
-            "MAN_*",
-            "EG*_*",
-            "UK_*"
-          ],
-          "exclude": ["EGLL_*", "LTC_NW_*", "LTC_NE_*", "LTC_SW_*", "LTC_SE_*"],
-          "priority": ["*_FMP", "*_CTR", "*_APP", "*_TWR", "*_GND", "*_DEL"],
-          "frequencies": "HideAll",
-          "grouping": "None"
-        }
-      }
     }
   ]
 }

--- a/dataset/EG/profiles/ESSEX.json
+++ b/dataset/EG/profiles/ESSEX.json
@@ -8,7 +8,92 @@
         "rows": 4,
         "keys": [
           {
+            "label": ["GMP"],
+            "station_id": "EGGW_DEL"
+          },
+          {
+            "label": ["GMC"],
+            "station_id": "EGGW_GND"
+          },
+          {
+            "label": ["AIR"],
+            "station_id": "EGGW_TWR"
+          },
+          {
             "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["FIN"],
+            "station_id": "EGGW_F_APP"
+          },
+          {
+            "label": ["INT"],
+            "station_id": "EGGW_APP"
+          },
+          {
+            "label": ["CO INT"],
+            "station_id": "ESSEX_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["BB", "RAD"],
+            "station_id": "EGBB_APP"
+          },
+          {
+            "label": ["NX", "RAD"],
+            "station_id": "EGNX_APP"
+          },
+          {
+            "label": ["TC", "NW"],
+            "station_id": "LTC_NW_CTR"
+          },
+          {
+            "label": ["TC", "SW"],
+            "station_id": "LTC_SW_CTR"
+          },
+          {
+            "label": ["TC", "Stansted"],
+            "station_id": "EGSS_APP"
+          },
+          {
+            "label": ["TC", "Heathrow"],
+            "station_id": "EGLL_N_APP"
+          },
+          {
+            "label": ["TC", "NE"],
+            "station_id": "LTC_NE_CTR"
+          },
+          {
+            "label": ["TC", "SE"],
+            "station_id": "LTC_SE_CTR"
+          },
+          {
+            "label": ["TC", "Thames"],
+            "station_id": "THAMES_APP"
+          },
+          {
+            "label": ["TC", "Gatwick"],
+            "station_id": "EGKK_APP"
           }
         ]
       }

--- a/dataset/EG/profiles/ESSEX.json
+++ b/dataset/EG/profiles/ESSEX.json
@@ -1,0 +1,167 @@
+{
+  "id": "ESSEX",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["EGGW", "ADC"],
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": []
+          }
+        ]
+      }
+    },
+    {
+      "label": ["EGSC", "ADC"],
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": ["AIR"],
+            "station_id": "EGSC_TWR"
+          },
+          {
+            "label": ["RAD"],
+            "station_id": "EGSC_APP"
+          },
+          {
+            "label": ["APP"],
+            "station_id": "EGSC_A_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["SS", "FIN"],
+            "station_id": "EGSS_F_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          }
+        ]
+      }
+    },
+    {
+      "label": ["EGSS", "ADC"],
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": []
+          }
+        ]
+      }
+    },
+    {
+      "label": ["TC", "ESSEX"],
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": []
+          }
+        ]
+      }
+    },
+    {
+      "label": ["SUP", "Flow"],
+      "page": {
+        "rows": 2,
+        "keys": [
+          {
+            "label": ["UK", "FMP"],
+            "station_id": "UK_FMP"
+          },
+          {
+            "label": ["LTC", "FMP"],
+            "station_id": "LTC_FMP"
+          },
+          {
+            "label": ["UK", "FMP", "2"],
+            "station_id": "UK_A_FMP"
+          },
+          {
+            "label": ["UK", "FMP", "3"],
+            "station_id": "UK_B_FMP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["LAC", "Group", "Supvisr"],
+            "station_id": "LON_GS_CTR"
+          },
+          {
+            "label": ["LTC", "Group", "Supvisr"],
+            "station_id": "LTC_GS_CTR"
+          },
+          {
+            "label": ["MAN", "Group", "Supvisr"],
+            "station_id": "MAN_GS_CTR"
+          },
+          {
+            "label": ["MAN", "FMP"],
+            "station_id": "MAN_FMP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["STC", "FMP"],
+            "station_id": "STC_FMP"
+          },
+          {
+            "label": ["ScAC", "Group", "Supvisr"],
+            "station_id": "SCO_GS_CTR"
+          },
+          {
+            "label": ["STC", "Group", "Supvisr"],
+            "station_id": "STC_GS_CTR"
+          }
+        ]
+      }
+    },
+    {
+      "label": ["Other", "direct", "call"],
+      "page": {
+        "rows": 10,
+        "client_page": {
+          "include": [
+            "SOLENT*",
+            "THAMES*",
+            "ESSEX*",
+            "NAT_*",
+            "LON_*",
+            "LTC_*",
+            "SCO_*",
+            "STC_*",
+            "MAN_*",
+            "EG*_*",
+            "UK_*"
+          ],
+          "exclude": ["EGLL_*", "LTC_NW_*", "LTC_NE_*", "LTC_SW_*", "LTC_SE_*"],
+          "priority": ["*_FMP", "*_CTR", "*_APP", "*_TWR", "*_GND", "*_DEL"],
+          "frequencies": "HideAll",
+          "grouping": "None"
+        }
+      }
+    }
+  ]
+}

--- a/dataset/EG/profiles/ESSEX.json
+++ b/dataset/EG/profiles/ESSEX.json
@@ -294,7 +294,22 @@
             "label": []
           },
           {
+            "label": ["GW", "GMC"],
+            "station_id": "EGGW_GND"
+          },
+          {
             "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["LF", "LARS"],
+            "station_id": "EGLF_L_APP"
+          },
+          {
+            "label": ["SS", "GMC"],
+            "station_id": "EGSS_GND"
           },
           {
             "label": ["TC", "NW"],
@@ -309,8 +324,8 @@
             "station_id": "EGUL_APP"
           },
           {
-            "label": ["LF", "LARS"],
-            "station_id": "EGLF_L_APP"
+            "label": ["Duxford", "Info"],
+            "station_id": "EGSU_I_TWR"
           },
           {
             "label": ["TC", "NE"],
@@ -325,8 +340,7 @@
             "station_id": "THAMES_APP"
           },
           {
-            "label": ["Duxford", "Info"],
-            "station_id": "EGSU_I_TWR"
+            "label": []
           }
         ]
       }

--- a/dataset/EG/profiles/ESSEX.json
+++ b/dataset/EG/profiles/ESSEX.json
@@ -302,8 +302,8 @@
             "station_id": "LTC_NW_CTR"
           },
           {
-            "label": ["TC", "NE"],
-            "station_id": "LTC_NE_CTR"
+            "label": ["TC", "SW"],
+            "station_id": "LTC_SW_CTR"
           },
           {
             "label": ["UL", "APP"],
@@ -314,8 +314,8 @@
             "station_id": "EGLF_L_APP"
           },
           {
-            "label": ["TC", "SW"],
-            "station_id": "LTC_SW_CTR"
+            "label": ["TC", "NE"],
+            "station_id": "LTC_NE_CTR"
           },
           {
             "label": ["TC", "SE"],

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -682,6 +682,41 @@ controlled_by = ["EGVV_D_CTR"]
 ####################
 
 [[stations]]
+id = "EGBB_APP"
+parent_id = "LTC_MC_CTR"
+controlled_by = ["EGBB_APP", "EGBB_F_APP"]
+
+[[stations]]
+id = "EGBB_F_APP"
+parent_id = "EGBB_APP"
+controlled_by = ["EGBB_F_APP"]
+
+[[stations]]
+id = "EGGW_DEL"
+parent_id = "EGGW_GND"
+controlled_by = ["EGGW_DEL"]
+
+[[stations]]
+id = "EGGW_GND"
+parent_id = "EGGW_TWR"
+controlled_by = ["EGGW_APP"]
+
+[[stations]]
+id = "EGGW_TWR"
+parent_id = "EGGW_APP"
+controlled_by = ["EGGW_TWR"]
+
+[[stations]]
+id = "EGGW_APP"
+parent_id = "LTC_NW_CTR"
+controlled_by = ["EGGW_APP", "EGGW_F_APP", "ESSEX_APP"]
+
+[[stations]]
+id = "EGGW_F_APP"
+parent_id = "EGGW_APP"
+controlled_by = ["EGGW_F_APP"]
+
+[[stations]]
 id = "EGKK_APP"
 parent_id = "LTC_SW_CTR"
 controlled_by = ["EGKK_APP", "EGKK_F_APP"]
@@ -783,6 +818,16 @@ controlled_by = ["EGLM_R_TWR"]
 id = "EGLW_TWR"
 parent_id = "EGLL-CTR-TC_SVFR"
 controlled_by = ["EGLW_TWR"]
+
+[[stations]]
+id = "EGNX_APP"
+parent_id = "LTC_MW_CTR"
+controlled_by = ["EGNX_APP", "EGNX_F_APP"]
+
+[[stations]]
+id = "EGNX_F_APP"
+parent_id = "EGNX_APP"
+controlled_by = ["EGNX_F_APP"]
 
 [[stations]]
 id = "EGSC_TWR"

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -785,9 +785,29 @@ parent_id = "EGLL-CTR-TC_SVFR"
 controlled_by = ["EGLW_TWR"]
 
 [[stations]]
+id = "EGSC_TWR"
+parent_id = "EGSC_APP"
+controlled_by = ["EGSC_TWR"]
+
+[[stations]]
+id = "EGSC_APP"
+parent_id = "EGSC_A_APP"
+controlled_by = ["EGSC_APP"]
+
+[[stations]]
+id = "EGSC_A_APP"
+parent_id = "EGSS_APP"
+controlled_by = ["EGSC_A_APP"]
+
+[[stations]]
 id = "EGSS_APP"
 parent_id = "LTC_NL_CTR"
 controlled_by = ["EGSS_APP", "EGSS_F_APP", "ESSEX_APP"]
+
+[[stations]]
+id = "EGSS_F_APP"
+parent_id = "EGSS_APP"
+controlled_by = ["EGSS_F_APP"]
 
 [[stations]]
 id = "EGTF_R_TWR"

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -899,8 +899,8 @@ controlled_by = ["EGWU_TWR", "EGWU_F_APP", "EGWU_P_APP"]
 
 [[stations]]
 id = "EGWU_APP"
-parent_id = "EGLL_N_APP"
-controlled_by = ["EGWU_APP", "EGVV_D_CTR", "EGVV_W_CTR", "EGVV_CTR"]
+parent_id = "EGVV_D_CTR"
+controlled_by = ["EGWU_APP", "EGWU_F_APP", "EGWU_P_APP"]
 
 [[stations]]
 id = "EGWU_F_APP"

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -870,8 +870,22 @@ parent_id = "EGSS_APP"
 controlled_by = ["EGSS_F_APP"]
 
 [[stations]]
+id = "EGSU_I_TWR"
+controlled_by = ["EGSU_I_TWR"]
+
+[[stations]]
 id = "EGTF_R_TWR"
 controlled_by = ["EGTF_R_TWR"]
+
+[[stations]]
+id = "EGUL_APP"
+parent_id = "EGVV_E_CTR"
+controlled_by = ["EGUL_APP", "EGUL_P_APP"]
+
+[[stations]]
+id = "EGUL_P_APP"
+parent_id = "EGUL_APP"
+controlled_by = ["EGUL_P_APP"]
 
 [[stations]]
 id = "EGWU_GND"

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -845,6 +845,21 @@ parent_id = "EGSS_APP"
 controlled_by = ["EGSC_A_APP"]
 
 [[stations]]
+id = "EGSS_DEL"
+parent_id = "EGSS_GND"
+controlled_by = ["EGSS_DEL"]
+
+[[stations]]
+id = "EGSS_GND"
+parent_id = "EGSS_TWR"
+controlled_by = ["EGSS_TWR"]
+
+[[stations]]
+id = "EGSS_TWR"
+parent_id = "EGSS_APP"
+controlled_by = ["EGSS_TWR"]
+
+[[stations]]
 id = "EGSS_APP"
 parent_id = "LTC_NL_CTR"
 controlled_by = ["EGSS_APP", "EGSS_F_APP", "ESSEX_APP"]


### PR DESCRIPTION
Adds profile for stations covered top-down by `ESSEX_APP` (not technically TC ESSEX though due to SC).

As with the LL profile, the intent is that ADC can use only their tab (and the SUP/FLOW tab if needed) for most/all calls.
APC is a common tab for GW, SC, and SS APC units.

Also removes the all direct call from LL - it is expected that the telephone directory is used in place of it (especially with the search function).

# Views

<img width="1697" height="1261" alt="image" src="https://github.com/user-attachments/assets/e7787431-c6cd-48bc-8a39-7472275424e8" />

<img width="1692" height="1256" alt="image" src="https://github.com/user-attachments/assets/359db876-0356-4d41-bd84-a649c27478c9" />

<img width="1692" height="1260" alt="image" src="https://github.com/user-attachments/assets/9ded6755-2923-4f34-845d-2ffeb98ec353" />

<img width="1690" height="1263" alt="image" src="https://github.com/user-attachments/assets/3bf1f925-4384-41f1-b2f2-8f56707bb748" />

<img width="1692" height="1256" alt="image" src="https://github.com/user-attachments/assets/1c76856f-35b0-4dda-9fe3-392a1ed8a8cd" />

