### PR TITLE
build: add AIRAC gating

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,14 @@
 
 <!-- What does this PR change and why? -->
 
+### AIRAC dependency
+
+- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.
+
+<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
+     The merge check will block until that cycle's effective date, then pass automatically.
+     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->
+
 ### Checklist
 
 - [ ] Dataset files are in the correct `dataset/{FIR}/` directory.

--- a/.github/workflows/airac-gate.yml
+++ b/.github/workflows/airac-gate.yml
@@ -22,6 +22,7 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Find any airac/* label on this PR

--- a/.github/workflows/airac-gate.yml
+++ b/.github/workflows/airac-gate.yml
@@ -1,4 +1,4 @@
-name: AIRAC Gate
+name: AIRAC
 
 on:
   pull_request:
@@ -13,6 +13,7 @@ defaults:
 
 jobs:
   gate:
+    name: "AIRAC ✓"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/airac-gate.yml
+++ b/.github/workflows/airac-gate.yml
@@ -1,0 +1,141 @@
+name: AIRAC Gate
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, labeled, unlabeled, synchronize]
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check AIRAC labels
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Find any airac/* label on this PR
+          AIRAC_LABEL=$(gh pr view "$PR_NUMBER" --json labels \
+            --jq '.labels[].name | select(startswith("airac/"))' | head -1)
+
+          if [[ -z "$AIRAC_LABEL" ]]; then
+            echo "No AIRAC label found - gate open."
+            echo "has_label=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CYCLE="${AIRAC_LABEL#airac/}"
+          echo "Found AIRAC label: $AIRAC_LABEL (cycle $CYCLE)"
+          echo "has_label=true" >> "$GITHUB_OUTPUT"
+          echo "label=$AIRAC_LABEL" >> "$GITHUB_OUTPUT"
+          echo "cycle=$CYCLE" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout cycles file
+        if: steps.check.outputs.has_label == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/airac-cycles.yml
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Evaluate gate
+        if: steps.check.outputs.has_label == 'true'
+        id: gate
+        env:
+          CYCLE: ${{ steps.check.outputs.cycle }}
+          LABEL: ${{ steps.check.outputs.label }}
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+
+          # Look up the effective date for this cycle
+          EFFECTIVE_DATE=$(grep "\"$CYCLE\"" .github/airac-cycles.yml | cut -d: -f1 | tr -d ' ' || true)
+
+          if [[ -z "$EFFECTIVE_DATE" ]]; then
+            echo "::error::Label '$LABEL' references unknown AIRAC cycle '$CYCLE'. Check .github/airac-cycles.yml."
+            exit 1
+          fi
+
+          echo "effective_date=$EFFECTIVE_DATE" >> "$GITHUB_OUTPUT"
+
+          if [[ "$TODAY" < "$EFFECTIVE_DATE" ]]; then
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+            echo "::error::Merge blocked until $EFFECTIVE_DATE (AIRAC $CYCLE)"
+          else
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+            echo "AIRAC $CYCLE is effective ($EFFECTIVE_DATE <= $TODAY). Gate open."
+          fi
+
+      - name: Generate GitHub token
+        if: steps.check.outputs.has_label == 'true'
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: vacs-data
+
+      - name: Post or update comment
+        if: steps.check.outputs.has_label == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CYCLE: ${{ steps.check.outputs.cycle }}
+          LABEL: ${{ steps.check.outputs.label }}
+          BLOCKED: ${{ steps.gate.outputs.blocked }}
+          EFFECTIVE_DATE: ${{ steps.gate.outputs.effective_date }}
+        run: |
+          MARKER="<!-- airac-gate-bot -->"
+
+          if [[ "$BLOCKED" == "true" ]]; then
+            BODY="$MARKER
+          > [!CAUTION]
+          > **Merge blocked** - This PR targets **AIRAC cycle $CYCLE** (effective $EFFECTIVE_DATE).
+          >
+          > The merge check will pass automatically once the cycle date arrives.
+          > You can [enable auto-merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) now - the PR will merge on its own once all checks pass.
+          >
+          > [View all PRs for AIRAC $CYCLE](https://github.com/$GH_REPO/pulls?q=is%3Apr+is%3Aopen+label%3A${LABEL})"
+          else
+            BODY="$MARKER
+          > [!TIP]
+          > **AIRAC cycle $CYCLE** is now effective ($EFFECTIVE_DATE). This PR is ready to merge!"
+          fi
+
+          # Find existing bot comment
+          COMMENT_ID=$(gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | head -1)
+
+          if [[ -n "$COMMENT_ID" ]]; then
+            gh api "repos/$GH_REPO/issues/comments/$COMMENT_ID" \
+              -X PATCH -f body="$BODY" --silent
+            echo "Updated existing comment $COMMENT_ID"
+          else
+            gh api "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
+              -f body="$BODY" --silent
+            echo "Posted new comment"
+          fi
+
+      - name: Fail if blocked
+        if: steps.gate.outputs.blocked == 'true'
+        run: |
+          echo "### ❌ AIRAC Gate - Blocked" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Merge is blocked until **${{ steps.gate.outputs.effective_date }}** (AIRAC ${{ steps.check.outputs.cycle }}). Enable **auto-merge** to merge automatically when the gate opens." >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
+      - name: Pass
+        if: steps.check.outputs.has_label != 'true' || steps.gate.outputs.blocked != 'true'
+        run: |
+          echo "### ✅ AIRAC Gate - Open" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-airac-labels.yml
+++ b/.github/workflows/sync-airac-labels.yml
@@ -1,0 +1,104 @@
+name: Sync AIRAC Labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/airac-cycles.yml"
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday, 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      max_upcoming:
+        description: "Number of upcoming AIRAC cycles to create labels for"
+        required: false
+        type: number
+        default: 4
+
+permissions: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/airac-cycles.yml
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: vacs-data
+
+      - name: Sync labels
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          MAX_UPCOMING: ${{ inputs.max_upcoming || 4 }}
+        shell: bash
+        run: |
+          LABEL_COLOR="DC521D"
+          TODAY=$(date -u +%Y-%m-%d)
+          CUTOFF_DATE=$(date -u -d "-90 days" +%Y-%m-%d 2>/dev/null \
+                     || date -u -v-90d +%Y-%m-%d) # GNU/BSD compat
+
+          echo "Syncing AIRAC labels (today: $TODAY, cutoff: $CUTOFF_DATE, max upcoming: $MAX_UPCOMING)..."
+
+          # Collect upcoming cycle dates (on or after today), sorted
+          upcoming=()
+          while IFS=: read -r date cycle_raw; do
+            [[ "$date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || continue
+            if [[ "$date" >= "$TODAY" ]]; then
+              upcoming+=("$date")
+            fi
+          done < .github/airac-cycles.yml
+
+          # Keep only the next N upcoming cycles
+          upcoming=("${upcoming[@]:0:$MAX_UPCOMING}")
+
+          # Now process all entries
+          while IFS=: read -r date cycle_raw; do
+            [[ "$date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || continue
+            cycle=$(echo "$cycle_raw" | tr -d ' "')
+            label="airac/$cycle"
+
+            if [[ "$date" < "$CUTOFF_DATE" ]]; then
+              # Delete old labels if no open PRs reference them
+              if gh label view "$label" --json name &>/dev/null; then
+                open_prs=$(gh pr list --label "$label" --state open --json number --jq 'length')
+                if [[ "$open_prs" -eq 0 ]]; then
+                  echo "Deleting stale label: $label (cycle date: $date)"
+                  gh label delete "$label" --yes
+                else
+                  echo "Keeping stale label: $label ($open_prs open PRs)"
+                fi
+              fi
+            elif [[ " ${upcoming[*]} " == *" $date "* ]]; then
+              # Create/update labels only for the next N upcoming cycles
+              description="AIRAC $cycle - effective $date"
+              if ! gh label view "$label" --json name &>/dev/null; then
+                gh label create "$label" --color "$LABEL_COLOR" --description "$description"
+                echo "Created label: $label"
+              fi
+            else
+              # Future cycle beyond the window, or past cycle within 90 days - delete if it exists
+              # (past-but-recent labels with open PRs are kept)
+              if gh label view "$label" --json name &>/dev/null; then
+                open_prs=$(gh pr list --label "$label" --state open --json number --jq 'length')
+                if [[ "$open_prs" -eq 0 ]]; then
+                  echo "Deleting out-of-window label: $label"
+                  gh label delete "$label" --yes
+                fi
+              fi
+            fi
+          done < .github/airac-cycles.yml
+
+          echo "### ✅ AIRAC labels synced" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tag-airac.yml
+++ b/.github/workflows/tag-airac.yml
@@ -76,3 +76,59 @@ jobs:
             -f sha="$TAG_SHA"
 
           echo "Created verified tag $TAG_NAME"
+
+      - name: Unlock AIRAC PRs
+        if: steps.check.outputs.cycle_name != ''
+        env:
+          CYCLE: ${{ steps.check.outputs.cycle_name }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        shell: bash
+        run: |
+          LABEL="airac/$CYCLE"
+
+          # Find all open PRs with this cycle's label
+          PR_NUMBERS=$(gh pr list --label "$LABEL" --state open --json number --jq '.[].number')
+
+          if [[ -z "$PR_NUMBERS" ]]; then
+            echo "No open PRs with label $LABEL"
+            exit 0
+          fi
+
+          MARKER="<!-- airac-gate-bot -->"
+          COMMENT="$MARKER
+          > [!TIP]
+          > **AIRAC cycle $CYCLE is now effective.** This PR is ready to merge!
+          >
+          > The merge gate has been lifted. If auto-merge is enabled, this PR will merge once CI passes."
+
+          for pr in $PR_NUMBERS; do
+            echo "Unlocking PR #$pr..."
+
+            # Remove the AIRAC label (triggers gate re-evaluation → pass)
+            gh pr edit "$pr" --remove-label "$LABEL"
+
+            # Update or post the bot comment
+            COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/$pr/comments" \
+              --jq ".[] | select(.body | startswith(\"$MARKER\")) | .id" | head -1)
+
+            if [[ -n "$COMMENT_ID" ]]; then
+              gh api "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" \
+                -X PATCH -f body="$COMMENT" --silent
+            else
+              gh api "repos/${{ github.repository }}/issues/$pr/comments" \
+                -f body="$COMMENT" --silent
+            fi
+
+            # Check for merge conflicts
+            MERGEABLE=$(gh pr view "$pr" --json mergeable --jq '.mergeable')
+            if [[ "$MERGEABLE" == "CONFLICTING" ]]; then
+              gh pr comment "$pr" --body "> [!WARNING]
+          > This PR has **merge conflicts** that must be resolved before it can merge.
+          > Please rebase or merge \`main\` into your branch and push to unblock auto-merge."
+              echo "  PR #$pr has merge conflicts - notified author"
+            fi
+
+            echo "  PR #$pr unlocked"
+          done
+
+          echo "### ✅ Unlocked $(echo "$PR_NUMBERS" | wc -w | tr -d ' ') PR(s) for AIRAC $CYCLE" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
creates `airac/2604`, `airac/2605`, etc... labels automatically (4 next AIRACs by default).
if a PR has an `airac/*` label attached, CI will block until the AIRAC's effective date is reached, so auto-merging can be enabled to automatically deploy these changes at the scheduled time.