### PR TITLE
feat (EDGG): add client config as AFIS profile

### DIFF
--- a/dataset/EDGG/positions.json
+++ b/dataset/EDGG/positions.json
@@ -1058,919 +1058,1072 @@
       "id": "EDEH_I_TWR",
       "prefixes": ["EDEH"],
       "frequency": "132.055",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDEL_I_TWR",
       "prefixes": ["EDEL"],
       "frequency": "124.030",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDEM_I_TWR",
       "prefixes": ["EDEM"],
       "frequency": "130.660",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDEN_I_TWR",
       "prefixes": ["EDEN"],
       "frequency": "119.005",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDEP_I_TWR",
       "prefixes": ["EDEP"],
       "frequency": "122.480",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDER_I_TWR",
       "prefixes": ["EDER"],
       "frequency": "120.130",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDEW_I_TWR",
       "prefixes": ["EDEW"],
       "frequency": "131.010",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFA_I_TWR",
       "prefixes": ["EDFA"],
       "frequency": "121.030",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFB_I_TWR",
       "prefixes": ["EDFB"],
       "frequency": "120.430",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFC_I_TWR",
       "prefixes": ["EDFC"],
       "frequency": "132.430",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFD_I_TWR",
       "prefixes": ["EDFD"],
       "frequency": "121.215",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFE_I_TWR",
       "prefixes": ["EDFE"],
       "frequency": "118.405",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFE_GND",
       "prefixes": ["EDFE"],
       "frequency": "121.730",
-      "facility_type": "GND"
+      "facility_type": "GND",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFG_I_TWR",
       "prefixes": ["EDFG"],
       "frequency": "123.055",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFI_I_TWR",
       "prefixes": ["EDFI"],
       "frequency": "118.330",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFJ_I_TWR",
       "prefixes": ["EDFJ"],
       "frequency": "118.430",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFK_I_TWR",
       "prefixes": ["EDFK"],
       "frequency": "124.755",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFL_I_TWR",
       "prefixes": ["EDFL"],
       "frequency": "122.505",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFN_I_TWR",
       "prefixes": ["EDFN"],
       "frequency": "134.915",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFO_I_TWR",
       "prefixes": ["EDFO"],
       "frequency": "124.515",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFP_I_TWR",
       "prefixes": ["EDFP"],
       "frequency": "122.340",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFQ_I_TWR",
       "prefixes": ["EDFQ"],
       "frequency": "135.165",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFR_I_TWR",
       "prefixes": ["EDFR"],
       "frequency": "128.360",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFS_I_TWR",
       "prefixes": ["EDFS"],
       "frequency": "119.980",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFT_I_TWR",
       "prefixes": ["EDFT"],
       "frequency": "122.180",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFU_I_TWR",
       "prefixes": ["EDFU"],
       "frequency": "121.035",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFV_I_TWR",
       "prefixes": ["EDFV"],
       "frequency": "124.605",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFW_I_TWR",
       "prefixes": ["EDFW"],
       "frequency": "132.990",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFX_I_TWR",
       "prefixes": ["EDFX"],
       "frequency": "121.190",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFY_I_TWR",
       "prefixes": ["EDFY"],
       "frequency": "128.775",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDFZ_I_TWR",
       "prefixes": ["EDFZ"],
       "frequency": "122.930",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGA_I_TWR",
       "prefixes": ["EDGA"],
       "frequency": "126.410",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGB_I_TWR",
       "prefixes": ["EDGB"],
       "frequency": "122.530",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGE_I_TWR",
       "prefixes": ["EDGE"],
       "frequency": "119.755",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGF_I_TWR",
       "prefixes": ["EDGF"],
       "frequency": "118.985",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGH_I_TWR",
       "prefixes": ["EDGH"],
       "frequency": "122.430",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGI_I_TWR",
       "prefixes": ["EDGI"],
       "frequency": "120.835",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGJ_I_TWR",
       "prefixes": ["EDGJ"],
       "frequency": "119.990",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGK_I_TWR",
       "prefixes": ["EDGK"],
       "frequency": "125.815",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGM_I_TWR",
       "prefixes": ["EDGM"],
       "frequency": "128.340",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGO_I_TWR",
       "prefixes": ["EDGO"],
       "frequency": "118.410",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGP_I_TWR",
       "prefixes": ["EDGP"],
       "frequency": "130.640",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGQ_I_TWR",
       "prefixes": ["EDGQ"],
       "frequency": "133.585",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGR_I_TWR",
       "prefixes": ["EDGR"],
       "frequency": "127.860",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGS_I_TWR",
       "prefixes": ["EDGS"],
       "frequency": "120.380",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGT_I_TWR",
       "prefixes": ["EDGT"],
       "frequency": "132.810",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGU_I_TWR",
       "prefixes": ["EDGU"],
       "frequency": "132.015",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGW_I_TWR",
       "prefixes": ["EDGW"],
       "frequency": "127.455",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGX_I_TWR",
       "prefixes": ["EDGX"],
       "frequency": "118.265",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGY_I_TWR",
       "prefixes": ["EDGY"],
       "frequency": "118.255",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGZ_I_TWR",
       "prefixes": ["EDGZ"],
       "frequency": "123.605",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKA_I_TWR",
       "prefixes": ["EDKA"],
       "frequency": "122.880",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKB_I_TWR",
       "prefixes": ["EDKB"],
       "frequency": "135.155",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKD_I_TWR",
       "prefixes": ["EDKD"],
       "frequency": "121.190",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKF_I_TWR",
       "prefixes": ["EDKF"],
       "frequency": "125.840",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKH_I_TWR",
       "prefixes": ["EDKH"],
       "frequency": "123.685",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKI_I_TWR",
       "prefixes": ["EDKI"],
       "frequency": "122.230",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKL_I_TWR",
       "prefixes": ["EDKL"],
       "frequency": "122.430",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKM_I_TWR",
       "prefixes": ["EDKM"],
       "frequency": "126.015",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKN_I_TWR",
       "prefixes": ["EDKN"],
       "frequency": "133.580",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKO_I_TWR",
       "prefixes": ["EDKO"],
       "frequency": "129.380",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKP_I_TWR",
       "prefixes": ["EDKP"],
       "frequency": "127.110",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKR_I_TWR",
       "prefixes": ["EDKR"],
       "frequency": "127.090",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKU_I_TWR",
       "prefixes": ["EDKU"],
       "frequency": "121.405",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKV_I_TWR",
       "prefixes": ["EDKV"],
       "frequency": "130.085",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKW_I_TWR",
       "prefixes": ["EDKW"],
       "frequency": "118.005",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDKZ_I_TWR",
       "prefixes": ["EDKZ"],
       "frequency": "130.605",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLA_I_TWR",
       "prefixes": ["EDLA"],
       "frequency": "121.210",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLB_I_TWR",
       "prefixes": ["EDLB"],
       "frequency": "135.005",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLC_I_TWR",
       "prefixes": ["EDLC"],
       "frequency": "121.315",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLD_I_TWR",
       "prefixes": ["EDLD"],
       "frequency": "122.705",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLE_I_TWR",
       "prefixes": ["EDLE"],
       "frequency": "119.755",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLF_I_TWR",
       "prefixes": ["EDLF"],
       "frequency": "126.705",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLG_I_TWR",
       "prefixes": ["EDLG"],
       "frequency": "118.455",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLH_I_TWR",
       "prefixes": ["EDLH"],
       "frequency": "134.055",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLI_I_TWR",
       "prefixes": ["EDLI"],
       "frequency": "118.355",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLJ_I_TWR",
       "prefixes": ["EDLJ"],
       "frequency": "135.060",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLK_I_TWR",
       "prefixes": ["EDLK"],
       "frequency": "120.680",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLM_I_TWR",
       "prefixes": ["EDLM"],
       "frequency": "134.610",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLO_I_TWR",
       "prefixes": ["EDLO"],
       "frequency": "136.410",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLQ_I_TWR",
       "prefixes": ["EDLQ"],
       "frequency": "120.740",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLR_I_TWR",
       "prefixes": ["EDLR"],
       "frequency": "121.035",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLS_I_TWR",
       "prefixes": ["EDLS"],
       "frequency": "119.205",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLT_I_TWR",
       "prefixes": ["EDLT"],
       "frequency": "122.855",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLX_I_TWR",
       "prefixes": ["EDLX"],
       "frequency": "122.030",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLY_I_TWR",
       "prefixes": ["EDLY"],
       "frequency": "122.930",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDLZ_I_TWR",
       "prefixes": ["EDLZ"],
       "frequency": "133.465",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDPA_I_TWR",
       "prefixes": ["EDPA"],
       "frequency": "121.405",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDPU_I_TWR",
       "prefixes": ["EDPU"],
       "frequency": "135.115",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDPY_I_TWR",
       "prefixes": ["EDPY"],
       "frequency": "121.235",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDQB_I_TWR",
       "prefixes": ["EDQB"],
       "frequency": "118.260",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDQF_I_TWR",
       "prefixes": ["EDQF"],
       "frequency": "123.790",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDQG_I_TWR",
       "prefixes": ["EDQG"],
       "frequency": "125.505",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRA_I_TWR",
       "prefixes": ["EDRA"],
       "frequency": "122.355",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRB_I_TWR",
       "prefixes": ["EDRB"],
       "frequency": "118.705",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRC_I_TWR",
       "prefixes": ["EDRC"],
       "frequency": "120.185",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRD_I_TWR",
       "prefixes": ["EDRD"],
       "frequency": "129.285",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRE_I_TWR",
       "prefixes": ["EDRE"],
       "frequency": "135.060",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRF_I_TWR",
       "prefixes": ["EDRF"],
       "frequency": "122.405",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRG_I_TWR",
       "prefixes": ["EDRG"],
       "frequency": "128.360",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRH_I_TWR",
       "prefixes": ["EDRH"],
       "frequency": "130.655",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRI_I_TWR",
       "prefixes": ["EDRI"],
       "frequency": "124.010",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRJ_I_TWR",
       "prefixes": ["EDRJ"],
       "frequency": "121.210",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRK_I_TWR",
       "prefixes": ["EDRK"],
       "frequency": "122.655",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRL_I_TWR",
       "prefixes": ["EDRL"],
       "frequency": "128.585",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRM_I_TWR",
       "prefixes": ["EDRM"],
       "frequency": "129.035",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRN_I_TWR",
       "prefixes": ["EDRN"],
       "frequency": "131.285",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRO_I_TWR",
       "prefixes": ["EDRO"],
       "frequency": "123.005",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRP_I_TWR",
       "prefixes": ["EDRP"],
       "frequency": "122.355",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRS_I_TWR",
       "prefixes": ["EDRS"],
       "frequency": "118.930",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRT_I_TWR",
       "prefixes": ["EDRT"],
       "frequency": "118.390",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRV_I_TWR",
       "prefixes": ["EDRV"],
       "frequency": "121.390",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRW_I_TWR",
       "prefixes": ["EDRW"],
       "frequency": "128.390",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRX_I_TWR",
       "prefixes": ["EDRX"],
       "frequency": "135.185",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRY_I_TWR",
       "prefixes": ["EDRY"],
       "frequency": "118.080",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDRZ_I_TWR",
       "prefixes": ["EDRZ"],
       "frequency": "123.830",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSA_I_TWR",
       "prefixes": ["EDSA"],
       "frequency": "125.835",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSD_I_TWR",
       "prefixes": ["EDSD"],
       "frequency": "128.755",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSF_I_TWR",
       "prefixes": ["EDSF"],
       "frequency": "125.815",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSG_I_TWR",
       "prefixes": ["EDSG"],
       "frequency": "118.190",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSH_I_TWR",
       "prefixes": ["EDSH"],
       "frequency": "123.710",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSI_I_TWR",
       "prefixes": ["EDSI"],
       "frequency": "125.635",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSK_I_TWR",
       "prefixes": ["EDSK"],
       "frequency": "122.755",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSL_I_TWR",
       "prefixes": ["EDSL"],
       "frequency": "135.005",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSM_I_TWR",
       "prefixes": ["EDSM"],
       "frequency": "122.430",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSN_I_TWR",
       "prefixes": ["EDSN"],
       "frequency": "119.605",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSP_I_TWR",
       "prefixes": ["EDSP"],
       "frequency": "123.385",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSR_I_TWR",
       "prefixes": ["EDSR"],
       "frequency": "127.530",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDST_I_TWR",
       "prefixes": ["EDST"],
       "frequency": "125.615",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSV_I_TWR",
       "prefixes": ["EDSV"],
       "frequency": "119.415",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSW_I_TWR",
       "prefixes": ["EDSW"],
       "frequency": "127.155",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSX_I_TWR",
       "prefixes": ["EDSX"],
       "frequency": "119.610",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDSZ_I_TWR",
       "prefixes": ["EDSZ"],
       "frequency": "129.505",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTA_I_TWR",
       "prefixes": ["EDTA"],
       "frequency": "118.435",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTB_I_TWR",
       "prefixes": ["EDTB"],
       "frequency": "125.915",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTC_I_TWR",
       "prefixes": ["EDTC"],
       "frequency": "123.990",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTD_I_TWR",
       "prefixes": ["EDTD"],
       "frequency": "126.690",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTE_I_TWR",
       "prefixes": ["EDTE"],
       "frequency": "133.385",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTF_I_TWR",
       "prefixes": ["EDTF"],
       "frequency": "118.255",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTG_I_TWR",
       "prefixes": ["EDTG"],
       "frequency": "124.030",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTH_I_TWR",
       "prefixes": ["EDTH"],
       "frequency": "134.115",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTK_I_TWR",
       "prefixes": ["EDTK"],
       "frequency": "119.985",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTM_I_TWR",
       "prefixes": ["EDTM"],
       "frequency": "135.180",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTN_I_TWR",
       "prefixes": ["EDTN"],
       "frequency": "118.330",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTO_I_TWR",
       "prefixes": ["EDTO"],
       "frequency": "132.040",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTP_I_TWR",
       "prefixes": ["EDTP"],
       "frequency": "122.435",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTQ_I_TWR",
       "prefixes": ["EDTQ"],
       "frequency": "124.610",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTR_I_TWR",
       "prefixes": ["EDTR"],
       "frequency": "134.535",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTS_I_TWR",
       "prefixes": ["EDTS"],
       "frequency": "127.535",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTU_I_TWR",
       "prefixes": ["EDTU"],
       "frequency": "123.605",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTW_I_TWR",
       "prefixes": ["EDTW"],
       "frequency": "118.390",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTY_I_TWR",
       "prefixes": ["EDTY"],
       "frequency": "129.230",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDTZ_I_TWR",
       "prefixes": ["EDTZ"],
       "frequency": "124.355",
