### PR TITLE
AT98 addition

### DIFF
--- a/dataset/FAJO/positions.json
+++ b/dataset/FAJO/positions.json
@@ -29,6 +29,13 @@
       "prefixes": ["FAJO"],
       "frequency": "120.900",
       "facility_type": "FSS"
+    },
+    {
+      "id": "AT98_I_FSS",
+      "prefixes": ["AT98"],
+      "frequency": "119.500",
+      "facility_type": "FSS",
+      "profile_id": "AT98"
     }
   ]
 }

--- a/dataset/FAJO/profiles/AT98.json
+++ b/dataset/FAJO/profiles/AT98.json
@@ -1,0 +1,43 @@
+{
+  "id": "AT98",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["WOLFS", "FANG"],
+      "page": {
+        "rows": 3,
+        "keys": [
+          {
+            "label": []
+          },
+          {
+            "label": ["WOLFS", "FANG", "INFO"]
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["JOBURG", "OCA"],
+            "station_id": "LXGB_P_APP"
+          },
+          {
+            "label": ["OCA", "FLOW"],
+            "station_id": "FAJO_FMP"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dataset/FAJO/stations.json
+++ b/dataset/FAJO/stations.json
@@ -23,6 +23,11 @@
       "id": "FAJO_3_FSS",
       "parent_id": "FAJO_FSS",
       "controlled_by": ["FAJO_3_FSS"]
+    },
+    {
+      "id": "AT98_I_FSS",
+      "parent_id": "FAJO_FSS",
+      "controlled_by": ["AT98_I_FSS"]
     }
   ]
 }


### PR DESCRIPTION
This adds AT98 profile and positions
<img width="1496" height="1167" alt="image" src="https://github.com/user-attachments/assets/fae72c87-1041-4696-b060-e80fa47d5dab" />
