### PR TITLE
Update EGGX for v2.1.0 and add missing clearance position

### DIFF
--- a/dataset/NAT/positions.toml
+++ b/dataset/NAT/positions.toml
@@ -3,7 +3,7 @@ id = "NAT_FSS"
 prefixes = ["NAT"]
 frequency = "131.900"
 facility_type = "FSS"
-default_call_sources =["NAT_BBx"]
+default_call_sources = ["NAT_BBx"]
 # Default call source backup - they should use a Shanwick/Gander source as required for that coordination
 
 [[positions]]
@@ -12,7 +12,7 @@ prefixes = ["EGGX"]
 frequency = "131.800"
 facility_type = "CTR"
 profile_id = "EGGX"
-default_call_sources =["Shanwick"]
+default_call_sources = ["Shanwick"]
 
 [[positions]]
 id = "EGGX_A_CTR"
@@ -20,7 +20,7 @@ prefixes = ["EGGX"]
 frequency = "131.450"
 facility_type = "CTR"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_A"]
+default_call_sources = ["Shanwick_A"]
 
 [[positions]]
 id = "EGGX_1_CTR"
@@ -28,7 +28,7 @@ prefixes = ["EGGX"]
 frequency = "131.450"
 facility_type = "CTR"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_A"]
+default_call_sources = ["Shanwick_A"]
 
 [[positions]]
 id = "EGGX_B_CTR"
@@ -36,7 +36,7 @@ prefixes = ["EGGX"]
 frequency = "131.550"
 facility_type = "CTR"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_B"]
+default_call_sources = ["Shanwick_B"]
 
 [[positions]]
 id = "EGGX_2_CTR"
@@ -44,7 +44,7 @@ prefixes = ["EGGX"]
 frequency = "131.550"
 facility_type = "CTR"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_B"]
+default_call_sources = ["Shanwick_B"]
 
 [[positions]]
 id = "EGGX_C_CTR"
@@ -52,7 +52,7 @@ prefixes = ["EGGX"]
 frequency = "131.650"
 facility_type = "CTR"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_C"]
+default_call_sources = ["Shanwick_C"]
 
 [[positions]]
 id = "EGGX_3_CTR"
@@ -60,7 +60,7 @@ prefixes = ["EGGX"]
 frequency = "131.650"
 facility_type = "CTR"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_C"]
+default_call_sources = ["Shanwick_C"]
 
 [[positions]]
 id = "EGGX_D_CTR"
@@ -68,7 +68,7 @@ prefixes = ["EGGX"]
 frequency = "131.750"
 facility_type = "CTR"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_D"]
+default_call_sources = ["Shanwick_D"]
 
 [[positions]]
 id = "EGGX_4_CTR"
@@ -76,7 +76,7 @@ prefixes = ["EGGX"]
 frequency = "131.750"
 facility_type = "CTR"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_D"]
+default_call_sources = ["Shanwick_D"]
 
 [[positions]]
 id = "EGGX_F_CTR"
@@ -84,7 +84,7 @@ prefixes = ["EGGX"]
 frequency = "131.850"
 facility_type = "CTR"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_F"]
+default_call_sources = ["Shanwick_F"]
 
 [[positions]]
 id = "EGGX_5_CTR"
@@ -92,7 +92,7 @@ prefixes = ["EGGX"]
 frequency = "131.850"
 facility_type = "CTR"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_F"]
+default_call_sources = ["Shanwick_F"]
 
 [[positions]]
 id = "EGGX_DEL"
@@ -100,7 +100,7 @@ prefixes = ["EGGX"]
 frequency = "127.650"
 facility_type = "DEL"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_DEL"]
+default_call_sources = ["Shanwick_DEL"]
 
 [[positions]]
 id = "EGGX_A_DEL"
@@ -108,7 +108,7 @@ prefixes = ["EGGX"]
 frequency = "127.900"
 facility_type = "DEL"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_DEL_A"]
+default_call_sources = ["Shanwick_DEL_A"]
 
 [[positions]]
 id = "EGGX_1_DEL"
@@ -116,7 +116,7 @@ prefixes = ["EGGX"]
 frequency = "127.900"
 facility_type = "DEL"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_DEL_A"]
+default_call_sources = ["Shanwick_DEL_A"]
 
 [[positions]]
 id = "EGGX_B_DEL"
@@ -124,7 +124,7 @@ prefixes = ["EGGX"]
 frequency = "123.950"
 facility_type = "DEL"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_DEL_B"]
+default_call_sources = ["Shanwick_DEL_B"]
 
 [[positions]]
 id = "EGGX_2_DEL"
@@ -132,7 +132,7 @@ prefixes = ["EGGX"]
 frequency = "123.950"
 facility_type = "DEL"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_DEL_B"]
+default_call_sources = ["Shanwick_DEL_B"]
 
 [[positions]]
 id = "EGGX_C_DEL"
@@ -140,7 +140,7 @@ prefixes = ["EGGX"]
 frequency = "124.175"
 facility_type = "DEL"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_DEL_C"]