-      "facility_type": "TWR"
+      "facility_type": "TWR",
+      "profile_id": "EDGG_AFIS"
     },
     {
       "id": "EDGG_FMP",

--- a/dataset/EDGG/positions.json
+++ b/dataset/EDGG/positions.json
@@ -6,7 +6,7 @@
       "frequency": "133.215",
       "facility_type": "CTR",
       "profile_id": "EDGG_UPR",
-      "default_call_source": ["EDYY-MH"]
+      "default_call_sources": ["EDYY-MH"]
     },
     {
       "id": "EDYY_MM_CTR",
@@ -14,7 +14,7 @@
       "frequency": "130.110",
       "facility_type": "CTR",
       "profile_id": "EDGG_UPR",
-      "default_call_source": ["EDYY-MH", "EDYY-ML"]
+      "default_call_sources": ["EDYY-MH", "EDYY-ML"]
     },
     {
       "id": "EDYY_ML_CTR",
@@ -29,7 +29,7 @@
       "frequency": "122.835",
       "facility_type": "CTR",
       "profile_id": "EDGG_UPR",
-      "default_call_source": ["EDYY-RH"]
+      "default_call_sources": ["EDYY-RH"]
     },
     {
       "id": "EDYY_RL_CTR",
@@ -37,7 +37,7 @@
       "frequency": "128.790",
       "facility_type": "CTR",
       "profile_id": "EDGG_UPR",
-      "default_call_source": ["EDYY-RH"]
+      "default_call_sources": ["EDYY-RH"]
     },
     {
       "id": "EDUU_CW_CTR",
@@ -45,7 +45,7 @@
       "frequency": "134.690",
       "facility_type": "CTR",
       "profile_id": "EDGG_UPR",
-      "default_call_source": ["EDUU-UCW"]
+      "default_call_sources": ["EDUU-UCW"]
     },
     {
       "id": "EDUU_W_CTR",
@@ -53,7 +53,7 @@
       "frequency": "136.560",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_source": ["EDUU-UW"]
+      "default_call_sources": ["EDUU-UW"]
     },
     {
       "id": "EDUU_C_CTR",
@@ -61,7 +61,7 @@
       "frequency": "130.260",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_source": ["EDUU-UC"]
+      "default_call_sources": ["EDUU-UC"]
     },
     {
       "id": "EDUU_FUL_CTR",
@@ -69,7 +69,7 @@
       "frequency": "122.785",
       "facility_type": "CTR",
       "profile_id": "EDGG_UPR",
-      "default_call_source": ["EDUU-FUL"]
+      "default_call_sources": ["EDUU-FUL"]
     },
     {
       "id": "EDUU_FFM_CTR",
@@ -77,7 +77,7 @@
       "frequency": "132.330",
       "facility_type": "CTR",
       "profile_id": "EDGG_UPR",
-      "default_call_source": ["EDUU-FFM"]
+      "default_call_sources": ["EDUU-FFM"]
     },
     {
       "id": "EDUU_NTM_CTR",
@@ -85,7 +85,7 @@
       "frequency": "132.080",
       "facility_type": "CTR",
       "profile_id": "EDGG_UPR",
-      "default_call_source": ["EDUU-NTM"]
+      "default_call_sources": ["EDUU-NTM"]
     },
     {
       "id": "EDUU_WUR_CTR",
@@ -93,7 +93,7 @@
       "frequency": "134.085",
       "facility_type": "CTR",
       "profile_id": "EDGG_UPR",
-      "default_call_source": ["EDUU-WUR"]
+      "default_call_sources": ["EDUU-WUR"]
     },
     {
       "id": "EDUU_TGO_CTR",
@@ -101,7 +101,7 @@
       "frequency": "132.405",
       "facility_type": "CTR",
       "profile_id": "EDGG_UPR",
-      "default_call_source": ["EDUU-TGO"]
+      "default_call_sources": ["EDUU-TGO"]
     },
     {
       "id": "EDUU_SLN_CTR",
@@ -109,7 +109,7 @@
       "frequency": "120.930",
       "facility_type": "CTR",
       "profile_id": "EDGG_UPR",
-      "default_call_source": ["EDUU-SLN"]
+      "default_call_sources": ["EDUU-SLN"]
     },
     {
       "id": "EDGG_NH_CTR",
@@ -117,7 +117,7 @@
       "frequency": "136.480",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_source": ["EDGG-PAD"]
+      "default_call_sources": ["EDGG-PAD"]
     },
     {
       "id": "EDGG_N_CTR",
@@ -125,7 +125,7 @@
       "frequency": "118.215",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_source": ["EDGG-PAD"]
+      "default_call_sources": ["EDGG-PAD"]
     },
     {
       "id": "EDGG_PAH_CTR",
@@ -133,7 +133,7 @@
       "frequency": "136.625",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_source": ["EDGG-PAD"]
+      "default_call_sources": ["EDGG-PAD"]
     },
     {
       "id": "EDGG_PAD_CTR",
@@ -141,7 +141,7 @@
       "frequency": "135.650",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG6",
-      "default_call_source": ["EDGG-PAD"]
+      "default_call_sources": ["EDGG-PAD"]
     },
     {
       "id": "EDGG_CSH_CTR",
@@ -163,7 +163,7 @@
       "frequency": "127.925",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_source": ["EDGG-GIN"]
+      "default_call_sources": ["EDGG-GIN"]
     },
     {
       "id": "EDGG_CO_CTR",
@@ -178,7 +178,7 @@
       "frequency": "133.815",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_source": ["EDGG-GIN"]
+      "default_call_sources": ["EDGG-GIN"]
     },
     {
       "id": "EDGG_CA_CTR",
@@ -186,7 +186,7 @@
       "frequency": "133.835",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_source": ["EDGG-GIN"]
+      "default_call_sources": ["EDGG-GIN"]
     },
     {
       "id": "EDGG_HEF_CTR",
@@ -194,7 +194,7 @@
       "frequency": "127.725",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG3",
-      "default_call_source": ["EDGG-HEF"]
+      "default_call_sources": ["EDGG-HEF"]
     },
     {
       "id": "EDGG_GED_CTR",
@@ -202,7 +202,7 @@
       "frequency": "124.430",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG3",
-      "default_call_source": ["EDGG-GED"]
+      "default_call_sources": ["EDGG-GED"]
     },
     {
       "id": "EDGG_GIH_CTR",
@@ -210,7 +210,7 @@
       "frequency": "128.075",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG3",
-      "default_call_source": ["EDGG-GIN"]
+      "default_call_sources": ["EDGG-GIN"]
     },
     {
       "id": "EDGG_GIN_CTR",
@@ -218,7 +218,7 @@
       "frequency": "124.730",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG3",
-      "default_call_source": ["EDGG-GIN"]
+      "default_call_sources": ["EDGG-GIN"]
     },
     {
       "id": "EDGG_SIG_CTR",
@@ -226,7 +226,7 @@
       "frequency": "124.900",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG3",
-      "default_call_source": ["EDGG-SIG"]
+      "default_call_sources": ["EDGG-SIG"]
     },
     {
       "id": "EDGG_TAU_CTR",
@@ -234,7 +234,7 @@
       "frequency": "127.625",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG3",
-      "default_call_source": ["EDGG-TAU"]
+      "default_call_sources": ["EDGG-TAU"]
     },
     {
       "id": "EDGG_RUH_CTR",
@@ -242,7 +242,7 @@
       "frequency": "135.725",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG5",
-      "default_call_source": ["EDGG-RUD"]
+      "default_call_sources": ["EDGG-RUD"]
     },
     {
       "id": "EDGG_RUD_CTR",
@@ -250,7 +250,7 @@
       "frequency": "133.435",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG5",
-      "default_call_source": ["EDGG-RUD"]
+      "default_call_sources": ["EDGG-RUD"]
     },
     {
       "id": "EDGG_KIR_CTR",
@@ -258,7 +258,7 @@
       "frequency": "133.460",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG5",
-      "default_call_source": ["EDGG-KIR"]
+      "default_call_sources": ["EDGG-KIR"]
     },
     {
       "id": "EDGG_SH_CTR",
@@ -266,7 +266,7 @@
       "frequency": "123.010",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_source": ["EDGG-DKB"]
+      "default_call_sources": ["EDGG-DKB"]
     },
     {
       "id": "EDGG_S_CTR",
@@ -274,7 +274,7 @@
       "frequency": "136.315",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_source": ["EDGG-DKB"]
+      "default_call_sources": ["EDGG-DKB"]
     },
     {
       "id": "EDGG_SA_CTR",
@@ -282,7 +282,7 @@
       "frequency": "131.365",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_source": ["EDGG-DKB"]
+      "default_call_sources": ["EDGG-DKB"]
     },
     {
       "id": "EDGG_MAN_CTR",
@@ -290,7 +290,7 @@
       "frequency": "132.155",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG2",
-      "default_call_source": ["EDGG-MAN"]
+      "default_call_sources": ["EDGG-MAN"]
     },
     {
       "id": "EDGG_HAB_CTR",
@@ -298,7 +298,7 @@
       "frequency": "134.800",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG4",
-      "default_call_source": ["EDGG-HAB"]
+      "default_call_sources": ["EDGG-HAB"]
     },
     {
       "id": "EDGG_PSA_CTR",
@@ -306,7 +306,7 @@
       "frequency": "125.405",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG4",
-      "default_call_source": ["EDGG-PSA"]
+      "default_call_sources": ["EDGG-PSA"]
     },
     {
       "id": "EDGG_KTG_CTR",
@@ -314,7 +314,7 @@
       "frequency": "123.280",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG4",
-      "default_call_source": ["EDGG-KTG"]
+      "default_call_sources": ["EDGG-KTG"]
     },
     {
       "id": "EDGG_DKH_CTR",
@@ -322,7 +322,7 @@
       "frequency": "133.340",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG4",
-      "default_call_source": ["EDGG-DKB"]
+      "default_call_sources": ["EDGG-DKB"]
     },
     {
       "id": "EDGG_DKB_CTR",
@@ -330,7 +330,7 @@
       "frequency": "125.200",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG4",
-      "default_call_source": ["EDGG-DKB"]
+      "default_call_sources": ["EDGG-DKB"]
     },
     {
       "id": "EDGG_KNG_CTR",
@@ -338,7 +338,7 @@
       "frequency": "125.680",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG4",
-      "default_call_source": ["EDGG-KNG"]
+      "default_call_sources": ["EDGG-KNG"]
     },
     {
       "id": "EDGG_NKR_CTR",
@@ -346,7 +346,7 @@
       "frequency": "127.500",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG2",
-      "default_call_source": ["EDGG-NKR"]
+      "default_call_sources": ["EDGG-NKRH"]
     },
     {
       "id": "EDGG_LBU_CTR",
@@ -354,7 +354,7 @@
       "frequency": "127.050",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG2",
-      "default_call_source": ["EDGG-LBU"]
+      "default_call_sources": ["EDGG-LBU"]
     },
     {
       "id": "EDGG_BAH_CTR",
@@ -362,7 +362,7 @@
       "frequency": "124.035",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG2",
-      "default_call_source": ["EDGG-BAD"]
+      "default_call_sources": ["EDGG-BAD"]
     },
     {
       "id": "EDGG_BAD_CTR",
@@ -370,7 +370,7 @@
       "frequency": "131.300",
       "facility_type": "CTR",
       "profile_id": "EDGG_EBG2",
-      "default_call_source": ["EDGG-BAD"]
+      "default_call_sources": ["EDGG-BAD"]
     },
     {
       "id": "EDGG_AH_CTR",
@@ -392,7 +392,7 @@
       "frequency": "134.065",
       "facility_type": "APP",
       "profile_id": "EDGG_KLA",
-      "default_call_source": ["EDGG-DLA"]
+      "default_call_sources": ["EDGG-DLA"]
     },
     {
       "id": "EDDG_HMM_APP",
@@ -400,7 +400,7 @@
       "frequency": "129.300",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG6",
-      "default_call_source": ["EDDG-HMM"]
+      "default_call_sources": ["EDGG-HMM"]
     },
     {
       "id": "EDDG_F_APP",
@@ -408,7 +408,7 @@
       "frequency": "129.180",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG6",
-      "default_call_source": ["EDGG-DGAT"]
+      "default_call_sources": ["EDGG-DGAT"]
     },
     {
       "id": "EDDL_BOT_APP",
@@ -416,7 +416,7 @@
       "frequency": "119.110",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG1",
-      "default_call_source": ["EDDL-BOT"]
+      "default_call_sources": ["EDGG-BOT"]
     },
     {
       "id": "EDDL_DEP",
@@ -424,7 +424,7 @@
       "frequency": "121.355",
       "facility_type": "DEP",
       "profile_id": "EDGG_EBG1",
-      "default_call_source": ["EDGG-DLD"]
+      "default_call_sources": ["EDGG-DLD"]
     },
     {
       "id": "EDDL_APP",
@@ -432,7 +432,7 @@
       "frequency": "128.555",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG1",
-      "default_call_source": ["EDGG-DLA"]
+      "default_call_sources": ["EDGG-DLA"]
     },
     {
       "id": "EDDL_F_APP",
@@ -440,7 +440,7 @@
       "frequency": "128.655",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG1",
-      "default_call_source": ["EDGG-DLAT"]
+      "default_call_sources": ["EDGG-DLAT"]
     },
     {
       "id": "EDDK_NOR_APP",
@@ -448,7 +448,7 @@
       "frequency": "127.365",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG7",
-      "default_call_source": ["EDDK-NOR"]
+      "default_call_sources": ["EDGG-NOR"]
     },
     {
       "id": "EDDK_F_APP",
@@ -456,7 +456,7 @@
       "frequency": "121.055",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG7",
-      "default_call_source": ["EDGG-DKAT"]
+      "default_call_sources": ["EDGG-DKAT"]
     },
     {
       "id": "EDDK_APP",
@@ -464,7 +464,7 @@
       "frequency": "135.350",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG7",
-      "default_call_source": ["EDGG-DKA"]
+      "default_call_sources": ["EDGG-DKA"]
     },
     {
       "id": "EDLP_PAL_APP",
@@ -472,7 +472,7 @@
       "frequency": "125.225",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG6",
-      "default_call_source": ["EDLP-PADL"]
+      "default_call_sources": ["EDGG-PADL"]
     },
     {
       "id": "EDDF_N_APP",
@@ -480,7 +480,7 @@
       "frequency": "120.805",
       "facility_type": "APP",
       "profile_id": "EDGG_DFAN",
-      "default_call_source": ["EDGG-DFAN"]
+      "default_call_sources": ["EDGG-DFAN"]
     },
     {
       "id": "EDDF_S_APP",
@@ -488,7 +488,7 @@
       "frequency": "125.355",
       "facility_type": "APP",
       "profile_id": "EDGG_DFAN",
-      "default_call_source": ["EDGG-DFAS"]
+      "default_call_sources": ["EDGG-DFAS"]
     },
     {
       "id": "EDDF_H_APP",
@@ -496,7 +496,7 @@
       "frequency": "127.280",
       "facility_type": "APP",
       "profile_id": "EDGG_DFAN",
-      "default_call_source": ["EDGG-DFANT"]
+      "default_call_sources": ["EDGG-DFANT"]
     },
     {
       "id": "EDDF_L_APP",
@@ -504,7 +504,7 @@
       "frequency": "118.505",
       "facility_type": "APP",
       "profile_id": "EDGG_DFAN",
-      "default_call_source": ["EDGG-DFAST"]
+      "default_call_sources": ["EDGG-DFAST"]
     },
     {
       "id": "EDDF_N_DEP",
@@ -512,7 +512,7 @@
       "frequency": "120.155",
       "facility_type": "DEP",
       "profile_id": "EDGG_DFAN",
-      "default_call_source": ["EDGG-DFDN"]
+      "default_call_sources": ["EDGG-DFDN"]
     },
     {
       "id": "EDDF_S_DEP",
@@ -520,7 +520,7 @@
       "frequency": "136.130",
       "facility_type": "DEP",
       "profile_id": "EDGG_DFAN",
-      "default_call_source": ["EDGG-DFDS"]
+      "default_call_sources": ["EDGG-DFDS"]
     },
     {
       "id": "EDFH_EIF_APP",
@@ -528,7 +528,7 @@
       "frequency": "125.600",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG5",
-      "default_call_source": ["EDGG-EIF"]
+      "default_call_sources": ["EDGG-EIF"]
     },
     {
       "id": "EDDR_PFA_APP",
@@ -536,7 +536,7 @@
       "frequency": "129.675",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG5",
-      "default_call_source": ["EDGG-PFA"]
+      "default_call_sources": ["EDGG-PFA"]
     },
     {
       "id": "EDDS_STG_APP",
@@ -544,7 +544,7 @@
       "frequency": "125.050",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG8",
-      "default_call_source": ["EDGG-STG"]
+      "default_call_sources": ["EDGG-STG"]
     },
     {
       "id": "EDDS_REU_APP",
@@ -552,7 +552,7 @@
       "frequency": "119.200",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG8",
-      "default_call_source": ["EDGG-REU"]
+      "default_call_sources": ["EDGG-REU"]
     },
     {
       "id": "EDDS_F_APP",
@@ -560,7 +560,7 @@
       "frequency": "119.850",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG8",
-      "default_call_source": ["EDGG-DSAT"]
+      "default_call_sources": ["EDGG-DSAT"]
     },
     {
       "id": "EDFM_NKL_APP",
@@ -568,7 +568,7 @@
       "frequency": "129.355",
       "facility_type": "APP",
       "profile_id": "EDGG_EBG2",
-      "default_call_source": ["EDGG-NKRL"]
+      "default_call_sources": ["EDGG-NKRL"]
     },
     {
       "id": "ETAD_APP",
@@ -576,7 +576,7 @@
       "frequency": "129.475",
       "facility_type": "APP",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TADA"]
+      "default_call_sources": ["EDGG-TADA"]
     },
     {
       "id": "ETAR_APP",
@@ -584,7 +584,7 @@
       "frequency": "124.280",
       "facility_type": "APP",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TARA"]
+      "default_call_sources": ["EDGG-TARA"]
     },
     {
       "id": "ETHF_APP",
@@ -592,7 +592,7 @@
       "frequency": "120.865",
       "facility_type": "APP",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-THFA"]
+      "default_call_sources": ["EDGG-THFA"]
     },
     {
       "id": "ETHN_APP",
@@ -600,7 +600,7 @@
       "frequency": "127.190",
       "facility_type": "APP",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-THNA"]
+      "default_call_sources": ["EDGG-THNA"]
     },
     {
       "id": "ETNG_APP",
@@ -608,7 +608,7 @@
       "frequency": "123.730",
       "facility_type": "APP",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TNGA"]
+      "default_call_sources": ["EDGG-TNGA"]
     },
     {
       "id": "ETNN_APP",
@@ -616,7 +616,7 @@
       "frequency": "129.055",
       "facility_type": "APP",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TNNA"]
+      "default_call_sources": ["EDGG-TNNA"]
     },
     {
       "id": "ETSB_APP",
@@ -624,7 +624,7 @@
       "frequency": "130.155",
       "facility_type": "APP",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TSBA"]
+      "default_call_sources": ["EDGG-TSBA"]
     },
     {
       "id": "EDDL_TWR",
@@ -632,7 +632,7 @@
       "frequency": "118.305",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DLT"]
+      "default_call_sources": ["EDGG-DLT"]
     },
     {
       "id": "EDDL_E_GND",
@@ -640,7 +640,7 @@
       "frequency": "121.605",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DLGE"]
+      "default_call_sources": ["EDGG-DLGE"]
     },
     {
       "id": "EDDL_W_GND",
@@ -648,7 +648,7 @@
       "frequency": "121.680",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DLGW"]
+      "default_call_sources": ["EDGG-DLGW"]
     },
     {
       "id": "EDDL_DEL",
@@ -656,7 +656,7 @@
       "frequency": "121.780",
       "facility_type": "DEL",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DLC"]
+      "default_call_sources": ["EDGG-DLC"]
     },
     {
       "id": "EDDK_TWR",
@@ -664,7 +664,7 @@
       "frequency": "124.980",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DKT"]
+      "default_call_sources": ["EDGG-DKT"]
     },
     {
       "id": "EDDK_GND",
@@ -672,7 +672,7 @@
       "frequency": "121.730",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DKG"]
+      "default_call_sources": ["EDGG-DKG"]
     },
     {
       "id": "EDDK_P_GND",
@@ -687,7 +687,7 @@
       "frequency": "121.855",
       "facility_type": "DEL",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DLC"]
+      "default_call_sources": ["EDGG-DLC"]
     },
     {
       "id": "EDDF_C_TWR",
@@ -695,7 +695,7 @@
       "frequency": "118.780",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DFTC"]
+      "default_call_sources": ["EDGG-DFTC"]
     },
     {
       "id": "EDDF_W_TWR",
@@ -703,7 +703,7 @@
       "frequency": "124.855",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DFTW"]
+      "default_call_sources": ["EDGG-DFTW"]
     },
     {
       "id": "EDDF_N_TWR",
@@ -711,7 +711,7 @@
       "frequency": "136.500",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DFTN"]
+      "default_call_sources": ["EDGG-DFTN"]
     },
     {
       "id": "EDDF_S_TWR",
@@ -719,7 +719,7 @@
       "frequency": "119.905",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DFTS"]
+      "default_call_sources": ["EDGG-DFTS"]
     },
     {
       "id": "EDDF_C_GND",
@@ -727,7 +727,7 @@
       "frequency": "121.855",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DFGC"]
+      "default_call_sources": ["EDGG-DFGC"]
     },
     {
       "id": "EDDF_W_GND",
@@ -735,7 +735,7 @@
       "frequency": "121.755",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DFGW"]
+      "default_call_sources": ["EDGG-DFGW"]
     },
     {
       "id": "EDDF_E_GND",
@@ -743,7 +743,7 @@
       "frequency": "121.955",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DFGE"]
+      "default_call_sources": ["EDGG-DFGE"]
     },
     {
       "id": "EDDF_S_GND",
@@ -751,7 +751,7 @@
       "frequency": "121.655",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DFGS"]
+      "default_call_sources": ["EDGG-DFGS"]
     },
     {
       "id": "EDDF_ICE_GND",
@@ -759,7 +759,7 @@
       "frequency": "121.985",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DFGI"]
+      "default_call_sources": ["EDGG-DFGI"]
     },
     {
       "id": "EDDF_GND",
@@ -767,7 +767,7 @@
       "frequency": "121.805",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DFG"]
+      "default_call_sources": ["EDGG-DFG"]
     },
     {
       "id": "EDDF_DEL",
@@ -775,7 +775,7 @@
       "frequency": "122.035",
       "facility_type": "DEL",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DLC"]
+      "default_call_sources": ["EDGG-DLC"]
     },
     {
       "id": "EDDS_TWR",
@@ -783,7 +783,7 @@
       "frequency": "118.805",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DST"]
+      "default_call_sources": ["EDGG-DST"]
     },
     {
       "id": "EDDS_VFR_TWR",
@@ -791,7 +791,7 @@
       "frequency": "119.055",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DSTV"]
+      "default_call_sources": ["EDGG-DSTV"]
     },
     {
       "id": "EDDS_GND",
@@ -799,7 +799,7 @@
       "frequency": "118.605",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DSG"]
+      "default_call_sources": ["EDGG-DSG"]
     },
     {
       "id": "EDDS_DEL",
@@ -807,7 +807,7 @@
       "frequency": "121.915",
       "facility_type": "DEL",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DSC"]
+      "default_call_sources": ["EDGG-DSC"]
     },
     {
       "id": "EDDG_TWR",
@@ -815,7 +815,7 @@
       "frequency": "129.805",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DGT"]
+      "default_call_sources": ["EDGG-DGT"]
     },
     {
       "id": "EDDG_GND",
@@ -823,7 +823,7 @@
       "frequency": "121.880",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DGG"]
+      "default_call_sources": ["EDGG-DGG"]
     },
     {
       "id": "EDDR_TWR",
@@ -831,7 +831,7 @@
       "frequency": "118.355",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DRT"]
+      "default_call_sources": ["EDGG-DRT"]
     },
     {
       "id": "EDDR_GND",
@@ -839,7 +839,7 @@
       "frequency": "118.555",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-DRG"]
+      "default_call_sources": ["EDGG-DRG"]
     },
     {
       "id": "EDFH_TWR",
@@ -847,7 +847,7 @@
       "frequency": "119.655",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-FHT"]
+      "default_call_sources": ["EDGG-FHT"]
     },
     {
       "id": "EDFH_GND",
@@ -855,7 +855,7 @@
       "frequency": "121.980",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-FHG"]
+      "default_call_sources": ["EDGG-FHG"]
     },
     {
       "id": "EDFM_TWR",
@@ -863,7 +863,7 @@
       "frequency": "129.780",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-FMT"]
+      "default_call_sources": ["EDGG-FMT"]
     },
     {
       "id": "EDLN_TWR",
@@ -871,7 +871,7 @@
       "frequency": "120.455",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-LNT"]
+      "default_call_sources": ["EDGG-LNT"]
     },
     {
       "id": "EDLN_GND",
@@ -879,7 +879,7 @@
       "frequency": "121.930",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-LNG"]
+      "default_call_sources": ["EDGG-LNG"]
     },
     {
       "id": "EDLP_TWR",
@@ -887,7 +887,7 @@
       "frequency": "133.380",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-LPT"]
+      "default_call_sources": ["EDGG-LPT"]
     },
     {
       "id": "EDLP_GND",
@@ -895,7 +895,7 @@
       "frequency": "121.930",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-LPG"]
+      "default_call_sources": ["EDGG-LPG"]
     },
     {
       "id": "EDLV_TWR",
@@ -903,7 +903,7 @@
       "frequency": "129.405",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-LVT"]
+      "default_call_sources": ["EDGG-LVT"]
     },
     {
       "id": "EDLW_TWR",
@@ -911,7 +911,7 @@
       "frequency": "134.180",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-LWT"]
+      "default_call_sources": ["EDGG-LWT"]
     },
     {
       "id": "EDLW_GND",
@@ -919,7 +919,7 @@
       "frequency": "121.830",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-LWG"]
+      "default_call_sources": ["EDGG-LWG"]
     },
     {
       "id": "EDSB_TWR",
@@ -927,7 +927,7 @@
       "frequency": "134.105",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-SBT"]
+      "default_call_sources": ["EDGG-SBT"]
     },
     {
       "id": "EDSB_GND",
@@ -935,7 +935,7 @@
       "frequency": "121.830",
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-SBG"]
+      "default_call_sources": ["EDGG-SBG"]
     },
     {
       "id": "EDTL_TWR",
@@ -943,7 +943,7 @@
       "frequency": "125.180",
       "facility_type": "TWR",
       "profile_id": "EDGG_TWR",
-      "default_call_source": ["EDGG-TLT"]
+      "default_call_sources": ["EDGG-TLT"]
     },
     {
       "id": "ETAD_TWR",
@@ -951,7 +951,7 @@
       "frequency": "122.200",
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TADT"]
+      "default_call_sources": ["EDGG-TADT"]
     },
     {
       "id": "ETAD_GND",
@@ -959,7 +959,7 @@
       "frequency": "121.865",
       "facility_type": "GND",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TADG"]
+      "default_call_sources": ["EDGG-TADG"]
     },
     {
       "id": "ETAD_DEL",
@@ -967,7 +967,7 @@
       "frequency": "120.905",
       "facility_type": "DEL",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TADC"]
+      "default_call_sources": ["EDGG-TADC"]
     },
     {
       "id": "ETAR_TWR",
@@ -975,7 +975,7 @@
       "frequency": "133.205",
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TART"]
+      "default_call_sources": ["EDGG-TART"]
     },
     {
       "id": "ETAR_GND",
@@ -983,7 +983,7 @@
       "frequency": "121.775",
       "facility_type": "GND",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TARG"]
+      "default_call_sources": ["EDGG-TARG"]
     },
     {
       "id": "ETHF_TWR",
@@ -991,7 +991,7 @@
       "frequency": "122.300",
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-THFT"]
+      "default_call_sources": ["EDGG-THFT"]
     },
     {
       "id": "ETHF_GND",
@@ -999,7 +999,7 @@
       "frequency": "131.450",
       "facility_type": "GND",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-THFG"]
+      "default_call_sources": ["EDGG-THFG"]
     },
     {
       "id": "ETHN_TWR",
@@ -1007,7 +1007,7 @@
       "frequency": "134.205",
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-THNT"]
+      "default_call_sources": ["EDGG-THNT"]
     },
     {
       "id": "ETNG_TWR",
@@ -1015,7 +1015,7 @@
       "frequency": "120.055",
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TNGT"]
+      "default_call_sources": ["EDGG-TNGT"]
     },
     {
       "id": "ETNN_TWR",
@@ -1023,7 +1023,7 @@
       "frequency": "136.205",
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TNNT"]
+      "default_call_sources": ["EDGG-TNNT"]
     },
     {
       "id": "ETOU_TWR",
@@ -1031,7 +1031,7 @@
       "frequency": "122.100",
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TOUT"]
+      "default_call_sources": ["EDGG-TOUT"]
     },
     {
       "id": "ETOU_GND",
@@ -1039,7 +1039,7 @@
       "frequency": "126.555",
       "facility_type": "GND",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TOUG"]
+      "default_call_sources": ["EDGG-TOUG"]
     },
     {
       "id": "ETSB_TWR",
@@ -1047,7 +1047,7 @@
       "frequency": "129.060",
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
-      "default_call_source": ["EDGG-TSBT"]
+      "default_call_sources": ["EDGG-TSBT"]
     },
     {
       "id": "EDEH_I_TWR",

--- a/dataset/EDGG/positions.json
+++ b/dataset/EDGG/positions.json
@@ -5,14 +5,16 @@
       "prefixes": ["EDYY"],
       "frequency": "133.215",
       "facility_type": "CTR",
-      "profile_id": "EDGG_UPR"
+      "profile_id": "EDGG_UPR",
+      "default_call_source": ["EDYY-MH"]
     },
     {
       "id": "EDYY_MM_CTR",
       "prefixes": ["EDYY"],
       "frequency": "130.110",
       "facility_type": "CTR",
-      "profile_id": "EDGG_UPR"
+      "profile_id": "EDGG_UPR",
+      "default_call_source": ["EDYY-MH", "EDYY-ML"]
     },
     {
       "id": "EDYY_ML_CTR",
@@ -26,105 +28,120 @@
       "prefixes": ["EDYY"],
       "frequency": "122.835",
       "facility_type": "CTR",
-      "profile_id": "EDGG_UPR"
+      "profile_id": "EDGG_UPR",
+      "default_call_source": ["EDYY-RH"]
     },
     {
       "id": "EDYY_RL_CTR",
       "prefixes": ["EDYY"],
       "frequency": "128.790",
       "facility_type": "CTR",
-      "profile_id": "EDGG_UPR"
+      "profile_id": "EDGG_UPR",
+      "default_call_source": ["EDYY-RH"]
     },
     {
       "id": "EDUU_CW_CTR",
       "prefixes": ["EDUU"],
       "frequency": "134.690",
       "facility_type": "CTR",
-      "profile_id": "EDGG_UPR"
+      "profile_id": "EDGG_UPR",
+      "default_call_source": ["EDUU-UCW"]
     },
     {
       "id": "EDUU_W_CTR",
       "prefixes": ["EDUU"],
       "frequency": "136.560",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB"
+      "profile_id": "EDGG_MBB",
+      "default_call_source": ["EDUU-UW"]
     },
     {
       "id": "EDUU_C_CTR",
       "prefixes": ["EDUU"],
       "frequency": "130.260",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB"
+      "profile_id": "EDGG_MBB",
+      "default_call_source": ["EDUU-UC"]
     },
     {
       "id": "EDUU_FUL_CTR",
       "prefixes": ["EDUU"],
       "frequency": "122.785",
       "facility_type": "CTR",
-      "profile_id": "EDGG_UPR"
+      "profile_id": "EDGG_UPR",
+      "default_call_source": ["EDUU-FUL"]
     },
     {
       "id": "EDUU_FFM_CTR",
       "prefixes": ["EDUU"],
       "frequency": "132.330",
       "facility_type": "CTR",
-      "profile_id": "EDGG_UPR"
+      "profile_id": "EDGG_UPR",
+      "default_call_source": ["EDUU-FFM"]
     },
     {
       "id": "EDUU_NTM_CTR",
       "prefixes": ["EDUU"],
       "frequency": "132.080",
       "facility_type": "CTR",
-      "profile_id": "EDGG_UPR"
+      "profile_id": "EDGG_UPR",
+      "default_call_source": ["EDUU-NTM"]
     },
     {
       "id": "EDUU_WUR_CTR",
       "prefixes": ["EDUU"],
       "frequency": "134.085",
       "facility_type": "CTR",
-      "profile_id": "EDGG_UPR"
+      "profile_id": "EDGG_UPR",
+      "default_call_source": ["EDUU-WUR"]
     },
     {
       "id": "EDUU_TGO_CTR",
       "prefixes": ["EDUU"],
       "frequency": "132.405",
       "facility_type": "CTR",
-      "profile_id": "EDGG_UPR"
+      "profile_id": "EDGG_UPR",
+      "default_call_source": ["EDUU-TGO"]
     },
     {
       "id": "EDUU_SLN_CTR",
       "prefixes": ["EDUU"],
       "frequency": "120.930",
       "facility_type": "CTR",
-      "profile_id": "EDGG_UPR"
+      "profile_id": "EDGG_UPR",
+      "default_call_source": ["EDUU-SLN"]
     },
     {
       "id": "EDGG_NH_CTR",
       "prefixes": ["EDGG"],
       "frequency": "136.480",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB"
+      "profile_id": "EDGG_MBB",
+      "default_call_source": ["EDGG-PAD"]
     },
     {
       "id": "EDGG_N_CTR",
       "prefixes": ["EDGG"],
       "frequency": "118.215",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB"
+      "profile_id": "EDGG_MBB",
+      "default_call_source": ["EDGG-PAD"]
     },
     {
       "id": "EDGG_PAH_CTR",
       "prefixes": ["EDGG"],
       "frequency": "136.625",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB"
+      "profile_id": "EDGG_MBB",
+      "default_call_source": ["EDGG-PAD"]
     },
     {
       "id": "EDGG_PAD_CTR",
       "prefixes": ["EDGG"],
       "frequency": "135.650",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG6"
+      "profile_id": "EDGG_EBG6",
+      "default_call_source": ["EDGG-PAD"]
     },
     {
       "id": "EDGG_CSH_CTR",
@@ -145,7 +162,8 @@
       "prefixes": ["EDGG"],
       "frequency": "127.925",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB"
+      "profile_id": "EDGG_MBB",
+      "default_call_source": ["EDGG-GIN"]
     },
     {
       "id": "EDGG_CO_CTR",
@@ -159,175 +177,200 @@
       "prefixes": ["EDGG"],
       "frequency": "133.815",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB"
+      "profile_id": "EDGG_MBB",
+      "default_call_source": ["EDGG-GIN"]
     },
     {
       "id": "EDGG_CA_CTR",
       "prefixes": ["EDGG"],
       "frequency": "133.835",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB"
+      "profile_id": "EDGG_MBB",
+      "default_call_source": ["EDGG-GIN"]
     },
     {
       "id": "EDGG_HEF_CTR",
       "prefixes": ["EDGG"],
       "frequency": "127.725",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG3"
+      "profile_id": "EDGG_EBG3",
+      "default_call_source": ["EDGG-HEF"]
     },
     {
       "id": "EDGG_GED_CTR",
       "prefixes": ["EDGG"],
       "frequency": "124.430",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG3"
+      "profile_id": "EDGG_EBG3",
+      "default_call_source": ["EDGG-GED"]
     },
     {
       "id": "EDGG_GIH_CTR",
       "prefixes": ["EDGG"],
       "frequency": "128.075",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG3"
+      "profile_id": "EDGG_EBG3",
+      "default_call_source": ["EDGG-GIN"]
     },
     {
       "id": "EDGG_GIN_CTR",
       "prefixes": ["EDGG"],
       "frequency": "124.730",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG3"
+      "profile_id": "EDGG_EBG3",
+      "default_call_source": ["EDGG-GIN"]
     },
     {
       "id": "EDGG_SIG_CTR",
       "prefixes": ["EDGG"],
       "frequency": "124.900",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG3"
+      "profile_id": "EDGG_EBG3",
+      "default_call_source": ["EDGG-SIG"]
     },
     {
       "id": "EDGG_TAU_CTR",
       "prefixes": ["EDGG"],
       "frequency": "127.625",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG3"
+      "profile_id": "EDGG_EBG3",
+      "default_call_source": ["EDGG-TAU"]
     },
     {
       "id": "EDGG_RUH_CTR",
       "prefixes": ["EDGG"],
       "frequency": "135.725",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG5"
+      "profile_id": "EDGG_EBG5",
+      "default_call_source": ["EDGG-RUD"]
     },
     {
       "id": "EDGG_RUD_CTR",
       "prefixes": ["EDGG"],
       "frequency": "133.435",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG5"
+      "profile_id": "EDGG_EBG5",
+      "default_call_source": ["EDGG-RUD"]
     },
     {
       "id": "EDGG_KIR_CTR",
       "prefixes": ["EDGG"],
       "frequency": "133.460",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG5"
+      "profile_id": "EDGG_EBG5",
+      "default_call_source": ["EDGG-KIR"]
     },
     {
       "id": "EDGG_SH_CTR",
       "prefixes": ["EDGG"],
       "frequency": "123.010",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB"
+      "profile_id": "EDGG_MBB",
+      "default_call_source": ["EDGG-DKB"]
     },
     {
       "id": "EDGG_S_CTR",
       "prefixes": ["EDGG"],
       "frequency": "136.315",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB"
+      "profile_id": "EDGG_MBB",
+      "default_call_source": ["EDGG-DKB"]
     },
     {
       "id": "EDGG_SA_CTR",
       "prefixes": ["EDGG"],
       "frequency": "131.365",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB"
+      "profile_id": "EDGG_MBB",
+      "default_call_source": ["EDGG-DKB"]
     },
     {
       "id": "EDGG_MAN_CTR",
       "prefixes": ["EDGG"],
       "frequency": "132.155",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG2"
+      "profile_id": "EDGG_EBG2",
+      "default_call_source": ["EDGG-MAN"]
     },
     {
       "id": "EDGG_HAB_CTR",
       "prefixes": ["EDGG"],
       "frequency": "134.800",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG4"
+      "profile_id": "EDGG_EBG4",
+      "default_call_source": ["EDGG-HAB"]
     },
     {
       "id": "EDGG_PSA_CTR",
       "prefixes": ["EDGG"],
       "frequency": "125.405",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG4"
+      "profile_id": "EDGG_EBG4",
+      "default_call_source": ["EDGG-PSA"]
     },
     {
       "id": "EDGG_KTG_CTR",
       "prefixes": ["EDGG"],
       "frequency": "123.280",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG4"
+      "profile_id": "EDGG_EBG4",
+      "default_call_source": ["EDGG-KTG"]
     },
     {
       "id": "EDGG_DKH_CTR",
       "prefixes": ["EDGG"],
       "frequency": "133.340",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG4"
+      "profile_id": "EDGG_EBG4",
+      "default_call_source": ["EDGG-DKB"]
     },
     {
       "id": "EDGG_DKB_CTR",
       "prefixes": ["EDGG"],
       "frequency": "125.200",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG4"
+      "profile_id": "EDGG_EBG4",
+      "default_call_source": ["EDGG-DKB"]
     },
     {
       "id": "EDGG_KNG_CTR",
       "prefixes": ["EDGG"],
       "frequency": "125.680",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG4"
+      "profile_id": "EDGG_EBG4",
+      "default_call_source": ["EDGG-KNG"]
     },
     {
       "id": "EDGG_NKR_CTR",
       "prefixes": ["EDGG"],
       "frequency": "127.500",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG2"
+      "profile_id": "EDGG_EBG2",
+      "default_call_source": ["EDGG-NKR"]
     },
     {
       "id": "EDGG_LBU_CTR",
       "prefixes": ["EDGG"],
       "frequency": "127.050",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG2"
+      "profile_id": "EDGG_EBG2",
+      "default_call_source": ["EDGG-LBU"]
     },
     {
       "id": "EDGG_BAH_CTR",
       "prefixes": ["EDGG"],
       "frequency": "124.035",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG2"
+      "profile_id": "EDGG_EBG2",
+      "default_call_source": ["EDGG-BAD"]
     },
     {
       "id": "EDGG_BAD_CTR",
       "prefixes": ["EDGG"],
       "frequency": "131.300",
       "facility_type": "CTR",
-      "profile_id": "EDGG_EBG2"
+      "profile_id": "EDGG_EBG2",
+      "default_call_source": ["EDGG-BAD"]
     },
     {
       "id": "EDGG_AH_CTR",
@@ -348,252 +391,288 @@
       "prefixes": ["EDGG"],
       "frequency": "134.065",
       "facility_type": "APP",
-      "profile_id": "EDGG_KLA"
+      "profile_id": "EDGG_KLA",
+      "default_call_source": ["EDGG-DLA"]
     },
     {
       "id": "EDDG_HMM_APP",
       "prefixes": ["EDDG"],
       "frequency": "129.300",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG6"
+      "profile_id": "EDGG_EBG6",
+      "default_call_source": ["EDDG-HMM"]
     },
     {
       "id": "EDDG_F_APP",
       "prefixes": ["EDDG"],
       "frequency": "129.180",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG6"
+      "profile_id": "EDGG_EBG6",
+      "default_call_source": ["EDGG-DGAT"]
     },
     {
       "id": "EDDL_BOT_APP",
       "prefixes": ["EDDL"],
       "frequency": "119.110",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG1"
+      "profile_id": "EDGG_EBG1",
+      "default_call_source": ["EDDL-BOT"]
     },
     {
       "id": "EDDL_DEP",
       "prefixes": ["EDDL"],
       "frequency": "121.355",
       "facility_type": "DEP",
-      "profile_id": "EDGG_EBG1"
+      "profile_id": "EDGG_EBG1",
+      "default_call_source": ["EDGG-DLD"]
     },
     {
       "id": "EDDL_APP",
       "prefixes": ["EDDL"],
       "frequency": "128.555",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG1"
+      "profile_id": "EDGG_EBG1",
+      "default_call_source": ["EDGG-DLA"]
     },
     {
       "id": "EDDL_F_APP",
       "prefixes": ["EDDL"],
       "frequency": "128.655",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG1"
+      "profile_id": "EDGG_EBG1",
+      "default_call_source": ["EDGG-DLAT"]
     },
     {
       "id": "EDDK_NOR_APP",
       "prefixes": ["EDDK"],
       "frequency": "127.365",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG7"
+      "profile_id": "EDGG_EBG7",
+      "default_call_source": ["EDDK-NOR"]
     },
     {
       "id": "EDDK_F_APP",
       "prefixes": ["EDDK"],
       "frequency": "121.055",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG7"
+      "profile_id": "EDGG_EBG7",
+      "default_call_source": ["EDGG-DKAT"]
     },
     {
       "id": "EDDK_APP",
       "prefixes": ["EDDK"],
       "frequency": "135.350",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG7"
+      "profile_id": "EDGG_EBG7",
+      "default_call_source": ["EDGG-DKA"]
     },
     {
       "id": "EDLP_PAL_APP",
       "prefixes": ["EDLP"],
       "frequency": "125.225",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG6"
+      "profile_id": "EDGG_EBG6",
+      "default_call_source": ["EDLP-PADL"]
     },
     {
       "id": "EDDF_N_APP",
       "prefixes": ["EDDF"],
       "frequency": "120.805",
       "facility_type": "APP",
-      "profile_id": "EDGG_DFAN"
+      "profile_id": "EDGG_DFAN",
+      "default_call_source": ["EDGG-DFAN"]
     },
     {
       "id": "EDDF_S_APP",
       "prefixes": ["EDDF"],
       "frequency": "125.355",
       "facility_type": "APP",
-      "profile_id": "EDGG_DFAN"
+      "profile_id": "EDGG_DFAN",
+      "default_call_source": ["EDGG-DFAS"]
     },
     {
       "id": "EDDF_H_APP",
       "prefixes": ["EDDF"],
       "frequency": "127.280",
       "facility_type": "APP",
-      "profile_id": "EDGG_DFAN"
+      "profile_id": "EDGG_DFAN",
+      "default_call_source": ["EDGG-DFANT"]
     },
     {
       "id": "EDDF_L_APP",
       "prefixes": ["EDDF"],
       "frequency": "118.505",
       "facility_type": "APP",
-      "profile_id": "EDGG_DFAN"
+      "profile_id": "EDGG_DFAN",
+      "default_call_source": ["EDGG-DFAST"]
     },
     {
       "id": "EDDF_N_DEP",
       "prefixes": ["EDDF"],
       "frequency": "120.155",
       "facility_type": "DEP",
-      "profile_id": "EDGG_DFAN"
+      "profile_id": "EDGG_DFAN",
+      "default_call_source": ["EDGG-DFDN"]
     },
     {
       "id": "EDDF_S_DEP",
       "prefixes": ["EDDF"],
       "frequency": "136.130",
       "facility_type": "DEP",
-      "profile_id": "EDGG_DFAN"
+      "profile_id": "EDGG_DFAN",
+      "default_call_source": ["EDGG-DFDS"]
     },
     {
       "id": "EDFH_EIF_APP",
       "prefixes": ["EDFH"],
       "frequency": "125.600",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG5"
+      "profile_id": "EDGG_EBG5",
+      "default_call_source": ["EDGG-EIF"]
     },
     {
       "id": "EDDR_PFA_APP",
       "prefixes": ["EDDR"],
       "frequency": "129.675",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG5"
+      "profile_id": "EDGG_EBG5",
+      "default_call_source": ["EDGG-PFA"]
     },
     {
       "id": "EDDS_STG_APP",
       "prefixes": ["EDDS"],
       "frequency": "125.050",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG8"
+      "profile_id": "EDGG_EBG8",
+      "default_call_source": ["EDGG-STG"]
     },
     {
       "id": "EDDS_REU_APP",
       "prefixes": ["EDDS"],
       "frequency": "119.200",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG8"
+      "profile_id": "EDGG_EBG8",
+      "default_call_source": ["EDGG-REU"]
     },
     {
       "id": "EDDS_F_APP",
       "prefixes": ["EDDS"],
       "frequency": "119.850",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG8"
+      "profile_id": "EDGG_EBG8",
+      "default_call_source": ["EDGG-DSAT"]
     },
     {
       "id": "EDFM_NKL_APP",
       "prefixes": ["EDFM"],
       "frequency": "129.355",
       "facility_type": "APP",
-      "profile_id": "EDGG_EBG2"
+      "profile_id": "EDGG_EBG2",
+      "default_call_source": ["EDGG-NKRL"]
     },
     {
       "id": "ETAD_APP",
       "prefixes": ["ETAD"],
       "frequency": "129.475",
       "facility_type": "APP",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TADA"]
     },
     {
       "id": "ETAR_APP",
       "prefixes": ["ETAR"],
       "frequency": "124.280",
       "facility_type": "APP",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TARA"]
     },
     {
       "id": "ETHF_APP",
       "prefixes": ["ETHF"],
       "frequency": "120.865",
       "facility_type": "APP",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-THFA"]
     },
     {
       "id": "ETHN_APP",
       "prefixes": ["ETHN"],
       "frequency": "127.190",
       "facility_type": "APP",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-THNA"]
     },
     {
       "id": "ETNG_APP",
       "prefixes": ["ETNG"],
       "frequency": "123.730",
       "facility_type": "APP",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TNGA"]
     },
     {
       "id": "ETNN_APP",
       "prefixes": ["ETNN"],
       "frequency": "129.055",
       "facility_type": "APP",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TNNA"]
     },
     {
       "id": "ETSB_APP",
       "prefixes": ["ETSB"],
       "frequency": "130.155",
       "facility_type": "APP",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TSBA"]
     },
     {
       "id": "EDDL_TWR",
       "prefixes": ["EDDL"],
       "frequency": "118.305",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DLT"]
     },
     {
       "id": "EDDL_E_GND",
       "prefixes": ["EDDL"],
       "frequency": "121.605",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DLGE"]
     },
     {
       "id": "EDDL_W_GND",
       "prefixes": ["EDDL"],
       "frequency": "121.680",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DLGW"]
     },
     {
       "id": "EDDL_DEL",
       "prefixes": ["EDDL"],
       "frequency": "121.780",
       "facility_type": "DEL",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DLC"]
     },
     {
       "id": "EDDK_TWR",
       "prefixes": ["EDDK"],
       "frequency": "124.980",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DKT"]
     },
     {
       "id": "EDDK_GND",
       "prefixes": ["EDDK"],
       "frequency": "121.730",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DKG"]
     },
     {
       "id": "EDDK_P_GND",
@@ -607,322 +686,373 @@
       "prefixes": ["EDDK"],
       "frequency": "121.855",
       "facility_type": "DEL",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DLC"]
     },
     {
       "id": "EDDF_C_TWR",
       "prefixes": ["EDDF"],
       "frequency": "118.780",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DFTC"]
     },
     {
       "id": "EDDF_W_TWR",
       "prefixes": ["EDDF"],
       "frequency": "124.855",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DFTW"]
     },
     {
       "id": "EDDF_N_TWR",
       "prefixes": ["EDDF"],
       "frequency": "136.500",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DFTN"]
     },
     {
       "id": "EDDF_S_TWR",
       "prefixes": ["EDDF"],
       "frequency": "119.905",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DFTS"]
     },
     {
       "id": "EDDF_C_GND",
       "prefixes": ["EDDF"],
       "frequency": "121.855",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DFGC"]
     },
     {
       "id": "EDDF_W_GND",
       "prefixes": ["EDDF"],
       "frequency": "121.755",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DFGW"]
     },
     {
       "id": "EDDF_E_GND",
       "prefixes": ["EDDF"],
       "frequency": "121.955",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DFGE"]
     },
     {
       "id": "EDDF_S_GND",
       "prefixes": ["EDDF"],
       "frequency": "121.655",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DFGS"]
+
     },
     {
       "id": "EDDF_ICE_GND",
       "prefixes": ["EDDF"],
       "frequency": "121.985",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DFGI"]
     },
     {
       "id": "EDDF_GND",
       "prefixes": ["EDDF"],
       "frequency": "121.805",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DFG"]
     },
     {
       "id": "EDDF_DEL",
       "prefixes": ["EDDF"],
       "frequency": "122.035",
       "facility_type": "DEL",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DLC"]
     },
     {
       "id": "EDDS_TWR",
       "prefixes": ["EDDS"],
       "frequency": "118.805",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DST"]
     },
     {
       "id": "EDDS_VFR_TWR",
       "prefixes": ["EDDS"],
       "frequency": "119.055",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DSTV"]
     },
     {
       "id": "EDDS_GND",
       "prefixes": ["EDDS"],
       "frequency": "118.605",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DSG"]
     },
     {
       "id": "EDDS_DEL",
       "prefixes": ["EDDS"],
       "frequency": "121.915",
       "facility_type": "DEL",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DSC"]
     },
     {
       "id": "EDDG_TWR",
       "prefixes": ["EDDG"],
       "frequency": "129.805",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DGT"]
     },
     {
       "id": "EDDG_GND",
       "prefixes": ["EDDG"],
       "frequency": "121.880",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DGG"]
     },
     {
       "id": "EDDR_TWR",
       "prefixes": ["EDDR"],
       "frequency": "118.355",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DRT"]
     },
     {
       "id": "EDDR_GND",
       "prefixes": ["EDDR"],
       "frequency": "118.555",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-DRG"]
     },
     {
       "id": "EDFH_TWR",
       "prefixes": ["EDFH"],
       "frequency": "119.655",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-FHT"]
     },
     {
       "id": "EDFH_GND",
       "prefixes": ["EDFH"],
       "frequency": "121.980",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-FHG"]
     },
     {
       "id": "EDFM_TWR",
       "prefixes": ["EDFM"],
       "frequency": "129.780",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-FMT"]
     },
     {
       "id": "EDLN_TWR",
       "prefixes": ["EDLN"],
       "frequency": "120.455",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-LNT"]
     },
     {
       "id": "EDLN_GND",
       "prefixes": ["EDLN"],
       "frequency": "121.930",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-LNG"]
     },
     {
       "id": "EDLP_TWR",
       "prefixes": ["EDLP"],
       "frequency": "133.380",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-LPT"]
     },
     {
       "id": "EDLP_GND",
       "prefixes": ["EDLP"],
       "frequency": "121.930",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-LPG"]
     },
     {
       "id": "EDLV_TWR",
       "prefixes": ["EDLV"],
       "frequency": "129.405",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-LVT"]
     },
     {
       "id": "EDLW_TWR",
       "prefixes": ["EDLW"],
       "frequency": "134.180",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-LWT"]
     },
     {
       "id": "EDLW_GND",
       "prefixes": ["EDLW"],
       "frequency": "121.830",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-LWG"]
     },
     {
       "id": "EDSB_TWR",
       "prefixes": ["EDSB"],
       "frequency": "134.105",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-SBT"]
     },
     {
       "id": "EDSB_GND",
       "prefixes": ["EDSB"],
       "frequency": "121.830",
       "facility_type": "GND",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-SBG"]
     },
     {
       "id": "EDTL_TWR",
       "prefixes": ["EDTL"],
       "frequency": "125.180",
       "facility_type": "TWR",
-      "profile_id": "EDGG_TWR"
+      "profile_id": "EDGG_TWR",
+      "default_call_source": ["EDGG-TLT"]
     },
     {
       "id": "ETAD_TWR",
       "prefixes": ["ETAD"],
       "frequency": "122.200",
       "facility_type": "TWR",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TADT"]
     },
     {
       "id": "ETAD_GND",
       "prefixes": ["ETAD"],
       "frequency": "121.865",
       "facility_type": "GND",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TADG"]
     },
     {
       "id": "ETAD_DEL",
       "prefixes": ["ETAD"],
       "frequency": "120.905",
       "facility_type": "DEL",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TADC"]
     },
     {
       "id": "ETAR_TWR",
       "prefixes": ["ETAR"],
       "frequency": "133.205",
       "facility_type": "TWR",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TART"]
+
     },
     {
       "id": "ETAR_GND",
       "prefixes": ["ETAR"],
       "frequency": "121.775",
       "facility_type": "GND",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TARG"]
     },
     {
       "id": "ETHF_TWR",
       "prefixes": ["ETHF"],
       "frequency": "122.300",
       "facility_type": "TWR",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-THFT"]
     },
     {
       "id": "ETHF_GND",
       "prefixes": ["ETHF"],
       "frequency": "131.450",
       "facility_type": "GND",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-THFG"]
     },
     {
       "id": "ETHN_TWR",
       "prefixes": ["ETHN"],
       "frequency": "134.205",
       "facility_type": "TWR",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-THNT"]
     },
     {
       "id": "ETNG_TWR",
       "prefixes": ["ETNG"],
       "frequency": "120.055",
       "facility_type": "TWR",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TNGT"]
+
     },
     {
       "id": "ETNN_TWR",
       "prefixes": ["ETNN"],
       "frequency": "136.205",
       "facility_type": "TWR",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TNNT"]
+
     },
     {
       "id": "ETOU_TWR",
       "prefixes": ["ETOU"],
       "frequency": "122.100",
       "facility_type": "TWR",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TOUT"]
+
     },
     {
       "id": "ETOU_GND",
       "prefixes": ["ETOU"],
       "frequency": "126.555",
       "facility_type": "GND",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TOUG"]
     },
     {
       "id": "ETSB_TWR",
       "prefixes": ["ETSB"],
       "frequency": "129.060",
       "facility_type": "TWR",
-      "profile_id": "EDGG_MIL"
+      "profile_id": "EDGG_MIL",
+      "default_call_source": ["EDGG-TSBT"]
     },
     {
       "id": "EDEH_I_TWR",

--- a/dataset/EDGG/positions.json
+++ b/dataset/EDGG/positions.json
@@ -752,7 +752,6 @@
       "facility_type": "GND",
       "profile_id": "EDGG_TWR",
       "default_call_source": ["EDGG-DFGS"]
-
     },
     {
       "id": "EDDF_ICE_GND",
@@ -977,7 +976,6 @@
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
       "default_call_source": ["EDGG-TART"]
-
     },
     {
       "id": "ETAR_GND",
@@ -1018,7 +1016,6 @@
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
       "default_call_source": ["EDGG-TNGT"]
-
     },
     {
       "id": "ETNN_TWR",
@@ -1027,7 +1024,6 @@
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
       "default_call_source": ["EDGG-TNNT"]
-
     },
     {
       "id": "ETOU_TWR",
@@ -1036,7 +1032,6 @@
       "facility_type": "TWR",
       "profile_id": "EDGG_MIL",
       "default_call_source": ["EDGG-TOUT"]
-
     },
     {
       "id": "ETOU_GND",

--- a/dataset/EDGG/profiles/EDGG_AFIS.json
+++ b/dataset/EDGG/profiles/EDGG_AFIS.json
@@ -1,0 +1,17 @@
+{
+  "id": "EDGG_AFIS",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": "AFIS",
+      "page": {
+        "rows": 5,
+        "client_page": {
+          "include": ["EDGG*", "EDXX*", "ED*_APP", "ED*_I_TWR"],
+          "grouping": "Icao",
+          "priority": ["*_CTR", "*_TWR"]
+        }
+      }
+    }
+  ]
+}

