### PR TITLE
feat (EDGG): Add EBBR stations to profiles

### DIFF
--- a/dataset/EDGG/profiles/EDGG_EBG5.json
+++ b/dataset/EDGG/profiles/EDGG_EBG5.json
@@ -166,33 +166,19 @@
             "station_id": "EDGG-NOR"
           },
           {
-            "label": [""]
+            "label": ["EDDK", "DKA"],
+            "station_id": "EDGG-DKA"
           },
           {
             "label": ["ETAR", "TWR"],
             "station_id": "EDGG-TART"
           },
           {
-            "label": ["EDYY", "LNH"]
-          },
-          {
-            "label": ["EBUU", "BL"]
-          },
-          {
-            "label": ["EDDK", "DKA"],
-            "station_id": "EDGG-DKA"
+            "label": ["EDYY", "LNH"],
+            "station_id": "EDYY-LNH"
           },
           {
             "label": [""]
-          },
-          {
-            "label": [""]
-          },
-          {
-            "label": ["EDYY", "LXH"]
-          },
-          {
-            "label": ["EBUU", "BE"]
           },
           {
             "label": ["EDDS", "STG"],
@@ -205,16 +191,36 @@
             "label": [""]
           },
           {
+            "label": ["EDYY", "LXH"],
+            "station_id": "EDYY-LXH"
+          },
+          {
+            "label": ["EBBU", "EHS"],
+            "station_id": "EBBU-EHS"
+          },
+          {
+            "label": ["EBBU", "ELS"],
+            "station_id": "EBBU-ELS"
+          },
+          {
+            "label": ["LFST", "APP"]
+          },
+          {
+            "label": [""]
+          },
+          {
             "label": ["LFEE", "UE"]
           },
           {
             "label": [""]
           },
           {
-            "label": ["LFST", "APP"]
+            "label": ["EBBU", "LUS"],
+            "station_id": "EBBU-LUS"
           },
           {
-            "label": ["ELLX", "APP"]
+            "label": ["ELLX", "APP"],
+            "station_id": "ELLX-APP"
           },
           {
             "label": [""]

--- a/dataset/EDGG/profiles/EDGG_EBG7.json
+++ b/dataset/EDGG/profiles/EDGG_EBG7.json
@@ -8,8 +8,8 @@
         "rows": 6,
         "keys": [
           {
-            "label": ["RL"],
-            "station_id": "EDYY-RL"
+            "label": ["RH"],
+            "station_id": "EDYY-RH"
           },
           {
             "label": ["PADH"],
@@ -32,8 +32,8 @@
             "station_id": "EDGG-DLGE"
           },
           {
-            "label": ["RH"],
-            "station_id": "EDYY-RH"
+            "label": ["RL"],
+            "station_id": "EDYY-RL"
           },
           {
             "label": ["EDGG", "SIG"],
@@ -53,8 +53,8 @@
             "label": [""]
           },
           {
-            "label": ["ML"],
-            "station_id": "EDYY-ML"
+            "label": ["MH"],
+            "station_id": "EDYY-MH"
           },
           {
             "label": ["EDGG", "TAU"],
@@ -77,8 +77,8 @@
             "station_id": "EDGG-DKG"
           },
           {
-            "label": ["MH"],
-            "station_id": "EDYY-MH"
+            "label": ["ML"],
+            "station_id": "EDYY-ML"
           },
           {
             "label": ["EDGG", "RUD"],
@@ -122,13 +122,16 @@
             "station_id": "EDUU-NTM"
           },
           {
-            "label": ["EDYY", "YO"]
+            "label": ["EDYY", "LNH"],
+            "station_id": "EDYY-LNH"
           },
           {
-            "label": ["EBBU", "BE"]
+            "label": ["EBBU", "EHS"],
+            "station_id": "EBBU-EHS"
           },
           {
-            "label": [""]
+            "label": ["EBBU", "ELS"],
+            "station_id": "EBBU-ELS"
           },
           {
             "label": [""]

--- a/dataset/EDGG/profiles/EDGG_KLA.json
+++ b/dataset/EDGG/profiles/EDGG_KLA.json
@@ -59,7 +59,7 @@
             "station_id": "EDGG-PAH"
           },
           {
-            "label": ["EBBU", "BE"]
+            "label": [""]
           },
           {
             "label": ["EHAA", "ACE"]
@@ -110,7 +110,22 @@
             "station_id": "EDUU-FFM"
           },
           {
-            "label": ["EDYY", "YO"]
+            "label": [""]
+          },
+          {
+            "label": ["EDYY", "LNH"],
+            "station_id": "EDYY-LNH"
+          },
+          {
+            "label": ["EBBU", "EHS"],
+            "station_id": "EBBU-EHS"
+          },
+          {
+            "label": ["EBBU", "ELS"],
+            "station_id": "EBBU-ELS"
+          },
+          {
+            "label": [""]
           }
         ]
       }