+default_call_sources = ["Shanwick_DEL_C"]
 
 [[positions]]
 id = "EGGX_3_DEL"
@@ -148,7 +148,7 @@ prefixes = ["EGGX"]
 frequency = "124.175"
 facility_type = "DEL"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_DEL_C"]
+default_call_sources = ["Shanwick_DEL_C"]
 
 [[positions]]
 id = "EGGX_D_DEL"
@@ -156,7 +156,7 @@ prefixes = ["EGGX"]
 frequency = "126.375"
 facility_type = "DEL"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_DEL_D"]
+default_call_sources = ["Shanwick_DEL_D"]
 
 [[positions]]
 id = "EGGX_4_DEL"
@@ -164,7 +164,7 @@ prefixes = ["EGGX"]
 frequency = "126.375"
 facility_type = "DEL"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_DEL_D"]
+default_call_sources = ["Shanwick_DEL_D"]
 
 [[positions]]
 id = "EGGX_F_DEL"
@@ -172,7 +172,7 @@ prefixes = ["EGGX"]
 frequency = "128.375"
 facility_type = "DEL"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_DEL_F"]
+default_call_sources = ["Shanwick_DEL_F"]
 
 [[positions]]
 id = "EGGX_5_DEL"
@@ -180,4 +180,4 @@ prefixes = ["EGGX"]
 frequency = "128.375"
 facility_type = "DEL"
 profile_id = "EGGX"
-default_call_sources =["Shanwick_DEL_F"]
+default_call_sources = ["Shanwick_DEL_F"]

--- a/dataset/NAT/positions.toml
+++ b/dataset/NAT/positions.toml
@@ -3,6 +3,8 @@ id = "NAT_FSS"
 prefixes = ["NAT"]
 frequency = "131.900"
 facility_type = "FSS"
+default_call_sources =["NAT_BBx"]
+# Default call source backup - they should use a Shanwick/Gander source as required for that coordination
 
 [[positions]]
 id = "EGGX_CTR"
@@ -10,6 +12,7 @@ prefixes = ["EGGX"]
 frequency = "131.800"
 facility_type = "CTR"
 profile_id = "EGGX"
+default_call_sources =["Shanwick"]
 
 [[positions]]
 id = "EGGX_A_CTR"
@@ -17,6 +20,7 @@ prefixes = ["EGGX"]
 frequency = "131.450"
 facility_type = "CTR"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_A"]
 
 [[positions]]
 id = "EGGX_1_CTR"
@@ -24,6 +28,7 @@ prefixes = ["EGGX"]
 frequency = "131.450"
 facility_type = "CTR"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_A"]
 
 [[positions]]
 id = "EGGX_B_CTR"
@@ -31,6 +36,7 @@ prefixes = ["EGGX"]
 frequency = "131.550"
 facility_type = "CTR"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_B"]
 
 [[positions]]
 id = "EGGX_2_CTR"
@@ -38,6 +44,7 @@ prefixes = ["EGGX"]
 frequency = "131.550"
 facility_type = "CTR"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_B"]
 
 [[positions]]
 id = "EGGX_C_CTR"
@@ -45,6 +52,7 @@ prefixes = ["EGGX"]
 frequency = "131.650"
 facility_type = "CTR"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_C"]
 
 [[positions]]
 id = "EGGX_3_CTR"
@@ -52,6 +60,7 @@ prefixes = ["EGGX"]
 frequency = "131.650"
 facility_type = "CTR"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_C"]
 
 [[positions]]
 id = "EGGX_D_CTR"
@@ -59,6 +68,7 @@ prefixes = ["EGGX"]
 frequency = "131.750"
 facility_type = "CTR"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_D"]
 
 [[positions]]
 id = "EGGX_4_CTR"
@@ -66,6 +76,7 @@ prefixes = ["EGGX"]
 frequency = "131.750"
 facility_type = "CTR"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_D"]
 
 [[positions]]
 id = "EGGX_F_CTR"
@@ -73,6 +84,7 @@ prefixes = ["EGGX"]
 frequency = "131.850"
 facility_type = "CTR"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_F"]
 
 [[positions]]
 id = "EGGX_5_CTR"
@@ -80,6 +92,7 @@ prefixes = ["EGGX"]
 frequency = "131.850"
 facility_type = "CTR"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_F"]
 
 [[positions]]
 id = "EGGX_DEL"
@@ -87,6 +100,7 @@ prefixes = ["EGGX"]
 frequency = "127.650"
 facility_type = "DEL"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_DEL"]
 
 [[positions]]
 id = "EGGX_A_DEL"
@@ -94,6 +108,7 @@ prefixes = ["EGGX"]
 frequency = "127.900"
 facility_type = "DEL"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_DEL_A"]
 
 [[positions]]
 id = "EGGX_1_DEL"
@@ -101,6 +116,7 @@ prefixes = ["EGGX"]
 frequency = "127.900"
 facility_type = "DEL"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_DEL_A"]
 
 [[positions]]
 id = "EGGX_B_DEL"