--- a/dataset/EDGG/profiles/EDGG_DFAN.json
+++ b/dataset/EDGG/profiles/EDGG_DFAN.json
@@ -9,38 +9,47 @@
         "keys": [
           {
             "label": ["DFAN"],
+            "color": "umber",
             "station_id": "EDGG-DFAN"
           },
           {
             "label": ["DFANT", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DFANT"
           },
           {
             "label": ["EDDF", "C", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DFTC"
           },
           {
             "label": ["EDDF", "C", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DFGC"
           },
           {
             "label": ["EDDF", "DEL"],
+            "color": "snow",
             "station_id": "EDGG-DFC"
           },
           {
             "label": ["DFAS"],
+            "color": "umber",
             "station_id": "EDGG-DFAS"
           },
           {
             "label": ["DFAST", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DFAST"
           },
           {
             "label": ["EDDF", "N", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DFTN"
           },
           {
             "label": ["EDDF", "E", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DFGE"
           },
           {
@@ -48,6 +57,7 @@
           },
           {
             "label": ["DFDN"],
+            "color": "umber",
             "station_id": "EDGG-DFDN"
           },
           {
@@ -55,18 +65,22 @@
           },
           {
             "label": ["EDDF", "W", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DFTW"
           },
           {
             "label": ["EDDF", "W", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DFGW"
           },
           {
             "label": ["EDDF", "ICE", "GND"],
+            "color": "snow",
             "station_id": "EDGG-DFGI"
           },
           {
             "label": ["DFDS"],
+            "color": "umber",
             "station_id": "EDGG-DFDS"
           },
           {
@@ -74,10 +88,12 @@
           },
           {
             "label": ["EDDF", "S", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DFTS"
           },
           {
             "label": ["EDDF", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DFG"
           },
           {
@@ -91,6 +107,7 @@
           },
           {
             "label": ["ETOU", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-TOUT"
           },
           {
@@ -101,10 +118,12 @@
           },
           {
             "label": ["PFA", "APP"],
+            "color": "umber",
             "station_id": "EDGG-PFA"
           },
           {
             "label": ["EDGG", "KIR"],
+            "color": "lagoon",
             "station_id": "EDGG-KIR"
           },
           {
@@ -112,50 +131,62 @@
           },
           {
             "label": ["EDGG", "MAN"],
+            "color": "lagoon",
             "station_id": "EDGG-MAN"
           },
           {
             "label": ["EDGG", "NKRH"],
+            "color": "lagoon",
             "station_id": "EDGG-NKRH"
           },
           {
             "label": ["EDGG", "RUD"],
+            "color": "lagoon",
             "station_id": "EDGG-RUD"
           },
           {
             "label": ["EDGG", "TAU"],
+            "color": "lagoon",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["EDGG", "HEF"],
+            "color": "lagoon",
             "station_id": "EDGG-HEF"
           },
           {
             "label": ["EDGG", "HAB"],
+            "color": "lagoon",
             "station_id": "EDGG-HAB"
           },
           {
             "label": ["EDGG", "KNG"],
+            "color": "lagoon",
             "station_id": "EDGG-KNG"
           },
           {
             "label": ["EDGG", "SIG"],
+            "color": "lagoon",
             "station_id": "EDGG-SIG"
           },
           {
             "label": ["EDGG", "GIN"],
+            "color": "lagoon",
             "station_id": "EDGG-GIN"
           },
           {
             "label": ["EDGG", "GED"],
+            "color": "lagoon",
             "station_id": "EDGG-GED"
           },
           {
             "label": ["EDGG", "KTG"],
+            "color": "lagoon",
             "station_id": "EDGG-KTG"
           },
           {
             "label": ["EDGG", "PSA"],
+            "color": "lagoon",
             "station_id": "EDGG-PSA"
           }
         ]

--- a/dataset/EDGG/profiles/EDGG_EBG1.json
+++ b/dataset/EDGG/profiles/EDGG_EBG1.json
@@ -9,38 +9,47 @@
         "keys": [
           {
             "label": ["RL"],
+            "color": "lilac",
             "station_id": "EDYY-RL"
           },
           {
             "label": ["PADH"],
+            "color": "lagoon",
             "station_id": "EDGG-PAH"
           },
           {
             "label": ["DLA"],
+            "color": "umber",
             "station_id": "EDGG-DLA"
           },
           {
             "label": ["EDDL", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DLT"
           },
           {
             "label": ["EDDL", "E", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DLGE"
           },
           {
             "label": ["EDDL", "DEL"],
+            "color": "snow",
             "station_id": "EDGG-DLC"
           },
           {
             "label": ["RH"],
+            "color": "lilac",
             "station_id": "EDYY-RH"
           },
           {
             "label": ["SIG"],
+            "color": "lagoon",
             "station_id": "EDGG-SIG"
           },
           {
             "label": ["DLAT"],
+            "color": "taupe",
             "station_id": "EDGG-DLAT"
           },
           {
@@ -48,6 +57,7 @@
           },
           {
             "label": ["EDDL", "W", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DLGW"
           },
           {
@@ -55,22 +65,27 @@
           },
           {
             "label": ["ML"],
+            "color": "lilac",
             "station_id": "EDYY-ML"
           },
           {
             "label": ["TAU"],
+            "color": "lagoon",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["DLD"],
+            "color": "umber",
             "station_id": "EDGG-DLD"
           },
           {
             "label": ["EDLW", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-LWT"
           },
           {
             "label": ["EDLW", "GND"],
+            "color": "blush",
             "station_id": "EDGG-LWG"
           },
           {
@@ -78,6 +93,7 @@
           },
           {
             "label": ["MH"],
+            "color": "lilac",
             "station_id": "EDYY-MH"
           },
           {
@@ -85,10 +101,12 @@
           },
           {
             "label": ["BOT"],
+            "color": "umber",
             "station_id": "EDGG-BOT"
           },
           {
             "label": ["EDLV", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-LVT"
           },
           {
@@ -99,18 +117,22 @@
           },
           {
             "label": ["NOR"],
+            "color": "umber",
             "station_id": "EDGG-NOR"
           },
           {
             "label": ["DKA"],
+            "color": "umber",
             "station_id": "EDGG-DKA"
           },
           {
             "label": ["PADL"],
+            "color": "umber",
             "station_id": "EDGG-PADL"
           },
           {
             "label": ["HMM"],
+            "color": "umber",
             "station_id": "EDGG-HMM"
           },
           {

--- a/dataset/EDGG/profiles/EDGG_EBG2.json
+++ b/dataset/EDGG/profiles/EDGG_EBG2.json
@@ -9,34 +9,42 @@
         "keys": [
           {
             "label": ["SLN"],
+            "color": "lilac",
             "station_id": "EDUU-SLN"
           },
           {
             "label": ["BAD"],
+            "color": "lagoon",
             "station_id": "EDGG-BAD"
           },
           {
             "label": ["STG"],
+            "color": "umber",
             "station_id": "EDGG-STG"
           },
           {
             "label": ["EDDF", "DSAT", "Feeder"],
+            "color": "clay",
             "station_id": "EDGG-DSAT"
           },
           {
             "label": ["EDDS", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DST"
           },
           {
             "label": ["TGO"],
+            "color": "lilac",
             "station_id": "EDUU-TGO"
           },
           {
             "label": ["LBU"],
+            "color": "lagoon",
             "station_id": "EDGG-LBU"
           },
           {
             "label": ["REU"],
+            "color": "umber",
             "station_id": "EDGG-REU"
           },
           {
@@ -44,38 +52,47 @@
           },
           {
             "label": ["EDSB", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-SBT"
           },
           {
             "label": ["WUR"],
+            "color": "lilac",
             "station_id": "EDUU-WUR"
           },
           {
             "label": ["MAN"],
+            "color": "lagoon",
             "station_id": "EDGG-MAN"
           },
           {
             "label": ["EDDF", "DFAS"],
+            "color": "clay",
             "station_id": "EDGG-DFAS"
           },
           {
             "label": ["EDDF", "DFDS"],
+            "color": "clay",
             "station_id": "EDGG-DFDS"
           },
           {
             "label": ["EDTL", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-TLT"
           },
           {
             "label": ["EDUU", "FUL"],
+            "color": "lavender",
             "station_id": "EDUU-FUL"
           },
           {
             "label": ["NKRH"],
+            "color": "lagoon",
             "station_id": "EDGG-NKRH"
           },
           {
             "label": ["EDFM", "NKRL"],
+            "color": "umber",
             "station_id": "EDGG-NKRL"
           },
           {
@@ -83,14 +100,17 @@
           },
           {
             "label": ["EDFM", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-FMT"
           },
           {
             "label": ["EDUU", "FFM"],
+            "color": "lavender",
             "station_id": "EDUU-FFM"
           },
           {
             "label": ["DKB"],
+            "color": "lagoon",
             "station_id": "EDGG-DKB"
           },
           {
@@ -104,28 +124,34 @@
           },
           {
             "label": ["EDUU", "NTM"],
+            "color": "lavender",
             "station_id": "EDUU-NTM"
           },
           {
             "label": ["KNG"],
+            "color": "lagoon",
             "station_id": "EDGG-KNG"
           },
           {
             "label": ["PSA"],
+            "color": "lagoon",
             "station_id": "EDGG-PSA"
           },
           {
             "label": ["EDMM", "WLD"],
+            "color": "mint",
             "station_id": "EDMM-WLD"
           },
           {
-            "label": ["LSAS", "SZN"]
+            "label": ["LSAS", "SZN"],
+            "color": "mint"
           },
           {
             "label": [""]
           },
           {
             "label": ["HAB"],
+            "color": "lagoon",
             "station_id": "EDGG-HAB"
           },
           {
@@ -133,28 +159,34 @@
           },
           {
             "label": ["EDMM", "NDG"],
+            "color": "mint",
             "station_id": "EDMM-NDG"
           },
           {
-            "label": ["LSAS", "SZE"]
+            "label": ["LSAS", "SZE"],
+            "color": "mint"
           },
           {
             "label": [""]
           },
           {
             "label": ["EDGG", "KIR"],
+            "color": "lagoon",
             "station_id": "EDGG-KIR"
           },
           {
             "label": ["EDDR", "PFA"],
+            "color": "clay",
             "station_id": "EDGG-PFA"
           },
           {
             "label": ["EDMM", "FUE"],
+            "color": "mint",
             "station_id": "EDMM-FUE"
           },
           {
-            "label": ["LSAS", "SZU"]
+            "label": ["LSAS", "SZU"],
+            "color": "mint"
           }
         ]
       }

--- a/dataset/EDGG/profiles/EDGG_EBG3.json
+++ b/dataset/EDGG/profiles/EDGG_EBG3.json
@@ -9,18 +9,22 @@
         "keys": [
           {
             "label": ["NTM"],
+            "color": "lilac",
             "station_id": "EDUU-NTM"
           },
           {
             "label": ["TAU"],
+            "color": "lagoon",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["DFAN"],
+            "color": "umber",
             "station_id": "EDGG-DFAN"
           },
           {
             "label": ["DFAS"],
+            "color": "umber",
             "station_id": "EDGG-DFAS"
           },
           {
@@ -33,10 +37,12 @@
               "keys": [
                 {
                   "label": ["DFANT"],
+                  "color": "taupe",
                   "station_id": "EDGG-DFANT"
                 },
                 {
                   "label": ["DFAST"],
+                  "color": "taupe",
                   "station_id": "EDGG-DFAST"
                 }
               ]
@@ -44,22 +50,27 @@
           },
           {
             "label": ["FFM"],
+            "color": "lilac",
             "station_id": "EDUU-FFM"
           },
           {
             "label": ["SIG"],
+            "color": "lagoon",
             "station_id": "EDGG-SIG"
           },
           {
             "label": ["DFDN"],
+            "color": "umber",
             "station_id": "EDGG-DFDN"
           },
           {
             "label": ["DFDS"],
+            "color": "umber",
             "station_id": "EDGG-DFDS"
           },
           {
             "label": ["EDDF", "C", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DFTC"
           },
           {
@@ -69,22 +80,27 @@
               "keys": [
                 {
                   "label": ["EDDF", "N", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DFTN"
                 },
                 {
                   "label": ["EDDF", "C", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGC"
                 },
                 {
                   "label": ["EDDF", "DEL"],
+                  "color": "snow",
                   "station_id": "EDGG-DFC"
                 },
                 {
                   "label": ["EDDF", "W", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DFTW"
                 },
                 {
                   "label": ["EDDF", "W", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGW"
                 },
                 {
@@ -92,14 +108,17 @@
                 },
                 {
                   "label": ["EDDF", "S", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DFTS"
                 },
                 {
                   "label": ["EDDF", "E", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGE"
                 },
                 {
                   "label": ["EDDF", "ICE"],
+                  "color": "snow",
                   "station_id": "EDGG-DFGI"
                 },
                 {
@@ -107,6 +126,7 @@
                 },
                 {
                   "label": ["EDDF", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFG"
                 },
                 {
@@ -117,22 +137,27 @@
           },
           {
             "label": ["FUL"],
+            "color": "lilac",
             "station_id": "EDUU-FUL"
           },
           {
             "label": ["GIN"],
+            "color": "lagoon",
             "station_id": "EDGG-GIN"
           },
           {
             "label": ["RUD"],
+            "color": "lagoon",
             "station_id": "EDGG-RUD"
           },
           {
             "label": ["EDFH", "EIF"],
+            "color": "clay",
             "station_id": "EDGG-EIF"
           },
           {
             "label": ["EDDR", "PFA"],
+            "color": "clay",
             "station_id": "EDGG-PFA"
           },
           {
@@ -140,22 +165,27 @@
           },
           {
             "label": ["EDUU", "SLN"],
+            "color": "lavender",
             "station_id": "EDUU-SLN"
           },
           {
             "label": ["HEF"],
+            "color": "lagoon",
             "station_id": "EDGG-HEF"
           },
           {
             "label": ["KIR"],
+            "color": "lagoon",
             "station_id": "EDGG-KIR"
           },
           {
             "label": ["EDDL", "DLA"],
+            "color": "clay",
             "station_id": "EDGG-DLA"
           },
           {
             "label": ["EDDK", "NOR"],
+            "color": "clay",
             "station_id": "EDGG-NOR"
           },
           {
@@ -165,26 +195,32 @@
               "keys": [
                 {
                   "label": ["DLD"],
+                  "color": "clay",
                   "station_id": "EDGG-DLD"
                 },
                 {
                   "label": ["DKA"],
+                  "color": "clay",
                   "station_id": "EDGG-DKA"
                 },
                 {
                   "label": ["BOT"],
+                  "color": "clay",
                   "station_id": "EDGG-BOT"
                 },
                 {
                   "label": ["EDDL", "TWR"],
+                  "color": "cadet",
                   "station_id": "EDGG-DLT"
                 },
                 {
                   "label": ["HMM"],
+                  "color": "clay",
                   "station_id": "EDGG-HMM"
                 },
                 {
                   "label": ["EDDK", "TWR"],
+                  "color": "cadet",
                   "station_id": "EDGG-DKT"
                 }
               ]
@@ -192,34 +228,42 @@
           },
           {
             "label": ["EDUU", "WUR"],
+            "color": "lavender",
             "station_id": "EDUU-WUR"
           },
           {
             "label": ["GED"],
+            "color": "lagoon",
             "station_id": "EDGG-GED"
           },
           {
             "label": ["EDGG", "PADH"],
+            "color": "mint",
             "station_id": "EDGG-PAH"
           },
           {
             "label": ["EDLP", "PADL"],
+            "color": "clay",
             "station_id": "EDGG-PADL"
           },
           {
             "label": ["EDGG", "MAN"],
+            "color": "mint",
             "station_id": "EDGG-MAN"
           },
           {
             "label": ["EDGG", "HAB"],
+            "color": "mint",
             "station_id": "EDGG-HAB"
           },
           {
             "label": ["EDYY", "RH"],
+            "color": "lavender",
             "station_id": "EDYY-RH"
           },
           {
             "label": ["EDYY", "RL"],
+            "color": "lavender",
             "station_id": "EDYY-RL"
           },
           {
@@ -227,22 +271,27 @@
           },
           {
             "label": ["EDUU", "SAL"],
+            "color": "lavender",
             "station_id": "EDUU-SAL"
           },
           {
             "label": ["EDMM", "HAL"],
+            "color": "mint",
             "station_id": "EDMM-HAL"
           },
           {
             "label": ["EDDP", "TRN"],
+            "color": "clay",
             "station_id": "EDMM-TRN"
           },
           {
             "label": ["EDYY", "MH"],
+            "color": "lavender",
             "station_id": "EDYY-MH"
           },
           {
             "label": ["EDYY", "ML"],
+            "color": "lavender",
             "station_id": "EDYY-ML"
           },
           {
@@ -250,26 +299,32 @@
           },
           {
             "label": ["EDUU", "ERL"],
+            "color": "lavender",
             "station_id": "EDUU-ERL"
           },
           {
             "label": ["EDMM", "GER"],
+            "color": "mint",
             "station_id": "EDMM-GER"
           },
           {
             "label": ["EDDP", "TRS"],
+            "color": "clay",
             "station_id": "EDMM-TRS"
           },
           {
             "label": ["EDYY", "SH"],
+            "color": "lavender",
             "station_id": "EDYY-SH"
           },
           {
             "label": ["EDYY", "SL"],
+            "color": "lavender",
             "station_id": "EDYY-SL"
           },
           {
             "label": ["EDWW", "HRZ"],
+            "color": "mint",
             "station_id": "EDWW-HRZ"
           },
           {
@@ -277,10 +332,12 @@
           },
           {
             "label": ["EDMM", "BBG"],
+            "color": "mint",
             "station_id": "EDMM-BBG"
           },
           {
             "label": ["EDDN", "FRK"],
+            "color": "clay",
             "station_id": "EDMM-FRK"
           }
         ]

--- a/dataset/EDGG/profiles/EDGG_EBG4.json
+++ b/dataset/EDGG/profiles/EDGG_EBG4.json
@@ -9,30 +9,37 @@
         "keys": [
           {
             "label": ["SLN"],
+            "color": "lilac",
             "station_id": "EDUU-SLN"
           },
           {
             "label": ["BAD"],
+            "color": "lagoon",
             "station_id": "EDGG-BAD"
           },
           {
             "label": ["STG"],
+            "color": "umber",
             "station_id": "EDGG-STG"
           },
           {
             "label": ["EDDS", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DST"
           },
           {
             "label": ["EDDS", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DSG"
           },
           {
             "label": ["TGO"],
+            "color": "lilac",
             "station_id": "EDUU-TGO"
           },
           {
             "label": ["LBU"],
+            "color": "lagoon",
             "station_id": "EDGG-LBU"
           },
           {
@@ -46,18 +53,22 @@
           },
           {
             "label": ["WUR"],
+            "color": "lilac",
             "station_id": "EDUU-WUR"
           },
           {
             "label": ["MAN"],
+            "color": "lagoon",
             "station_id": "EDGG-MAN"
           },
           {
             "label": ["EDDF", "DFAS"],
+            "color": "clay",
             "station_id": "EDGG-DFAS"
           },
           {
             "label": ["EDDF", "DFDS"],
+            "color": "clay",
             "station_id": "EDGG-DFDS"
           },
           {
@@ -65,14 +76,17 @@
           },
           {
             "label": ["EDUU", "FUL"],
+            "color": "lavender",
             "station_id": "EDUU-FUL"
           },
           {
             "label": ["NKRH"],
+            "color": "lagoon",
             "station_id": "EDGG-NKRH"
           },
           {
             "label": ["EDFM", "NKRL"],
+            "color": "clay",
             "station_id": "EDGG-NKRL"
           },
           {
@@ -83,14 +97,17 @@
           },
           {
             "label": ["EDUU", "FFM"],
+            "color": "lavender",
             "station_id": "EDUU-FFM"
           },
           {
             "label": ["DKB"],
+            "color": "lagoon",
             "station_id": "EDGG-DKB"
           },
           {
             "label": ["EDDN", "FRK"],
+            "color": "clay",
             "station_id": "EDMM-FRK"
           },
           {
@@ -101,30 +118,37 @@
           },
           {
             "label": ["EDUU", "ERL"],
+            "color": "lavender",
             "station_id": "EDUU-ERL"
           },
           {
             "label": ["KNG"],
+            "color": "lagoon",
             "station_id": "EDGG-KNG"
           },
           {
             "label": ["PSA"],
+            "color": "lagoon",
             "station_id": "EDGG-PSA"
           },
           {
             "label": ["EDMM", "WLD"],
+            "color": "mint",
             "station_id": "EDMM-WLD"
           },
           {
             "label": ["EDMM", "NDG"],
+            "color": "mint",
             "station_id": "EDMM-NDG"
           },
           {
             "label": ["EDUU", "DON"],
+            "color": "lavender",
             "station_id": "EDUU-DON"
           },
           {
             "label": ["HAB"],
+            "color": "lagoon",
             "station_id": "EDGG-HAB"
           },
           {
@@ -132,17 +156,21 @@
           },
           {
             "label": ["EDMM", "BBG"],
+            "color": "mint",
             "station_id": "EDMM-BBG"
           },
           {
-            "label": ["LSAS", "SZE"]
+            "label": ["LSAS", "SZE"],
+            "color": "mint"
           },
           {
             "label": ["EDUU", "AMM"],
+            "color": "lavender",
             "station_id": "EDUU-AMM"
           },
           {
             "label": ["KTG"],
+            "color": "lagoon",
             "station_id": "EDGG-KTG"
           },
           {
@@ -150,10 +178,12 @@
           },
           {
             "label": ["EDMM", "ALB"],
+            "color": "mint",
             "station_id": "EDMM-ALB"
           },
           {
-            "label": ["LSAS", "SZU"]
+            "label": ["LSAS", "SZU"],
+            "color": "lavender"
           }
         ]
       }

--- a/dataset/EDGG/profiles/EDGG_EBG5.json
+++ b/dataset/EDGG/profiles/EDGG_EBG5.json
@@ -9,34 +9,42 @@
         "keys": [
           {
             "label": ["NTM"],
+            "color": "lilac",
             "station_id": "EDUU-NTM"
           },
           {
             "label": ["RUD"],
+            "color": "lagoon",
             "station_id": "EDGG-RUD"
           },
           {
             "label": ["DFAN"],
+            "color": "umber",
             "station_id": "EDGG-DFAN"
           },
           {
             "label": ["DFANT"],
+            "color": "taupe",
             "station_id": "EDGG-DFANT"
           },
           {
             "label": ["EDDF", "C", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DFTC"
           },
           {
             "label": ["FFM"],
+            "color": "lilac",
             "station_id": "EDUU-FFM"
           },
           {
             "label": ["KIR"],
+            "color": "lagoon",
             "station_id": "EDGG-KIR"
           },
           {
             "label": ["DFAS"],
+            "color": "umber",
             "station_id": "EDGG-DFAS"
           },
           {
@@ -46,6 +54,7 @@
               "keys": [
                 {
                   "label": ["DFDN"],
+                  "color": "umber",
                   "station_id": "EDGG-DFDN"
                 },
                 {
@@ -53,10 +62,12 @@
                 },
                 {
                   "label": ["DFDS"],
+                  "color": "umber",
                   "station_id": "EDGG-DFDS"
                 },
                 {
                   "label": ["DFAST"],
+                  "color": "taupe",
                   "station_id": "EDGG-DFAST"
                 }
               ]
@@ -69,22 +80,27 @@
               "keys": [
                 {
                   "label": ["EDDF", "N", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DFTN"
                 },
                 {
                   "label": ["EDDF", "C", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGC"
                 },
                 {
                   "label": ["EDDF", "DEL"],
+                  "color": "snow",
                   "station_id": "EDGG-DFC"
                 },
                 {
                   "label": ["EDDF", "W", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DFTW"
                 },
                 {
                   "label": ["EDDF", "W", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGW"
                 },
                 {
@@ -92,14 +108,17 @@
                 },
                 {
                   "label": ["EDDF", "S", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DFTS"
                 },
                 {
                   "label": ["EDDF", "E", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGE"
                 },
                 {
                   "label": ["EDDF", "ICE"],
+                  "color": "snow",
                   "station_id": "EDGG-DFGI"
                 },
                 {
@@ -107,6 +126,7 @@
                 },
                 {
                   "label": ["EDDF", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFG"
                 },
                 {
@@ -117,14 +137,17 @@
           },
           {
             "label": ["EDUU", "SLN"],
+            "color": "lavender",
             "station_id": "EDUU-SLN"
           },
           {
             "label": ["TAU"],
+            "color": "lagoon",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["PFA"],
+            "color": "umber",
             "station_id": "EDGG-PFA"
           },
           {
@@ -132,18 +155,22 @@
           },
           {
             "label": ["EDFH", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-FHT"
           },
           {
             "label": ["EDYY", "RL"],
+            "color": "lavender",
             "station_id": "EDYY-RL"
           },
           {
             "label": ["EDGG", "MAN"],
+            "color": "mint",
             "station_id": "EDGG-MAN"
           },
           {
             "label": ["EIF"],
+            "color": "umber",
             "station_id": "EDGG-EIF"
           },
           {
@@ -151,30 +178,37 @@
           },
           {
             "label": ["ETOU", "TWR"],
+            "color": "steel",
             "station_id": "EDGG-TOUT"
           },
           {
             "label": ["EDYY", "RH"],
+            "color": "lavender",
             "station_id": "EDYY-RH"
           },
           {
             "label": ["EDGG", "NKRH"],
+            "color": "mint",
             "station_id": "EDGG-NKRH"
           },
           {
             "label": ["EDDK", "NOR"],
+            "color": "clay",
             "station_id": "EDGG-NOR"
           },
           {
             "label": ["EDDK", "DKA"],
+            "color": "clay",
             "station_id": "EDGG-DKA"
           },
           {
             "label": ["ETAR", "TWR"],
+            "color": "steel",
             "station_id": "EDGG-TART"
           },
           {
             "label": ["EDYY", "LNH"],
+            "color": "lavender",
             "station_id": "EDYY-LNH"
           },
           {
@@ -182,6 +216,7 @@
           },
           {
             "label": ["EDDS", "STG"],
+            "color": "clay",
             "station_id": "EDGG-STG"
           },
           {
@@ -192,34 +227,41 @@
           },
           {
             "label": ["EDYY", "LXH"],
+            "color": "lavender",
             "station_id": "EDYY-LXH"
           },
           {
             "label": ["EBBU", "EHS"],
+            "color": "mint",
             "station_id": "EBBU-EHS"
           },
           {
             "label": ["EBBU", "ELS"],
+            "color": "mint",
             "station_id": "EBBU-ELS"
           },
           {
-            "label": ["LFST", "APP"]
+            "label": ["LFST", "APP"],
+            "color": "clay"
           },
           {
             "label": [""]
           },
           {
-            "label": ["LFEE", "UE"]
+            "label": ["LFEE", "UE"],
+            "color": "lavender"
           },
           {
             "label": [""]
           },
           {
             "label": ["EBBU", "LUS"],
+            "color": "mint",
             "station_id": "EBBU-LUS"
           },
           {
             "label": ["ELLX", "APP"],
+            "color": "clay",
             "station_id": "ELLX-APP"
           },
           {

--- a/dataset/EDGG/profiles/EDGG_EBG6.json
+++ b/dataset/EDGG/profiles/EDGG_EBG6.json
@@ -9,73 +9,90 @@
         "keys": [
           {
             "label": ["MH"],
+            "color": "lilac",
             "station_id": "EDYY-MH"
           },
           {
             "label": ["ML"],
+            "color": "lilac",
             "station_id": "EDYY-ML"
           },
           {
             "label": ["PADH"],
+            "color": "lagoon",
             "station_id": "EDGG-PAH"
           },
           {
-            "label": ["HMM"],
-            "station_id": "EDGG-HMM"
-          },
-          {
             "label": ["EDDG", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DGT"
-          },
-          {
-            "label": ["RH"],
-            "station_id": "EDYY-RH"
-          },
-          {
-            "label": ["RL"],
-            "station_id": "EDYY-RL"
-          },
-          {
-            "label": ["PADL"],
-            "station_id": "EDGG-PADL"
-          },
-          {
-            "label": ["EDLP", "TWR"],
-            "station_id": "EDGG-PADL"
-          },
-          {
-            "label": ["EDLP", "GND"],
-            "station_id": "EDGG-LPG"
-          },
-          {
-            "label": ["EDUU", "FFM"],
-            "station_id": "EDUU-FFM"
-          },
-          {
-            "label": ["EDGG", "SIG"],
-            "station_id": "EDGG-SIG"
           },
           {
             "label": [""]
           },
           {
+            "label": ["RH"],
+            "color": "lilac",
+            "station_id": "EDYY-RH"
+          },
+          {
+            "label": ["RL"],
+            "color": "lilac",
+            "station_id": "EDYY-RL"
+          },
+          {
+            "label": ["PADL"],
+            "color": "umber",
+            "station_id": "EDGG-PADL"
+          },
+          {
+            "label": ["EDLP", "TWR"],
+            "color": "azure",
+            "station_id": "EDGG-PADL"
+          },
+          {
+            "label": ["EDLP", "GND"],
+            "color": "blush",
+            "station_id": "EDGG-LPG"
+          },
+          {
+            "label": ["EDUU", "FFM"],
+            "color": "lavender",
+            "station_id": "EDUU-FFM"
+          },
+          {
+            "label": ["EDGG", "SIG"],
+            "color": "mint",
+            "station_id": "EDGG-SIG"
+          },
+          {
+            "label": ["HMM"],
+            "color": "umber",
+            "station_id": "EDGG-HMM"
+          },
+          {
             "label": ["EDLW", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-LWT"
           },
           {
             "label": ["EDLW", "GND"],
+            "color": "blush",
             "station_id": "EDGG-LWG"
           },
           {
             "label": ["EDUU", "FUL"],
+            "color": "lavender",
             "station_id": "EDUU-FUL"
           },
           {
             "label": ["EDGG", "GIN"],
+            "color": "mint",
             "station_id": "EDGG-GIN"
           },
           {
             "label": ["DLA"],
+            "color": "umber",
             "station_id": "EDGG-DLA"
           },
           {
@@ -86,14 +103,17 @@
           },
           {
             "label": ["EDYY", "SH"],
+            "color": "lavender",
             "station_id": "EDYY-SH"
           },
           {
             "label": ["EDYY", "SL"],
+            "color": "lavender",
             "station_id": "EDYY-SL"
           },
           {
             "label": ["DKA"],
+            "color": "umber",
             "station_id": "EDGG-DKA"
           },
           {
@@ -104,19 +124,23 @@
           },
           {
             "label": ["EDYY", "CH"],
+            "color": "lavender",
             "station_id": "EDYY-CH"
           },
 
           {
             "label": ["EDYY", "CL"],
+            "color": "lavender",
             "station_id": "EDYY-CL"
           },
           {
             "label": ["EDWW", "HRZ"],
+            "color": "mint",
             "station_id": "EDWW-HRZ"
           },
           {
             "label": ["EDWW", "EMS"],
+            "color": "mint",
             "station_id": "EDWW-EMS"
           },
           {
@@ -124,10 +148,12 @@
           },
           {
             "label": ["EDYY", "JH"],
+            "color": "lavender",
             "station_id": "EDYY-JH"
           },
           {
             "label": ["EDYY", "JL"],
+            "color": "lavender",
             "station_id": "EDYY-JL"
           },
           {
@@ -141,17 +167,21 @@
           },
           {
             "label": ["EDYY", "HH"],
+            "color": "lavender",
             "station_id": "EDYY-HH"
           },
           {
             "label": ["EDYY", "HL"],
+            "color": "lavender",
             "station_id": "EDYY-HL"
           },
           {
-            "label": ["EDYY", "YYD"]
+            "label": ["EDYY", "YYD"],
+            "color": "lavender"
           },
           {
-            "label": ["EHAA", "ACE"]
+            "label": ["EHAA", "ACE"],
+            "color": "mint"
           },
           {
             "label": [""]

--- a/dataset/EDGG/profiles/EDGG_EBG7.json
+++ b/dataset/EDGG/profiles/EDGG_EBG7.json
@@ -9,38 +9,47 @@
         "keys": [
           {
             "label": ["RH"],
+            "color": "lilac",
             "station_id": "EDYY-RH"
           },
           {
             "label": ["PADH"],
+            "color": "lagoon",
             "station_id": "EDGG-PAH"
           },
           {
             "label": ["DLA"],
+            "color": "umber",
             "station_id": "EDGG-DLA"
           },
           {
             "label": ["DLAT", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DLAT"
           },
           {
             "label": ["EDDL", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DLT"
           },
           {
             "label": ["EDDL", "E", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DLGE"
           },
           {
             "label": ["RL"],
+            "color": "lilac",
             "station_id": "EDYY-RL"
           },
           {
             "label": ["EDGG", "SIG"],
+            "color": "mint",
             "station_id": "EDGG-SIG"
           },
           {
             "label": ["DLD"],
+            "color": "umber",
             "station_id": "EDGG-DLD"
           },
           {
@@ -50,42 +59,53 @@
             "label": [""]
           },
           {
-            "label": [""]
+            "label": ["EDDL", "W", "GND"],
+            "color": "blush",
+            "station_id": "EDGG-DLGW"
           },
           {
             "label": ["MH"],
+            "color": "lilac",
             "station_id": "EDYY-MH"
           },
           {
             "label": ["EDGG", "TAU"],
+            "color": "mint",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["DKA"],
+            "color": "umber",
             "station_id": "EDGG-DKA"
           },
           {
             "label": ["DKAT", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DKAT"
           },
           {
             "label": ["EDDK", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DKT"
           },
           {
             "label": ["EDDK", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DKG"
           },
           {
             "label": ["ML"],
+            "color": "lilac",
             "station_id": "EDYY-ML"
           },
           {
             "label": ["EDGG", "RUD"],
+            "color": "mint",
             "station_id": "EDGG-RUD"
           },
           {
             "label": ["NOR"],
+            "color": "umber",
             "station_id": "EDGG-NOR"
           },
           {
@@ -99,13 +119,16 @@
           },
           {
             "label": ["EDUU", "FFM"],
+            "color": "lavender",
             "station_id": "EDUU-FFM"
           },
           {
-            "label": ["EHAA", "ACE"]
+            "label": ["EHAA", "ACE"],
+            "color": "mint"
           },
           {
             "label": ["BOT"],
+            "color": "umber",
             "station_id": "EDGG-BOT"
           },
           {
@@ -119,18 +142,22 @@
           },
           {
             "label": ["EDUU", "NTM"],
+            "color": "lavender",
             "station_id": "EDUU-NTM"
           },
           {
             "label": ["EDYY", "LNH"],
+            "color": "lavender",
             "station_id": "EDYY-LNH"
           },
           {
             "label": ["EBBU", "EHS"],
+            "color": "mint",
             "station_id": "EBBU-EHS"
           },
           {
             "label": ["EBBU", "ELS"],
+            "color": "mint",
             "station_id": "EBBU-ELS"
           },
           {

--- a/dataset/EDGG/profiles/EDGG_EBG8.json
+++ b/dataset/EDGG/profiles/EDGG_EBG8.json
@@ -9,34 +9,42 @@
         "keys": [
           {
             "label": ["BAD"],
+            "color": "lagoon",
             "station_id": "EDGG-BAD"
           },
           {
             "label": ["STG"],
+            "color": "umber",
             "station_id": "EDGG-STG"
           },
           {
             "label": ["EDDS", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DST"
           },
           {
             "label": ["EDDS", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DSG"
           },
           {
             "label": ["EDDS", "DEL"],
+            "color": "snow",
             "station_id": "EDGG-DSC"
           },
           {
             "label": ["LBU"],
+            "color": "lagoon",
             "station_id": "EDGG-LBU"
           },
           {
             "label": ["REU"],
+            "color": "umber",
             "station_id": "EDGG-REU"
           },
           {
             "label": ["EDDS", "VFR", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DSTV"
           },
           {
@@ -47,10 +55,12 @@
           },
           {
             "label": ["NKRH"],
+            "color": "lagoon",
             "station_id": "EDGG-NKRH"
           },
           {
             "label": ["DSAT", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DSAT"
           },
           {
@@ -64,18 +74,22 @@
           },
           {
             "label": ["DKB"],
+            "color": "lagoon",
             "station_id": "EDGG-DKB"
           },
           {
             "label": ["EDGG", "NKRL"],
+            "color": "clay",
             "station_id": "EDGG-NKRL"
           },
           {
             "label": ["EDSB", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-SBT"
           },
           {
             "label": ["EDSB", "GND"],
+            "color": "blush",
             "station_id": "EDGG-SBG"
           },
           {
@@ -83,14 +97,17 @@
           },
           {
             "label": ["KNG"],
+            "color": "lagoon",
             "station_id": "EDGG-KNG"
           },
           {
             "label": ["EDGG", "PFA"],
+            "color": "clay",
             "station_id": "EDGG-PFA"
           },
           {
             "label": ["EDTL", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-TLT"
           },
           {
@@ -101,23 +118,28 @@
           },
           {
             "label": ["EDMM", "FUE"],
+            "color": "mint",
             "station_id": "EDMM-FUE"
           },
           {
             "label": ["EDMM", "SWA"],
+            "color": "mint",
             "station_id": "EDMM-SWA"
           },
           {
             "label": [""]
           },
           {
-            "label": ["LSAZ", "SZN"]
+            "label": ["LSAZ", "SZN"],
+            "color": "mint"
           },
           {
-            "label": ["LFST", "STA"]
+            "label": ["LFST", "STA"],
+            "color": "mint"
           },
           {
             "label": ["EDMM", "NDG"],
+            "color": "mint",
             "station_id": "EDMM-NDG"
           },
           {
@@ -127,7 +149,8 @@
             "label": [""]
           },
           {
-            "label": ["LSAZ", "SZE"]
+            "label": ["LSAZ", "SZE"],
+            "color": "mint"
           },
           {
             "label": [""]

--- a/dataset/EDGG/profiles/EDGG_KLA.json
+++ b/dataset/EDGG/profiles/EDGG_KLA.json
@@ -9,46 +9,57 @@
         "keys": [
           {
             "label": ["DKA"],
+            "color": "umber",
             "station_id": "EDGG-DKA"
           },
           {
             "label": ["EDDK", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DKT"
           },
           {
             "label": ["EDDK", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DKG"
           },
           {
             "label": ["EDDK", "DEL"],
+            "color": "snow",
             "station_id": "EDGG-DKC"
           },
           {
             "label": ["NOR"],
+            "color": "umber",
             "station_id": "EDGG-NOR"
           },
           {
             "label": ["EDDL", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DLT"
           },
           {
             "label": ["EDDL", "E", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DLGE"
           },
           {
             "label": ["EDDL", "DEL"],
+            "color": "snow",
             "station_id": "EDGG-DLC"
           },
           {
             "label": ["DLA"],
+            "color": "umber",
             "station_id": "EDGG-DLA"
           },
           {
             "label": ["DLAT"],
+            "color": "taupe",
             "station_id": "EDGG-DLAT"
           },
           {
             "label": ["EDDL", "W", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DLGW"
           },
           {
@@ -56,57 +67,70 @@
           },
           {
             "label": ["PADH"],
+            "color": "lagoon",
             "station_id": "EDGG-PAH"
           },
           {
             "label": [""]
           },
           {
-            "label": ["EHAA", "ACE"]
+            "label": ["EHAA", "ACE"],
+            "color": "mint"
           },
           {
             "label": [""]
           },
           {
             "label": ["EDGG", "RUD"],
+            "color": "mint",
             "station_id": "EDGG-RUD"
           },
           {
             "label": ["EDGG", "TAU"],
+            "color": "mint",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["EDGG", "SIG"],
+            "color": "mint",
             "station_id": "EDGG-SIG"
           },
           {
-            "label": ["EHVK", "CRS"]
+            "label": ["EHVK", "CRS"],
+            "color": "mint"
           },
           {
             "label": ["RH"],
+            "color": "lilac",
             "station_id": "EDYY-RH"
           },
           {
             "label": ["RL"],
+            "color": "lilac",
             "station_id": "EDYY-RL"
           },
           {
             "label": ["EDUU", "NTM"],
+            "color": "lavender",
             "station_id": "EDUU-NTM"
           },
           {
-            "label": ["EDYY", "YYD"]
+            "label": ["EDYY", "YYD"],
+            "color": "lavender"
           },
           {
             "label": ["MH"],
+            "color": "lilac",
             "station_id": "EDYY-MH"
           },
           {
             "label": ["ML"],
+            "color": "lilac",
             "station_id": "EDYY-ML"
           },
           {
             "label": ["EDUU", "FFM"],
+            "color": "lavender",
             "station_id": "EDUU-FFM"
           },
           {
@@ -114,14 +138,17 @@
           },
           {
             "label": ["EDYY", "LNH"],
+            "color": "lavender",
             "station_id": "EDYY-LNH"
           },
           {
             "label": ["EBBU", "EHS"],
+            "color": "mint",
             "station_id": "EBBU-EHS"
           },
           {
             "label": ["EBBU", "ELS"],
+            "color": "mint",
             "station_id": "EBBU-ELS"
           },
           {

--- a/dataset/EDGG/profiles/EDGG_MBB.json
+++ b/dataset/EDGG/profiles/EDGG_MBB.json
@@ -9,6 +9,7 @@
         "keys": [
           {
             "label": ["RL"],
+            "color": "lilac",
             "station_id": "EDYY-RL"
           },
           {
@@ -18,6 +19,7 @@
               "keys": [
                 {
                   "label": ["RH"],
+                  "color": "lilac",
                   "station_id": "EDYY-RH"
                 },
                 {
@@ -25,14 +27,17 @@
                 },
                 {
                   "label": ["MH"],
+                  "color": "lilac",
                   "station_id": "EDYY-MH"
                 },
                 {
                   "label": ["MM"],
+                  "color": "lilac",
                   "station_id": "EDYY-MM"
                 },
                 {
                   "label": ["EDYY", "JH"],
+                  "color": "lavender",
                   "station_id": "EDYY-JH"
                 },
                 {
@@ -40,6 +45,7 @@
                 },
                 {
                   "label": ["EDYY", "CH"],
+                  "color": "lavender",
                   "station_id": "EDYY-CH"
                 },
                 {
@@ -47,6 +53,7 @@
                 },
                 {
                   "label": ["EDYY", "SH"],
+                  "color": "lavender",
                   "station_id": "EDYY-SH"
                 },
                 {
@@ -57,14 +64,17 @@
           },
           {
             "label": ["PAD"],
+            "color": "lagoon",
             "station_id": "EDGG-PAD"
           },
           {
             "label": ["DLA"],
+            "color": "umber",
             "station_id": "EDGG-DLA"
           },
           {
             "label": ["EDDL", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DLT"
           },
           {
@@ -74,22 +84,27 @@
               "keys": [
                 {
                   "label": ["DLD"],
+                  "color": "umber",
                   "station_id": "EDGG-DLD"
                 },
                 {
                   "label": ["EDDL", "E", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DLGE"
                 },
                 {
                   "label": ["EDDL", "DEL"],
+                  "color": "snow",
                   "station_id": "EDGG-DLC"
                 },
                 {
                   "label": ["BOT"],
+                  "color": "umber",
                   "station_id": "EDGG-BOT"
                 },
                 {
                   "label": ["EDDL", "W", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DLGW"
                 },
                 {
@@ -97,6 +112,7 @@
                 },
                 {
                   "label": ["DLAT", "Feeder"],
+                  "color": "taupe",
                   "station_id": "EDGG-DLAT"
                 },
                 {
@@ -110,6 +126,7 @@
           },
           {
             "label": ["ML"],
+            "color": "lilac",
             "station_id": "EDYY-ML"
           },
           {
@@ -117,14 +134,17 @@
           },
           {
             "label": ["EDGG", "RUD"],
+            "color": "mint",
             "station_id": "EDGG-RUD"
           },
           {
             "label": ["NOR"],
+            "color": "umber",
             "station_id": "EDGG-NOR"
           },
           {
             "label": ["EDDK", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DKT"
           },
           {
@@ -134,18 +154,22 @@
               "keys": [
                 {
                   "label": ["DKA"],
+                  "color": "umber",
                   "station_id": "EDGG-DKA"
                 },
                 {
                   "label": ["EDDK", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DKG"
                 },
                 {
                   "label": ["EDDK", "DEL"],
+                  "color": "snow",
                   "station_id": "EDGG-DKC"
                 },
                 {
                   "label": ["DKAT", "Feeder"],
+                  "color": "taupe",
                   "station_id": "EDGG-DKAT"
                 },
                 {
@@ -159,61 +183,76 @@
           },
           {
             "label": ["EDYY", "JL"],
+            "color": "lavender",
             "station_id": "EDYY-JL"
           },
           {
-            "label": ["EDYY", "YYD"]
+            "label": ["EDYY", "YYD"],
+            "color": "lavender"
           },
           {
             "label": ["EDGG", "TAU"],
+            "color": "mint",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["HMM"],
+            "color": "umber",
             "station_id": "EDGG-HMM"
           },
           {
             "label": ["EDDG", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DGT"
           },
           {
             "label": ["EDDG", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DGG"
           },
           {
             "label": ["EDYY", "CL"],
+            "color": "lavender",
             "station_id": "EDYY-CL"
           },
           {
             "label": ["EDYY", "HL"],
+            "color": "lavender",
             "station_id": "EDYY-HL"
           },
           {
             "label": ["EDGG", "SIG"],
+            "color": "mint",
             "station_id": "EDGG-SIG"
           },
           {
             "label": ["PADL"],
+            "color": "umber",
             "station_id": "EDGG-PADL"
           },
           {
             "label": ["EDLP", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-LPT"
           },
           {
             "label": ["EDLP", "GND"],
+            "color": "blush",
             "station_id": "EDGG-LPG"
           },
           {
             "label": ["EDYY", "SL"],
+            "color": "lavender",
             "station_id": "EDYY-SL"
           },
           {
             "label": ["EDYY", "LNH"],
+            "color": "lavender",
             "station_id": "EDYY-LNH"
           },
           {
             "label": ["EDGG", "GIN"],
+            "color": "mint",
             "station_id": "EDGG-GIN"
           },
           {
@@ -227,6 +266,7 @@
           },
           {
             "label": ["EDUU", "NTM"],
+            "color": "lavender",
             "station_id": "EDUU-NTM"
           },
           {
@@ -234,19 +274,23 @@
           },
           {
             "label": ["EDWW", "EMS"],
+            "color": "mint",
             "station_id": "EDWW-EMS"
           },
           {
-            "label": ["EHAA", "ACE"]
+            "label": ["EHAA", "ACE"],
+            "color": "mint"
           },
           {
-            "label": ["EHMC", "MIL"]
+            "label": ["EHMC", "MIL"],
+            "color": "steel"
           },
           {
             "label": [""]
           },
           {
             "label": ["EDUU", "FFM"],
+            "color": "lavender",
             "station_id": "EDUU-FFM"
           },
           {
@@ -254,19 +298,22 @@
           },
           {
             "label": ["EDWW", "HRZ"],
+            "color": "mint",
             "station_id": "EDWW-HRZ"
           },
           {
             "label": [""]
           },
           {
-            "label": ["EHVK", "CRS"]
+            "label": ["EHVK", "CRS"],
+            "color": "mint"
           },
           {
             "label": [""]
           },
           {
             "label": ["EDUU", "FUL"],
+            "color": "lavender",
             "station_id": "EDUU-FUL"
           },
           {
@@ -277,10 +324,12 @@
           },
           {
             "label": ["EBUU", "EHS"],
+            "color": "mint",
             "station_id": "EBBU-EHS"
           },
           {
             "label": ["EBUU", "ELS"],
+            "color": "mint",
             "station_id": "EBBU-ELS"
           },
           {
@@ -296,22 +345,27 @@
         "keys": [
           {
             "label": ["NTM"],
+            "color": "lilac",
             "station_id": "EDUU-NTM"
           },
           {
             "label": ["EDUU", "SLN"],
+            "color": "lavender",
             "station_id": "EDUU-SLN"
           },
           {
             "label": ["RUD"],
+            "color": "lagoon",
             "station_id": "EDGG-RUD"
           },
           {
             "label": ["DFAN"],
+            "color": "umber",
             "station_id": "EDGG-DFAN"
           },
           {
             "label": ["DFTC"],
+            "color": "azure",
             "station_id": "EDGG-DFTC"
           },
           {
@@ -321,30 +375,37 @@
               "keys": [
                 {
                   "label": ["DFAS"],
+                  "color": "umber",
                   "station_id": "EDGG-DFAS"
                 },
                 {
                   "label": ["EDDF", "N", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DFTN"
                 },
                 {
                   "label": ["EDDF", "C", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGC"
                 },
                 {
                   "label": ["EDDF", "DEL"],
+                  "color": "snow",
                   "station_id": "EDGG-DFC"
                 },
                 {
                   "label": ["DFANT"],
+                  "color": "taupe",
                   "station_id": "EDGG-DFANT"
                 },
                 {
                   "label": ["EDDF", "W", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DFTW"
                 },
                 {
                   "label": ["EDDF", "W", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGW"
                 },
                 {
@@ -352,22 +413,27 @@
                 },
                 {
                   "label": ["DFAST"],
+                  "color": "taupe",
                   "station_id": "EDGG-DFAST"
                 },
                 {
                   "label": ["EDDF", "S", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DFTS"
                 },
                 {
                   "label": ["EDDF", "E", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGE"
                 },
                 {
                   "label": ["EDDF", "ICE"],
+                  "color": "snow",
                   "station_id": "EDGG-DFGI"
                 },
                 {
                   "label": ["DFDN"],
+                  "color": "umber",
                   "station_id": "EDGG-DFDN"
                 },
                 {
@@ -375,6 +441,7 @@
                 },
                 {
                   "label": ["EDDF", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFG"
                 },
                 {
@@ -382,6 +449,7 @@
                 },
                 {
                   "label": ["DFDS"],
+                  "color": "umber",
                   "station_id": "EDGG-DFDS"
                 },
                 {
@@ -398,30 +466,37 @@
           },
           {
             "label": ["FFM"],
+            "color": "lilac",
             "station_id": "EDUU-FFM"
           },
           {
             "label": ["EDUU", "WUR"],
+            "color": "lavender",
             "station_id": "EDUU-WUR"
           },
           {
             "label": ["KIR"],
+            "color": "lagoon",
             "station_id": "EDGG-KIR"
           },
           {
             "label": ["EIF"],
+            "color": "umber",
             "station_id": "EDGG-EIF"
           },
           {
             "label": ["EDFH", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-FHT"
           },
           {
             "label": ["EDFH", "GND"],
+            "color": "blush",
             "station_id": "EDGG-FHG"
           },
           {
             "label": ["FUL"],
+            "color": "lilac",
             "station_id": "EDUU-FUL"
           },
           {
@@ -429,22 +504,27 @@
           },
           {
             "label": ["TAU"],
+            "color": "lagoon",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["PFA"],
+            "color": "umber",
             "station_id": "EDGG-PFA"
           },
           {
             "label": ["EDDR", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DRT"
           },
           {
             "label": ["EDDR", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DRG"
           },
           {
             "label": ["EDUU", "SAL"],
+            "color": "lavender",
             "station_id": "EDUU-SAL"
           },
           {
@@ -452,6 +532,7 @@
           },
           {
             "label": ["SIG"],
+            "color": "lagoon",
             "station_id": "EDGG-SIG"
           },
           {
@@ -461,10 +542,12 @@
               "keys": [
                 {
                   "label": ["EDDL", "DLA"],
+                  "color": "clay",
                   "station_id": "EDGG-DLA"
                 },
                 {
                   "label": ["EDDK", "NOR"],
+                  "color": "clay",
                   "station_id": "EDGG-NOR"
                 },
                 {
@@ -472,6 +555,7 @@
                 },
                 {
                   "label": ["EDDK", "DKA"],
+                  "color": "clay",
                   "station_id": "EDGG-DKA"
                 }
               ]
@@ -479,6 +563,7 @@
           },
           {
             "label": ["ETOU", "TWR"],
+            "color": "steel",
             "station_id": "EDGG-TOUT"
           },
           {
@@ -486,77 +571,96 @@
           },
           {
             "label": ["EDUU", "ERL"],
+            "color": "lavender",
             "station_id": "EDUU-ERL"
           },
           {
             "label": ["EDYY", "LNH"],
+            "color": "lavender",
             "station_id": "EDYY-LNH"
           },
           {
             "label": ["GIN"],
+            "color": "lagoon",
             "station_id": "EDGG-GIN"
           },
           {
             "label": ["EDGG", "PAD"],
+            "color": "mint",
             "station_id": "EDGG-PAD"
           },
           {
             "label": ["EDWW", "HRZ"],
+            "color": "mint",
             "station_id": "EDWW-HRZ"
           },
           {
             "label": ["EBBU", "EHS"],
+            "color": "mint",
             "station_id": "EBBU-EHS"
           },
           {
             "label": ["EDYY", "SL"],
+            "color": "lavender",
             "station_id": "EDYY-SL"
           },
           {
             "label": ["EDYY", "LXH"],
+            "color": "lavender",
             "station_id": "EDYY-LXH"
           },
           {
             "label": ["HEF"],
+            "color": "lagoon",
             "station_id": "EDGG-HEF"
           },
           {
             "label": ["EDGG", "NKRH"],
+            "color": "mint",
             "station_id": "EDGG-NKRH"
           },
           {
             "label": ["EDMM", "HAL"],
+            "color": "mint",
             "station_id": "EDMM-HAL"
           },
           {
             "label": ["EBBU", "ELS"],
+            "color": "mint",
             "station_id": "EBBU-ELS"
           },
           {
             "label": ["EDYY", "ML"],
+            "color": "lavender",
             "station_id": "EDYY-ML"
           },
           {
-            "label": ["LFEE", "UE"]
+            "label": ["LFEE", "UE"],
+            "color": "lavender"
           },
           {
             "label": ["GED"],
+            "color": "lagoon",
             "station_id": "EDGG-GED"
           },
           {
             "label": ["EDGG", "MAN"],
+            "color": "mint",
             "station_id": "EDGG-MAN"
           },
           {
             "label": ["EDMM", "GER"],
+            "color": "mint",
             "station_id": "EDMM-GER"
           },
           {
             "label": ["EBBU", "HUS"],
+            "color": "mint",
             "station_id": "EBBU-HUS"
           },
           {
             "label": ["EDYY", "RL"],
+            "color": "lavender",
             "station_id": "EDYY-RL"
           },
           {
@@ -566,6 +670,7 @@
               "keys": [
                 {
                   "label": ["RH"],
+                  "color": "lavender",
                   "station_id": "EDYY-RH"
                 },
                 {
@@ -573,14 +678,17 @@
                 },
                 {
                   "label": ["MH"],
+                  "color": "lavender",
                   "station_id": "EDYY-MH"
                 },
                 {
                   "label": ["MM"],
+                  "color": "lavender",
                   "station_id": "EDYY-MM"
                 },
                 {
                   "label": ["EDYY", "JH"],
+                  "color": "lavender",
                   "station_id": "EDYY-JH"
                 },
                 {
@@ -588,6 +696,7 @@
                 },
                 {
                   "label": ["EDYY", "CH"],
+                  "color": "lavender",
                   "station_id": "EDYY-CH"
                 },
                 {
@@ -595,6 +704,7 @@
                 },
                 {
                   "label": ["EDYY", "SH"],
+                  "color": "lavender",
                   "station_id": "EDYY-SH"
                 },
                 {
@@ -608,14 +718,17 @@
           },
           {
             "label": ["EDGG", "HAB"],
+            "color": "mint",
             "station_id": "EDGG-HAB"
           },
           {
             "label": ["EDMM", "BBG"],
+            "color": "mint",
             "station_id": "EDMM-BBG"
           },
           {
             "label": ["EBBU", "LUS"],
+            "color": "mint",
             "station_id": "EBBU-LUS"
           }
         ]
@@ -628,26 +741,32 @@
         "keys": [
           {
             "label": ["SLN"],
+            "color": "lilac",
             "station_id": "EDUU-SLN"
           },
           {
             "label": ["EDUU", "NTM"],
+            "color": "lavender",
             "station_id": "EDUU-NTM"
           },
           {
             "label": ["MAN"],
+            "color": "lagoon",
             "station_id": "EDGG-MAN"
           },
           {
             "label": ["KTG"],
+            "color": "lagoon",
             "station_id": "EDGG-KTG"
           },
           {
             "label": ["STG"],
+            "color": "umber",
             "station_id": "EDGG-STG"
           },
           {
             "label": ["EDDS", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DST"
           },
           {
@@ -657,22 +776,27 @@
               "keys": [
                 {
                   "label": ["REU"],
+                  "color": "umber",
                   "station_id": "EDGG-REU"
                 },
                 {
                   "label": ["EDDS", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DSG"
                 },
                 {
                   "label": ["DSAT", "Feeder"],
+                  "color": "taupe",
                   "station_id": "EDGG-DSAT"
                 },
                 {
                   "label": ["EDDS", "DEL"],
+                  "color": "snow",
                   "station_id": "EDGG-DSC"
                 },
                 {
                   "label": ["EDDS", "VFR", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DSTV"
                 },
                 {
@@ -683,18 +807,22 @@
           },
           {
             "label": ["TGO"],
+            "color": "lilac",
             "station_id": "EDUU-TGO"
           },
           {
             "label": ["EDUU", "FFM"],
+            "color": "lavender",
             "station_id": "EDUU-FFM"
           },
           {
             "label": ["HAB"],
+            "color": "lagoon",
             "station_id": "EDGG-HAB"
           },
           {
             "label": ["KNG"],
+            "color": "lagoon",
             "station_id": "EDGG-KNG"
           },
           {
@@ -702,34 +830,42 @@
           },
           {
             "label": ["EDSB", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-SBT"
           },
           {
             "label": ["EDSB", "GND"],
+            "color": "blush",
             "station_id": "EDGG-SBG"
           },
           {
             "label": ["WUR"],
+            "color": "lilac",
             "station_id": "EDUU-WUR"
           },
           {
             "label": ["EDUU", "FUL"],
+            "color": "lavender",
             "station_id": "EDUU-FUL"
           },
           {
             "label": ["BAD"],
+            "color": "lagoon",
             "station_id": "EDGG-BAD"
           },
           {
             "label": ["DKB"],
+            "color": "lagoon",
             "station_id": "EDGG-DKB"
           },
           {
             "label": ["PSA"],
+            "color": "lagoon",
             "station_id": "EDGG-PSA"
           },
           {
             "label": ["EDTL", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-TLT"
           },
           {
@@ -737,25 +873,31 @@
           },
           {
             "label": ["EDUU", "ERL"],
+            "color": "lavender",
             "station_id": "EDUU-ERL"
           },
           {
-            "label": ["LFEE", "XE"]
+            "label": ["LFEE", "XE"],
+            "color": "lavender"
           },
           {
             "label": ["NKRH"],
+            "color": "lagoon",
             "station_id": "EDGG-NKRH"
           },
           {
             "label": ["LBU"],
+            "color": "lagoon",
             "station_id": "EDGG-LBU"
           },
           {
             "label": ["EDFM", "NKRL"],
+            "color": "umber",
             "station_id": "EDGG-NKRL"
           },
           {
             "label": ["EDFM", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-FMT"
           },
           {
@@ -763,6 +905,7 @@
           },
           {
             "label": ["EDUU", "DON"],
+            "color": "lavender",
             "station_id": "EDUU-DON"
           },
           {
@@ -770,18 +913,22 @@
           },
           {
             "label": ["EDGG", "KIR"],
+            "color": "mint",
             "station_id": "EDGG-KIR"
           },
           {
             "label": ["EDGG", "PFA"],
+            "color": "clay",
             "station_id": "EDGG-PFA"
           },
           {
             "label": ["DFAS"],
+            "color": "clay",
             "station_id": "EDGG-DFAS"
           },
           {
             "label": ["DFTC"],
+            "color": "cadet",
             "station_id": "EDGG-DFTC"
           },
           {
@@ -791,30 +938,37 @@
               "keys": [
                 {
                   "label": ["DFAS"],
+                  "color": "umber",
                   "station_id": "EDGG-DFAS"
                 },
                 {
                   "label": ["EDDF", "N", "TWR"],
+                  "color": "cadet",
                   "station_id": "EDGG-DFTN"
                 },
                 {
                   "label": ["EDDF", "C", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGC"
                 },
                 {
                   "label": ["EDDF", "DEL"],
+                  "color": "snow",
                   "station_id": "EDGG-DFC"
                 },
                 {
                   "label": ["DFANT"],
+                  "color": "taupe",
                   "station_id": "EDGG-DFANT"
                 },
                 {
                   "label": ["EDDF", "W", "TWR"],
+                  "color": "cadet",
                   "station_id": "EDGG-DFTW"
                 },
                 {
                   "label": ["EDDF", "W", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGW"
                 },
                 {
@@ -822,22 +976,27 @@
                 },
                 {
                   "label": ["DFAST"],
+                  "color": "taupe",
                   "station_id": "EDGG-DFAST"
                 },
                 {
                   "label": ["EDDF", "S", "TWR"],
+                  "color": "cadet",
                   "station_id": "EDGG-DFTS"
                 },
                 {
                   "label": ["EDDF", "E", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGE"
                 },
                 {
                   "label": ["EDDF", "ICE"],
+                  "color": "snow",
                   "station_id": "EDGG-DFGI"
                 },
                 {
                   "label": ["DFDN"],
+                  "color": "umber",
                   "station_id": "EDGG-DFDN"
                 },
                 {
@@ -845,6 +1004,7 @@
                 },
                 {
                   "label": ["EDDF", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFG"
                 },
                 {
@@ -852,6 +1012,7 @@
                 },
                 {
                   "label": ["DFDS"],
+                  "color": "umber",
                   "station_id": "EDGG-DFDS"
                 },
                 {
@@ -868,32 +1029,40 @@
           },
           {
             "label": ["EDUU", "AMM"],
+            "color": "lavender",
             "station_id": "EDUU-AMM"
           },
           {
-            "label": ["LSAS", "SZU"]
+            "label": ["LSAS", "SZU"],
+            "color": "lavender"
           },
           {
             "label": ["EDGG", "TAU"],
+            "color": "mint",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["EDGG", "SIG"],
+            "color": "mint",
             "station_id": "EDGG-SIG"
           },
           {
             "label": ["EDMM", "BBG"],
+            "color": "mint",
             "station_id": "EDMM-BBG"
           },
           {
             "label": ["EDMM", "NDG"],
+            "color": "mint",
             "station_id": "EDMM-NDG"
           },
           {
-            "label": ["LFEE", "UE"]
+            "label": ["LFEE", "UE"],
+            "color": "mint"
           },
           {
             "label": ["EDUU", "ALP"],
+            "color": "lavender",
             "station_id": "EDUU-ALP"
           },
           {
@@ -901,22 +1070,27 @@
           },
           {
             "label": ["EDGG", "GIN"],
+            "color": "mint",
             "station_id": "EDGG-GIN"
           },
           {
             "label": ["EDGG", "HEF"],
+            "color": "mint",
             "station_id": "EDGG-HEF"
           },
           {
             "label": ["EDMM", "ALB"],
+            "color": "mint",
             "station_id": "EDMM-ALB"
           },
           {
             "label": ["EDMM", "FUE"],
+            "color": "mint",
             "station_id": "EDMM-FUE"
           },
           {
-            "label": ["LFST", "STA"]
+            "label": ["LFST", "STA"],
+            "color": "mint"
           },
           {
             "label": [""]
@@ -926,6 +1100,7 @@
           },
           {
             "label": ["EDGG", "GED"],
+            "color": "mint",
             "station_id": "EDGG-GED"
           },
           {
@@ -933,13 +1108,16 @@
           },
           {
             "label": ["EDMM", "WLD"],
+            "color": "mint",
             "station_id": "EDMM-WLD"
           },
           {
-            "label": ["LSAZ", "SZN"]
+            "label": ["LSAZ", "SZN"],
+            "color": "mint"
           },
           {
-            "label": ["LSAZ", "SZE"]
+            "label": ["LSAZ", "SZE"],
+            "color": "mint"
           }
         ]
       }
@@ -951,73 +1129,90 @@
         "keys": [
           {
             "label": ["ML"],
+            "color": "lilac",
             "station_id": "EDYY-ML"
           },
           {
             "label": ["EDYY", "RL"],
+            "color": "lavender",
             "station_id": "EDYY-RL"
           },
           {
-            "label": ["PADH"],
-            "station_id": "EDGG-PAH"
+            "label": ["PAD"],
+            "color": "lagoon",
+            "station_id": "EDGG-PAD"
           },
           {
             "label": [""]
           },
           {
             "label": ["HMM"],
+            "color": "umber",
             "station_id": "EDGG-HMM"
           },
           {
             "label": ["EDDG", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DGT"
           },
           {
             "label": ["FFM"],
+            "color": "lilac",
             "station_id": "EDUU-FFM"
           },
           {
             "label": ["EDUU", "NTM"],
+            "color": "lavender",
             "station_id": "EDUU-NTM"
           },
           {
             "label": ["TAU"],
+            "color": "lagoon",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["EDGG", "RUD"],
+            "color": "mint",
             "station_id": "EDGG-RUD"
           },
           {
             "label": ["DLA"],
+            "color": "umber",
             "station_id": "EDGG-DLA"
           },
           {
             "label": ["EDDL", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DLT"
           },
           {
             "label": ["FUL"],
+            "color": "lilac",
             "station_id": "EDUU-FUL"
           },
           {
             "label": ["EDUU", "WUR"],
+            "color": "lavender",
             "station_id": "EDUU-WUR"
           },
           {
             "label": ["SIG"],
+            "color": "lagoon",
             "station_id": "EDGG-SIG"
           },
           {
             "label": ["EDGG", "KIR"],
+            "color": "mint",
             "station_id": "EDGG-KIR"
           },
           {
             "label": ["DKA"],
+            "color": "umber",
             "station_id": "EDGG-DKA"
           },
           {
             "label": ["EDDK", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DKT"
           },
           {
@@ -1025,26 +1220,32 @@
           },
           {
             "label": ["EDUU", "SLN"],
+            "color": "lavender",
             "station_id": "EDUU-SLN"
           },
           {
             "label": ["GIN"],
+            "color": "lagoon",
             "station_id": "EDGG-GIN"
           },
           {
             "label": ["EDGG", "MAN"],
+            "color": "mint",
             "station_id": "EDGG-MAN"
           },
           {
             "label": ["DFAN"],
+            "color": "umber",
             "station_id": "EDGG-DFAN"
           },
           {
             "label": ["EDDF", "C", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DFTC"
           },
           {
             "label": ["EDYY", "JL"],
+            "color": "lavender",
             "station_id": "EDYY-JL"
           },
           {
@@ -1054,6 +1255,7 @@
               "keys": [
                 {
                   "label": ["RH"],
+                  "color": "lilac",
                   "station_id": "EDYY-RH"
                 },
                 {
@@ -1061,14 +1263,17 @@
                 },
                 {
                   "label": ["MH"],
+                  "color": "lilac",
                   "station_id": "EDYY-MH"
                 },
                 {
                   "label": ["MM"],
+                  "color": "lilac",
                   "station_id": "EDYY-MM"
                 },
                 {
                   "label": ["EDYY", "JH"],
+                  "color": "lavender",
                   "station_id": "EDYY-JH"
                 },
                 {
@@ -1076,6 +1281,7 @@
                 },
                 {
                   "label": ["EDYY", "CH"],
+                  "color": "lavender",
                   "station_id": "EDYY-CH"
                 },
                 {
@@ -1083,6 +1289,7 @@
                 },
                 {
                   "label": ["EDYY", "SH"],
+                  "color": "lavender",
                   "station_id": "EDYY-SH"
                 },
                 {
@@ -1093,10 +1300,12 @@
           },
           {
             "label": ["GED"],
+            "color": "lagoon",
             "station_id": "EDGG-GED"
           },
           {
             "label": ["EDGG", "HAB"],
+            "color": "mint",
             "station_id": "EDGG-HAB"
           },
           {
@@ -1106,34 +1315,42 @@
               "keys": [
                 {
                   "label": ["DKLA"],
+                  "color": "umber",
                   "station_id": "EDGG-DKLA"
                 },
                 {
                   "label": ["DLAT", "Feeder"],
+                  "color": "taupe",
                   "station_id": "EDGG-DLAT"
                 },
                 {
                   "label": ["BOT"],
+                  "color": "umber",
                   "station_id": "EDGG-BOT"
                 },
                 {
                   "label": ["PADL"],
+                  "color": "umber",
                   "station_id": "EDGG-PADL"
                 },
                 {
                   "label": ["NOR"],
+                  "color": "umber",
                   "station_id": "EDGG-NOR"
                 },
                 {
                   "label": ["DKAT", "Feeder"],
+                  "color": "taupe",
                   "station_id": "EDGG-DKAT"
                 },
                 {
                   "label": ["DFAS"],
+                  "color": "umber",
                   "station_id": "EDGG-DFAS"
                 },
                 {
                   "label": ["DFAST", "Feeder"],
+                  "color": "taupe",
                   "station_id": "EDGG-DFAST"
                 },
                 {
@@ -1141,14 +1358,17 @@
                 },
                 {
                   "label": ["DFANT", "Feeder"],
+                  "color": "taupe",
                   "station_id": "EDGG-DFANT"
                 },
                 {
                   "label": ["DFDN"],
+                  "color": "umber",
                   "station_id": "EDGG-DFDN"
                 },
                 {
                   "label": ["DFDS"],
+                  "color": "umber",
                   "station_id": "EDGG-DFDS"
                 }
               ]
@@ -1164,10 +1384,12 @@
                 },
                 {
                   "label": ["EDDL", "E", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DLGE"
                 },
                 {
                   "label": ["EDDL", "DEL"],
+                  "color": "snow",
                   "station_id": "EDGG-DLC"
                 },
                 {
@@ -1175,6 +1397,7 @@
                 },
                 {
                   "label": ["EDDL", "W", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DLGW"
                 },
                 {
@@ -1185,10 +1408,12 @@
                 },
                 {
                   "label": ["EDDK", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DKG"
                 },
                 {
                   "label": ["EDDK", "DEL"],
+                  "color": "snow",
                   "station_id": "EDGG-DKC"
                 },
                 {
@@ -1196,18 +1421,22 @@
                 },
                 {
                   "label": ["EDDF", "C", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGC"
                 },
                 {
                   "label": ["EDDF", "DEL"],
+                  "color": "snow",
                   "station_id": "EDGG-DFC"
                 },
                 {
                   "label": ["EDDF", "N", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DFTN"
                 },
                 {
                   "label": ["EDDF", "W", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGW"
                 },
                 {
@@ -1215,14 +1444,17 @@
                 },
                 {
                   "label": ["EDDF", "S", "TWR"],
+                  "color": "azure",
                   "station_id": "EDGG-DFTS"
                 },
                 {
                   "label": ["EDDF", "E", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFGE"
                 },
                 {
                   "label": ["EDDF", "ICE"],
+                  "color": "snow",
                   "station_id": "EDGG-DFGI"
                 },
                 {
@@ -1230,6 +1462,7 @@
                 },
                 {
                   "label": ["EDDF", "GND"],
+                  "color": "blush",
                   "station_id": "EDGG-DFG"
                 },
                 {
@@ -1240,6 +1473,7 @@
           },
           {
             "label": ["EDYY", "SL"],
+            "color": "lavender",
             "station_id": "EDYY-SL"
           },
           {
@@ -1247,6 +1481,7 @@
           },
           {
             "label": ["HEF"],
+            "color": "lagoon",
             "station_id": "EDGG-HEF"
           },
           {
@@ -1260,6 +1495,7 @@
           },
           {
             "label": ["EDUU", "SAL"],
+            "color": "lavender",
             "station_id": "EDUU-SAL"
           },
           {
@@ -1267,22 +1503,27 @@
           },
           {
             "label": ["EDWW", "EMS"],
+            "color": "mint",
             "station_id": "EDWW-EMS"
           },
           {
             "label": ["EDMM", "HAL"],
+            "color": "mint",
             "station_id": "EDMM-HAL"
           },
           {
             "label": ["EDMM", "BBG"],
+            "color": "mint",
             "station_id": "EDMM-BBG"
           },
           {
             "label": ["EDDP", "TRS"],
+            "color": "clay",
             "station_id": "EDMM-TRS"
           },
           {
             "label": ["EDUU", "ERL"],
+            "color": "lavender",
             "station_id": "EDUU-ERL"
           },
           {
@@ -1290,10 +1531,12 @@
           },
           {
             "label": ["EDWW", "HRZ"],
+            "color": "mint",
             "station_id": "EDWW-HRZ"
           },
           {
             "label": ["EDMM", "GER"],
+            "color": "mint",
             "station_id": "EDMM-GER"
           },
           {
@@ -1301,6 +1544,7 @@
           },
           {
             "label": ["EDDN", "FRK"],
+            "color": "clay",
             "station_id": "EDMM-FRK"
           }
         ]

--- a/dataset/EDGG/profiles/EDGG_MIL.json
+++ b/dataset/EDGG/profiles/EDGG_MIL.json
@@ -9,82 +9,102 @@
         "keys": [
           {
             "label": ["EDGG", "RUD"],
+            "color": "mint",
             "station_id": "EDGG-RUD"
           },
           {
             "label": ["EDFH", "EIF"],
+            "color": "clay",
             "station_id": "EDGG-EIF"
           },
           {
             "label": ["EDDL", "DLA"],
+            "color": "clay",
             "station_id": "EDGG-DLA"
           },
           {
             "label": ["TADA"],
+            "color": "umber",
             "station_id": "EDGG-TADA"
           },
           {
             "label": ["ETAD", "TWR"],
+            "color": "steel",
             "station_id": "EDGG-TADT"
           },
           {
             "label": ["ETAD", "GND"],
+            "color": "blush",
             "station_id": "EDGG-TADG"
           },
           {
             "label": ["EDGG", "KIR"],
+            "color": "mint",
             "station_id": "EDGG-KIR"
           },
           {
             "label": ["EDDR", "PFA"],
+            "color": "clay",
             "station_id": "EDGG-PFA"
           },
           {
             "label": ["EDDL", "BOT"],
+            "color": "clay",
             "station_id": "EDGG-BOT"
           },
           {
             "label": ["TARA"],
+            "color": "umber",
             "station_id": "EDGG-TARA"
           },
           {
             "label": ["ETAR", "TWR"],
+            "color": "steel",
             "station_id": "EDGG-TART"
           },
           {
             "label": ["ETAR", "GND"],
+            "color": "blush",
             "station_id": "EDGG-TARG"
           },
           {
             "label": ["EDGG", "GIN"],
+            "color": "mint",
             "station_id": "EDGG-GIN"
           },
           {
             "label": ["EDDS", "STG"],
+            "color": "clay",
             "station_id": "EDGG-STG"
           },
           {
             "label": ["EDDK", "DKA"],
+            "color": "clay",
             "station_id": "EDGG-DKA"
           },
           {
             "label": ["THFA"],
+            "color": "umber",
             "station_id": "EDGG-THFA"
           },
           {
             "label": ["ETHF", "TWR"],
+            "color": "steel",
             "station_id": "EDGG-THFT"
           },
           {
             "label": ["ETHF", "GND"],
+            "color": "blush",
             "station_id": "EDGG-THFG"
           },
           {
             "label": ["EDGG", "HEF"],
+            "color": "mint",
             "station_id": "EDGG-HEF"
           },
           {
             "label": ["EDFM", "NKRL"],
+            "color": "clay",
             "station_id": "EDGG-NKRL"
           },
           {
@@ -92,10 +112,12 @@
           },
           {
             "label": ["THNA"],
+            "color": "umber",
             "station_id": "EDGG-THNA"
           },
           {
             "label": ["ETHN", "TWR"],
+            "color": "steel",
             "station_id": "EDGG-THNT"
           },
           {
@@ -103,22 +125,27 @@
           },
           {
             "label": ["EDGG", "DKB"],
+            "color": "mint",
             "station_id": "EDGG-DKB"
           },
           {
             "label": ["EDDN", "FRK"],
+            "color": "clay",
             "station_id": "EDMM-FRK"
           },
           {
             "label": ["EDDF", "DFAN"],
+            "color": "clay",
             "station_id": "EDGG-DFAN"
           },
           {
             "label": ["TNGA"],
+            "color": "umber",
             "station_id": "EDGG-TNGA"
           },
           {
             "label": ["ETNG", "TWR"],
+            "color": "steel",
             "station_id": "EDGG-TNGT"
           },
           {
@@ -126,22 +153,27 @@
           },
           {
             "label": ["EDGG", "NKRH"],
+            "color": "mint",
             "station_id": "EDGG-NKRH"
           },
           {
             "label": ["EDWW", "HRZ"],
+            "color": "mint",
             "station_id": "EDWW-HRZ"
           },
           {
             "label": ["ETOU", "TWR"],
+            "color": "steel",
             "station_id": "EDGG-TOUT"
           },
           {
             "label": ["TNNA"],
+            "color": "umber",
             "station_id": "EDGG-TNNA"
           },
           {
             "label": ["ETNN", "TWR"],
+            "color": "steel",
             "station_id": "EDGG-TNNT"
           },
           {
@@ -149,6 +181,7 @@
           },
           {
             "label": ["EDGG", "KNG"],
+            "color": "mint",
             "station_id": "EDGG-KNG"
           },
           {
@@ -156,14 +189,17 @@
           },
           {
             "label": ["ETOU", "GND"],
+            "color": "blush",
             "station_id": "EDGG-TOUG"
           },
           {
             "label": ["TSBA"],
+            "color": "umber",
             "station_id": "EDGG-TSBA"
           },
           {
             "label": ["ETSB", "TWR"],
+            "color": "steel",
             "station_id": "EDGG-TSBT"
           },
           {

--- a/dataset/EDGG/profiles/EDGG_TWR.json
+++ b/dataset/EDGG/profiles/EDGG_TWR.json
@@ -9,38 +9,47 @@
         "keys": [
           {
             "label": ["DFAN"],
+            "color": "umber",
             "station_id": "EDGG-DFAN"
           },
           {
             "label": ["DFANT", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DFANT"
           },
           {
             "label": ["EDDF", "C", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DFTC"
           },
           {
             "label": ["EDDF", "C", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DFGC"
           },
           {
             "label": ["EDDF", "DEL"],
+            "color": "snow",
             "station_id": "EDGG-DFC"
           },
           {
             "label": ["DFAS"],
+            "color": "umber",
             "station_id": "EDGG-DFAS"
           },
           {
             "label": ["DFAST", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DFAST"
           },
           {
             "label": ["EDDF", "W", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DFTW"
           },
           {
             "label": ["EDDF", "W", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DFGW"
           },
           {
@@ -48,6 +57,7 @@
           },
           {
             "label": ["DFDN"],
+            "color": "umber",
             "station_id": "EDGG-DFDN"
           },
           {
@@ -55,18 +65,22 @@
           },
           {
             "label": ["EDDF", "N", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DFTN"
           },
           {
             "label": ["EDDF", "E", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DFGE"
           },
           {
             "label": ["EDDF", "ICE"],
+            "color": "snow",
             "station_id": "EDGG-DFGI"
           },
           {
             "label": ["DFDS"],
+            "color": "umber",
             "station_id": "EDGG-DFDS"
           },
           {
@@ -74,10 +88,12 @@
           },
           {
             "label": ["EDDF", "S", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DFTS"
           },
           {
             "label": ["EDDF", "S", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DFGS"
           },
           {
@@ -94,6 +110,7 @@
           },
           {
             "label": ["EDDF", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DFG"
           },
           {
@@ -109,26 +126,32 @@
         "keys": [
           {
             "label": ["DLA"],
+            "color": "umber",
             "station_id": "EDGG-DLA"
           },
           {
             "label": ["DLAT", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DLAT"
           },
           {
             "label": ["EDDL", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DLT"
           },
           {
             "label": ["EDDL", "E", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DLGE"
           },
           {
             "label": ["EDDL", "DEL"],
+            "color": "snow",
             "station_id": "EDGG-DLC"
           },
           {
             "label": ["BOT"],
+            "color": "umber",
             "station_id": "EDGG-BOT"
           },
           {
@@ -139,6 +162,7 @@
           },
           {
             "label": ["EDDL", "W", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DLGW"
           },
           {
@@ -146,6 +170,7 @@
           },
           {
             "label": ["DLD"],
+            "color": "umber",
             "station_id": "EDGG-DLD"
           },
           {
@@ -162,6 +187,7 @@
           },
           {
             "label": ["DKLA"],
+            "color": "umber",
             "station_id": "EDGG-DKLA"
           },
           {
@@ -178,6 +204,7 @@
           },
           {
             "label": ["NOR"],
+            "color": "umber",
             "station_id": "EDGG-NOR"
           },
           {
@@ -185,22 +212,27 @@
           },
           {
             "label": ["EDDK", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DKT"
           },
           {
             "label": ["EDDK", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DKG"
           },
           {
             "label": ["EDDK", "DEL"],
+            "color": "snow",
             "station_id": "EDGG-DKC"
           },
           {
             "label": ["DKA"],
+            "color": "umber",
             "station_id": "EDGG-DKA"
           },
           {
             "label": ["DKAT", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DKAT"
           },
           {
@@ -222,10 +254,12 @@
         "keys": [
           {
             "label": ["STG"],
+            "color": "umber",
             "station_id": "EDGG-STG"
           },
           {
             "label": ["DSAT", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DSAT"
           },
           {
@@ -233,14 +267,17 @@
           },
           {
             "label": ["EDDS", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DST"
           },
           {
             "label": ["EDDS", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DSG"
           },
           {
             "label": ["EDDS", "DEL"],
+            "color": "snow",
             "station_id": "EDGG-DSC"
           },
           {
@@ -248,6 +285,7 @@
           },
           {
             "label": ["REU"],
+            "color": "umber",
             "station_id": "EDGG-REU"
           },
           {
@@ -258,26 +296,32 @@
           },
           {
             "label": ["EDSB", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-SBT"
           },
           {
             "label": ["EDSB", "GND"],
+            "color": "blush",
             "station_id": "EDGG-SBG"
           },
           {
             "label": ["EDDG", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DGT"
           },
           {
             "label": ["EDDG", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DGG"
           },
           {
             "label": ["HMM"],
+            "color": "umber",
             "station_id": "EDGG-HMM"
           },
           {
             "label": ["DGAT", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DGAT"
           },
           {
@@ -285,6 +329,7 @@
           },
           {
             "label": ["EDFM", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-FMT"
           },
           {
@@ -292,18 +337,22 @@
           },
           {
             "label": ["EDDR", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-DRT"
           },
           {
             "label": ["EDDR", "GND"],
+            "color": "blush",
             "station_id": "EDGG-DRG"
           },
           {
             "label": ["NKRL"],
+            "color": "umber",
             "station_id": "EDGG-NKRL"
           },
           {
             "label": ["DLA"],
+            "color": "umber",
             "station_id": "EDGG-DLA"
           },
           {
@@ -311,26 +360,32 @@
           },
           {
             "label": ["EDFH", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-FHT"
           },
           {
             "label": ["EDFH", "GND"],
+            "color": "blush",
             "station_id": "EDGG-FHG"
           },
           {
             "label": ["EDLN", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-LNT"
           },
           {
             "label": ["EDLN", "GND"],
+            "color": "blush",
             "station_id": "EDGG-LNG"
           },
           {
             "label": ["PFA"],
+            "color": "umber",
             "station_id": "EDGG-PFA"
           },
           {
             "label": ["DLD"],
+            "color": "umber",
             "station_id": "EDGG-DLD"
           },
           {
@@ -338,14 +393,17 @@
           },
           {
             "label": ["EDLP", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-LPT"
           },
           {
             "label": ["EDLP", "GND"],
+            "color": "blush",
             "station_id": "EDGG-LPG"
           },
           {
             "label": ["EDLV", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-LVT"
           },
           {
@@ -353,10 +411,12 @@
           },
           {
             "label": ["EIF"],
+            "color": "umber",
             "station_id": "EDGG-EIF"
           },
           {
             "label": ["DLAT", "Feeder"],
+            "color": "taupe",
             "station_id": "EDGG-DLAT"
           },
           {
@@ -364,10 +424,12 @@
           },
           {
             "label": ["EDLW", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-LWT"
           },
           {
             "label": ["EDLW", "GND"],
+            "color": "blush",
             "station_id": "EDGG-LWG"
           },
           {
@@ -378,10 +440,12 @@
           },
           {
             "label": ["BOT"],
+            "color": "umber",
             "station_id": "EDGG-BOT"
           },
           {
             "label": ["PAL"],
+            "color": "umber",
             "station_id": "EDGG-PADL"
           },
           {
@@ -389,6 +453,7 @@
           },
           {
             "label": ["EDTL", "TWR"],
+            "color": "azure",
             "station_id": "EDGG-TLT"
           },
           {

--- a/dataset/EDGG/profiles/EDGG_UPR.json
+++ b/dataset/EDGG/profiles/EDGG_UPR.json
@@ -327,7 +327,9 @@
             "label": [""]
           },
           {
-            "label": [""]
+            "label": ["EDGG", "PAD"],
+            "color": "mint",
+            "station_id": "EDGG-PAD"
           },
           {
             "label": [""]
@@ -343,15 +345,19 @@
             "station_id": "EDYY-SL"
           },
           {
-            "label": [""]
+            "label": ["EDYY", "LNH"],
+             "color": "lavender",
+             "station_id": "EDYY-LNH"
           },
           {
-            "label": [""]
-          },
+            "label": ["EDYY", "LXH"],
+            "color": "lavender",
+            "station_id": "EDYY-LXH"
+          },          
           {
-            "label": ["EDGG", "PAD"],
+            "label": ["EBBU", "EHS"],
             "color": "mint",
-            "station_id": "EDGG-PAD"
+            "station_id": "EBBU-EHS"
           },
           {
             "label": [""]
@@ -377,7 +383,9 @@
             "station_id": "EDMM-BBG"
           },
           {
-            "label": [""]
+            "label": ["EBBU", "LUS"],
+            "color": "mint",
+            "station_id": "EBBU-LUS"
           },
           {
             "label": [""]

--- a/dataset/EDGG/profiles/EDGG_UPR.json
+++ b/dataset/EDGG/profiles/EDGG_UPR.json
@@ -44,7 +44,7 @@
             "label": ["ML"],
             "color": "lilac",
             "station_id": "EDYY-ML"
-          },          
+          },
           {
             "label": ["HMM"],
             "color": "umber",

--- a/dataset/EDGG/profiles/EDGG_UPR.json
+++ b/dataset/EDGG/profiles/EDGG_UPR.json
@@ -346,14 +346,14 @@
           },
           {
             "label": ["EDYY", "LNH"],
-             "color": "lavender",
-             "station_id": "EDYY-LNH"
+            "color": "lavender",
+            "station_id": "EDYY-LNH"
           },
           {
             "label": ["EDYY", "LXH"],
             "color": "lavender",
             "station_id": "EDYY-LXH"
-          },          
+          },
           {
             "label": ["EBBU", "EHS"],
             "color": "mint",

--- a/dataset/EDGG/profiles/EDGG_UPR.json
+++ b/dataset/EDGG/profiles/EDGG_UPR.json
@@ -9,22 +9,27 @@
         "keys": [
           {
             "label": ["RH"],
+            "color": "lilac",
             "station_id": "EDYY-RH"
           },
           {
             "label": ["RL"],
+            "color": "lilac",
             "station_id": "EDYY-RL"
           },
           {
-            "label": ["HMM"],
-            "station_id": "EDGG-HMM"
+            "label": ["PAD"],
+            "color": "lagoon",
+            "station_id": "EDGG-PAD"
           },
           {
             "label": ["EDUU", "NTM"],
+            "color": "lavender",
             "station_id": "EDUU-NTM"
           },
           {
             "label": ["EDGG", "RUD"],
+            "color": "mint",
             "station_id": "EDGG-RUD"
           },
           {
@@ -32,22 +37,27 @@
           },
           {
             "label": ["MH"],
+            "color": "lilac",
             "station_id": "EDYY-MH"
           },
           {
             "label": ["ML"],
+            "color": "lilac",
             "station_id": "EDYY-ML"
-          },
+          },          
           {
-            "label": ["PAD"],
-            "station_id": "EDGG-PAD"
+            "label": ["HMM"],
+            "color": "umber",
+            "station_id": "EDGG-HMM"
           },
           {
             "label": ["EDUU", "FFM"],
+            "color": "lavender",
             "station_id": "EDUU-FFM"
           },
           {
             "label": ["EDGG", "TAU"],
+            "color": "mint",
             "station_id": "EDGG-TAU"
           },
           {
@@ -55,22 +65,27 @@
           },
           {
             "label": ["EDYY", "JH"],
+            "color": "lavender",
             "station_id": "EDYY-JH"
           },
           {
             "label": ["EDYY", "JL"],
+            "color": "lavender",
             "station_id": "EDYY-JL"
           },
           {
             "label": ["DLA"],
+            "color": "umber",
             "station_id": "EDGG-DLA"
           },
           {
             "label": ["EDUU", "FUL"],
+            "color": "lavender",
             "station_id": "EDUU-FUL"
           },
           {
             "label": ["EDGG", "SIG"],
+            "color": "mint",
             "station_id": "EDGG-SIG"
           },
           {
@@ -78,14 +93,17 @@
           },
           {
             "label": ["EDYY", "HH"],
+            "color": "lavender",
             "station_id": "EDYY-HH"
           },
           {
             "label": ["EDYY", "HL"],
+            "color": "lavender",
             "station_id": "EDYY-HL"
           },
           {
             "label": ["BOT"],
+            "color": "umber",
             "station_id": "EDGG-BOT"
           },
           {
@@ -93,6 +111,7 @@
           },
           {
             "label": ["EDGG", "GIN"],
+            "color": "mint",
             "station_id": "EDGG-GIN"
           },
           {
@@ -100,14 +119,17 @@
           },
           {
             "label": ["EDYY", "CH"],
+            "color": "lavender",
             "station_id": "EDYY-CH"
           },
           {
             "label": ["EDYY", "CL"],
+            "color": "lavender",
             "station_id": "EDYY-CL"
           },
           {
             "label": ["NOR"],
+            "color": "umber",
             "station_id": "EDGG-NOR"
           },
           {
@@ -115,6 +137,7 @@
           },
           {
             "label": ["EDWW", "EID"],
+            "color": "mint",
             "station_id": "EDWW-EID"
           },
           {
@@ -122,10 +145,12 @@
           },
           {
             "label": ["EDYY", "SH"],
+            "color": "lavender",
             "station_id": "EDYY-SH"
           },
           {
             "label": ["EDYY", "SL"],
+            "color": "lavender",
             "station_id": "EDYY-SL"
           },
           {
@@ -136,27 +161,32 @@
           },
           {
             "label": ["EDWW", "ALR"],
+            "color": "mint",
             "station_id": "EDWW-ALR"
           },
           {
             "label": [""]
           },
           {
-            "label": ["EDYY", "YYD"]
+            "label": ["EDYY", "YYD"],
+            "color": "lavender"
           },
           {
             "label": [""]
           },
           {
             "label": ["EBBU", "EHS"],
+            "color": "mint",
             "station_id": "EBBU-EHS"
           },
           {
             "label": ["EBBU", "ELS"],
+            "color": "mint",
             "station_id": "EBBU-ELS"
           },
           {
             "label": ["EDWW", "EMS"],
+            "color": "mint",
             "station_id": "EDWW-EMS"
           },
           {
@@ -164,19 +194,23 @@
           },
           {
             "label": ["EDYY", "LNH"],
+            "color": "lavender",
             "station_id": "EDYY-LNH"
           },
           {
             "label": [""]
           },
           {
-            "label": ["EHAA", "ACE"]
+            "label": ["EHAA", "ACE"],
+            "color": "mint"
           },
           {
-            "label": ["EHMC", "MIL"]
+            "label": ["EHMC", "MIL"],
+            "color": "steel"
           },
           {
             "label": ["EDWW", "HRZ"],
+            "color": "mint",
             "station_id": "EDWW-HRZ"
           },
           {
@@ -192,22 +226,27 @@
         "keys": [
           {
             "label": ["NTM"],
+            "color": "lilac",
             "station_id": "EDUU-NTM"
           },
           {
             "label": ["PFA"],
+            "color": "umber",
             "station_id": "EDGG-PFA"
           },
           {
             "label": ["SIG"],
+            "color": "lagoon",
             "station_id": "EDGG-SIG"
           },
           {
             "label": ["EDUU", "SLN"],
+            "color": "lavender",
             "station_id": "EDUU-SLN"
           },
           {
             "label": ["EDGG", "NKRH"],
+            "color": "mint",
             "station_id": "EDGG-NKRH"
           },
           {
@@ -215,22 +254,27 @@
           },
           {
             "label": ["FFM"],
+            "color": "lilac",
             "station_id": "EDUU-FFM"
           },
           {
             "label": ["KIR"],
+            "color": "lagoon",
             "station_id": "EDGG-KIR"
           },
           {
             "label": ["GIN"],
+            "color": "lagoon",
             "station_id": "EDGG-GIN"
           },
           {
             "label": ["EDUU", "TGO"],
+            "color": "lavender",
             "station_id": "EDUU-TGO"
           },
           {
             "label": ["EDGG", "MAN"],
+            "color": "mint",
             "station_id": "EDGG-MAN"
           },
           {
@@ -238,22 +282,27 @@
           },
           {
             "label": ["FUL"],
+            "color": "lilac",
             "station_id": "EDUU-FUL"
           },
           {
             "label": ["RUD"],
+            "color": "lagoon",
             "station_id": "EDGG-RUD"
           },
           {
             "label": ["HEF"],
+            "color": "lagoon",
             "station_id": "EDGG-HEF"
           },
           {
             "label": ["EDUU", "WUR"],
+            "color": "lavender",
             "station_id": "EDUU-WUR"
           },
           {
             "label": ["EDGG", "HAB"],
+            "color": "mint",
             "station_id": "EDGG-HAB"
           },
           {
@@ -261,14 +310,17 @@
           },
           {
             "label": ["EDYY", "LXH"],
+            "color": "lavender",
             "station_id": "EDYY-LXH"
           },
           {
             "label": ["TAU"],
+            "color": "lagoon",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["GED"],
+            "color": "lagoon",
             "station_id": "EDGG-GED"
           },
           {
@@ -282,10 +334,12 @@
           },
           {
             "label": ["EDYY", "SH"],
+            "color": "lavender",
             "station_id": "EDYY-SH"
           },
           {
             "label": ["EDYY", "SL"],
+            "color": "lavender",
             "station_id": "EDYY-SL"
           },
           {
@@ -296,6 +350,7 @@
           },
           {
             "label": ["EDGG", "PAD"],
+            "color": "mint",
             "station_id": "EDGG-PAD"
           },
           {
@@ -303,18 +358,22 @@
           },
           {
             "label": ["EDYY", "MH"],
+            "color": "lavender",
             "station_id": "EDYY-MH"
           },
           {
             "label": ["EDYY", "ML"],
+            "color": "lavender",
             "station_id": "EDYY-ML"
           },
           {
             "label": ["EDWW", "HRZ"],
+            "color": "mint",
             "station_id": "EDWW-HRZ"
           },
           {
             "label": ["EDMM", "BBG"],
+            "color": "mint",
             "station_id": "EDMM-BBG"
           },
           {
@@ -325,18 +384,22 @@
           },
           {
             "label": ["EDYY", "RH"],
+            "color": "lavender",
             "station_id": "EDYY-RH"
           },
           {
             "label": ["EDYY", "RL"],
+            "color": "lavender",
             "station_id": "EDYY-RL"
           },
           {
             "label": ["EDMM", "HAL"],
+            "color": "mint",
             "station_id": "EDMM-HAL"
           },
           {
             "label": ["EDMM", "GER"],
+            "color": "mint",
             "station_id": "EDMM-GER"
           },
           {
@@ -347,20 +410,25 @@
           },
           {
             "label": ["EDUU", "SAL"],
+            "color": "lavender",
             "station_id": "EDUU-SAL"
           },
           {
             "label": ["EDUU", "ERL"],
+            "color": "lavender",
             "station_id": "EDUU-ERL"
           },
           {
-            "label": ["LFEE", "HE"]
+            "label": ["LFEE", "HE"],
+            "color": "lavender"
           },
           {
-            "label": ["LFEE", "KE"]
+            "label": ["LFEE", "KE"],
+            "color": "lavender"
           },
           {
-            "label": ["LFEE", "UE"]
+            "label": ["LFEE", "UE"],
+            "color": "mint"
           },
           {
             "label": [""]
@@ -375,86 +443,107 @@
         "keys": [
           {
             "label": ["SLN"],
+            "color": "lilac",
             "station_id": "EDUU-SLN"
           },
           {
             "label": ["MAN"],
+            "color": "lagoon",
             "station_id": "EDGG-MAN"
           },
           {
             "label": ["HAB"],
+            "color": "lagoon",
             "station_id": "EDGG-HAB"
           },
           {
             "label": ["EDUU", "NTM"],
+            "color": "lavender",
             "station_id": "EDUU-NTM"
           },
           {
             "label": ["EDGG", "PFA"],
+            "color": "clay",
             "station_id": "EDGG-PFA"
           },
           {
             "label": ["EDGG", "KIR"],
+            "color": "mint",
             "station_id": "EDGG-KIR"
           },
           {
             "label": ["TGO"],
+            "color": "lilac",
             "station_id": "EDUU-TGO"
           },
           {
             "label": ["DKB"],
+            "color": "lagoon",
             "station_id": "EDGG-DKB"
           },
           {
             "label": ["PSA"],
+            "color": "lagoon",
             "station_id": "EDGG-PSA"
           },
           {
             "label": ["EDUU", "FFM"],
+            "color": "lavender",
             "station_id": "EDUU-FFM"
           },
           {
             "label": ["EDGG", "TAU"],
+            "color": "mint",
             "station_id": "EDGG-TAU"
           },
           {
             "label": ["EDGG", "SIG"],
+            "color": "mint",
             "station_id": "EDGG-SIG"
           },
           {
             "label": ["WUR"],
+            "color": "lilac",
             "station_id": "EDUU-WUR"
           },
           {
             "label": ["KNG"],
+            "color": "lagoon",
             "station_id": "EDGG-KNG"
           },
           {
             "label": ["KTG"],
+            "color": "lagoon",
             "station_id": "EDGG-KTG"
           },
           {
             "label": ["EDUU", "FUL"],
+            "color": "lavender",
             "station_id": "EDUU-FUL"
           },
           {
             "label": ["EDGG", "GIN"],
+            "color": "mint",
             "station_id": "EDGG-GIN"
           },
           {
             "label": ["EDGG", "HEF"],
+            "color": "mint",
             "station_id": "EDGG-HEF"
           },
           {
             "label": ["EDUU", "ERL"],
+            "color": "lavender",
             "station_id": "EDUU-ERL"
           },
           {
             "label": ["LBU"],
+            "color": "lagoon",
             "station_id": "EDGG-LBU"
           },
           {
             "label": ["BAD"],
+            "color": "lagoon",
             "station_id": "EDGG-BAD"
           },
           {
@@ -462,6 +551,7 @@
           },
           {
             "label": ["EDGG", "GED"],
+            "color": "mint",
             "station_id": "EDGG-GED"
           },
           {
@@ -469,14 +559,17 @@
           },
           {
             "label": ["EDUU", "DON"],
+            "color": "lavender",
             "station_id": "EDUU-DON"
           },
           {
             "label": ["EDMM", "BBG"],
+            "color": "mint",
             "station_id": "EDMM-BBG"
           },
           {
             "label": ["EDMM", "ALB"],
+            "color": "mint",
             "station_id": "EDMM-ALB"
           },
           {
@@ -490,14 +583,17 @@
           },
           {
             "label": ["EDUU", "AMM"],
+            "color": "lavender",
             "station_id": "EDUU-AMM"
           },
           {
             "label": ["EDMM", "WLD"],
+            "color": "mint",
             "station_id": "EDMM-WLD"
           },
           {
             "label": ["EDMM", "NDG"],
+            "color": "mint",
             "station_id": "EDMM-NDG"
           },
           {
@@ -511,10 +607,12 @@
           },
           {
             "label": ["EDUU", "ALP"],
+            "color": "lavender",
             "station_id": "EDUU-ALP"
           },
           {
             "label": ["EDMM", "FUE"],
+            "color": "mint",
             "station_id": "EDMM-FUE"
           },
           {
@@ -530,22 +628,28 @@
             "label": [""]
           },
           {
-            "label": ["LSAS", "SC"]
+            "label": ["LSAS", "SC"],
+            "color": "lavender"
           },
           {
-            "label": ["LSAZ", "SZN"]
+            "label": ["LSAZ", "SZN"],
+            "color": "mint"
           },
           {
-            "label": ["LSAZ", "SZE"]
+            "label": ["LSAZ", "SZE"],
+            "color": "mint"
           },
           {
-            "label": ["LFEE", "HE"]
+            "label": ["LFEE", "HE"],
+            "color": "lavender"
           },
           {
-            "label": ["LFEE", "KE"]
+            "label": ["LFEE", "KE"],
+            "color": "lavender"
           },
           {
-            "label": ["LFEE", "UE"]
+            "label": ["LFEE", "UE"],
+            "color": "mint"
           }
         ]
       }

--- a/dataset/EDGG/stations.json
+++ b/dataset/EDGG/stations.json
@@ -34,7 +34,13 @@
         "EDYY_RH_CTR",
         "EDGG_PAH_CTR",
         "EDGG_NH_CTR",
-        "EDGG_AH_CTR"
+        "EDGG_AH_CTR",
+        "EDYY_SL_CTR",
+        "EDYY_SH_CTR",
+        "EDYY_BB_CTR",
+        "EDWW_EMS_CTR",
+        "EDWW_W_CTR",
+        "EDWW_CTR"
       ]
     },
     {
@@ -47,7 +53,13 @@
         "EDYY_RL_CTR",
         "EDGG_PAH_CTR",
         "EDGG_NH_CTR",
-        "EDGG_AH_CTR"
+        "EDGG_AH_CTR",
+        "EDYY_SH_CTR",
+        "EDYY_SL_CTR",
+        "EDYY_BB_CTR",
+        "EDWW_EMS_CTR",
+        "EDWW_W_CTR",
+        "EDWW_CTR"
       ]
     },
     {


### PR DESCRIPTION
### Description
Adds a client config as AFIS profile, filtering the current implementation while keeping low maintenance.
Also adds default call sources

### Checklist
- [X] Dataset files are in the correct `dataset/{FIR}/` directory.
- [X] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