--- a/dataset/EDGG/profiles/EDGG_MBB.json
+++ b/dataset/EDGG/profiles/EDGG_MBB.json
@@ -209,7 +209,8 @@
             "station_id": "EDYY-SL"
           },
           {
-            "label": ["EDYY", "YO"]
+            "label": ["EDYY", "LNH"],
+            "station_id": "EDYY-LNH"
           },
           {
             "label": ["EDGG", "GIN"],
@@ -256,7 +257,7 @@
             "station_id": "EDWW-HRZ"
           },
           {
-            "label": ["EBUU", "BE"]
+            "label": [""]
           },
           {
             "label": ["EHVK", "CRS"]
@@ -275,10 +276,12 @@
             "label": [""]
           },
           {
-            "label": [""]
+            "label": ["EBUU", "EHS"],
+            "station_id": "EBBU-EHS"
           },
           {
-            "label": [""]
+            "label": ["EBUU", "ELS"],
+            "station_id": "EBBU-ELS"
           },
           {
             "label": [""]
@@ -486,7 +489,8 @@
             "station_id": "EDUU-ERL"
           },
           {
-            "label": ["EDYY", "YO"]
+            "label": ["EDYY", "LNH"],
+            "station_id": "EDYY-LNH"
           },
           {
             "label": ["GIN"],
@@ -501,14 +505,16 @@
             "station_id": "EDWW-HRZ"
           },
           {
-            "label": ["EBBU", "BE"]
+            "label": ["EBBU", "EHS"],
+            "station_id": "EBBU-EHS"
           },
           {
             "label": ["EDYY", "SL"],
             "station_id": "EDYY-SL"
           },
           {
-            "label": ["EDYY", "YL"]
+            "label": ["EDYY", "LXH"],
+            "station_id": "EDYY-LXH"
           },
           {
             "label": ["HEF"],
@@ -523,7 +529,8 @@
             "station_id": "EDMM-HAL"
           },
           {
-            "label": ["EBBU", "BL"]
+            "label": ["EBBU", "ELS"],
+            "station_id": "EBBU-ELS"
           },
           {
             "label": ["EDYY", "ML"],
@@ -545,7 +552,8 @@
             "station_id": "EDMM-GER"
           },
           {
-            "label": ["EBBU", "BH"]
+            "label": ["EBBU", "HUS"],
+            "station_id": "EBBU-HUS"
           },
           {
             "label": ["EDYY", "RL"],
@@ -607,7 +615,8 @@
             "station_id": "EDMM-BBG"
           },
           {
-            "label": [""]
+            "label": ["EBBU", "LUS"],
+            "station_id": "EBBU-LUS"
           }
         ]
       }

--- a/dataset/EDGG/profiles/EDGG_TWR.json
+++ b/dataset/EDGG/profiles/EDGG_TWR.json
@@ -284,7 +284,7 @@
             "label": [""]
           },
           {
-            "label": ["EDLM", "TWR"],
+            "label": ["EDFM", "TWR"],
             "station_id": "EDGG-FMT"
           },
           {

--- a/dataset/EDGG/profiles/EDGG_UPR.json
+++ b/dataset/EDGG/profiles/EDGG_UPR.json
@@ -148,10 +148,12 @@
             "label": [""]
           },
           {
-            "label": ["EBBU", "BE"]
+            "label": ["EBBU", "EHS"],
+            "station_id": "EBBU-EHS"
           },
           {
-            "label": [""]
+            "label": ["EBBU", "ELS"],
+            "station_id": "EBBU-ELS"
           },
           {
             "label": ["EDWW", "EMS"],
@@ -161,7 +163,8 @@
             "label": [""]
           },
           {
-            "label": ["EDYY", "YO"]
+            "label": ["EDYY", "LNH"],
+            "station_id": "EDYY-LNH"
           },
           {
             "label": [""]
@@ -257,7 +260,8 @@
             "label": [""]
           },
           {
-            "label": ["EDYY", "YL"]
+            "label": ["EDYY", "LXH"],
+            "station_id": "EDYY-LXH"
           },
           {
             "label": ["TAU"],


### PR DESCRIPTION
### Description

Adding station IDs for EBBR FIR to profiles with present dummy DA keys.
Updating layouts of affected profiles alongside.

(Also fixes as small typo in twr profile)

### Checklist

- [X] Dataset files are in the correct `dataset/{FIR}/` directory.
- [X] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