@@ -108,6 +124,7 @@ prefixes = ["EGGX"]
 frequency = "123.950"
 facility_type = "DEL"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_DEL_B"]
 
 [[positions]]
 id = "EGGX_2_DEL"
@@ -115,6 +132,7 @@ prefixes = ["EGGX"]
 frequency = "123.950"
 facility_type = "DEL"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_DEL_B"]
 
 [[positions]]
 id = "EGGX_C_DEL"
@@ -122,6 +140,7 @@ prefixes = ["EGGX"]
 frequency = "124.175"
 facility_type = "DEL"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_DEL_C"]
 
 [[positions]]
 id = "EGGX_3_DEL"
@@ -129,6 +148,7 @@ prefixes = ["EGGX"]
 frequency = "124.175"
 facility_type = "DEL"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_DEL_C"]
 
 [[positions]]
 id = "EGGX_D_DEL"
@@ -136,6 +156,7 @@ prefixes = ["EGGX"]
 frequency = "126.375"
 facility_type = "DEL"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_DEL_D"]
 
 [[positions]]
 id = "EGGX_4_DEL"
@@ -143,6 +164,7 @@ prefixes = ["EGGX"]
 frequency = "126.375"
 facility_type = "DEL"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_DEL_D"]
 
 [[positions]]
 id = "EGGX_F_DEL"
@@ -150,6 +172,7 @@ prefixes = ["EGGX"]
 frequency = "128.375"
 facility_type = "DEL"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_DEL_F"]
 
 [[positions]]
 id = "EGGX_5_DEL"
@@ -157,3 +180,4 @@ prefixes = ["EGGX"]
 frequency = "128.375"
 facility_type = "DEL"
 profile_id = "EGGX"
+default_call_sources =["Shanwick_DEL_F"]

--- a/dataset/NAT/profiles/EGGX.json
+++ b/dataset/NAT/profiles/EGGX.json
@@ -123,15 +123,7 @@
         {
           "label": ["NAT", "BBx"],
           "size": 7,
-          "page": {
-            "rows": 2,
-            "keys": [
-              {
-                "label": ["NAT", "BBx"],
-                "station_id": "NAT_BBx"
-              }
-            ]
-          }
+          "station_id": "NAT_BBx"
         },
         {
           "label": ["Santa", "Maria", "Radio"],

--- a/dataset/NAT/profiles/EGGX.json
+++ b/dataset/NAT/profiles/EGGX.json
@@ -340,7 +340,7 @@
                     "label": ["AS", "255-355"]
                   },
                   {
-                    "label": ["Lower", "SFC-255"]
+                    "label": ["Lower", "255-"]
                   },
                   {
                     "label": []
@@ -358,7 +358,7 @@
                     "label": ["Upper", "245-660"]
                   },
                   {
-                    "label": ["Lower", "SFC-245"]
+                    "label": ["Lower", "245-"]
                   }
                 ]
               }

--- a/dataset/NAT/profiles/EGGX.json
+++ b/dataset/NAT/profiles/EGGX.json
@@ -59,7 +59,7 @@
                 "label": ["Gander"]
               },
               {
-                "label": []
+                "label": ["DEL"]
               },
               {
                 "label": []
@@ -227,7 +227,8 @@
                 "station_id": "Shanwick"
               },
               {
-                "label": []
+                "label": ["DEL"],
+                "station_id": "Shanwick_DEL"
               },
               {
                 "label": []

--- a/dataset/NAT/profiles/EGGX.json
+++ b/dataset/NAT/profiles/EGGX.json
@@ -76,7 +76,7 @@
       "gap": 0.75,
       "children": [
         {
-          "label": ["Reykjavík", "Control"],
+          "label": ["Reykjavík"],
           "size": 7,
           "page": {
             "rows": 4,
@@ -126,7 +126,7 @@
           "station_id": "NAT_BBx"
         },
         {
-          "label": ["Santa", "Maria", "Radio"],
+          "label": ["Santa", "Maria"],
           "size": 7,
           "page": {
             "rows": 3,
@@ -245,7 +245,7 @@
       "gap": 0.75,
       "children": [
         {
-          "label": ["Scottish", "Control"],
+          "label": ["Scottish"],
           "size": 7,
           "page": {
             "rows": 2,
@@ -322,7 +322,7 @@
           "gap": 0.75,
           "children": [
             {
-              "label": ["Brest", "Control"],
+              "label": ["Brest"],
               "size": 7,
               "page": {
                 "rows": 2,
@@ -349,7 +349,7 @@
               }
             },
             {
-              "label": ["Madrid", "Radar"],
+              "label": ["Madrid"],
               "size": 7,
               "page": {
                 "rows": 2,


### PR DESCRIPTION
Adds default call sources.
Fixes missing general voice clearance position.

Removes 'Control', 'Radar', 'Radio' from adjacent station names.
Removes references to SFC.

Final 2 changes are for more consistency with under development domestic AC profiles.
