### PR TITLE
Refactor CZQM and CZQX station configurations

### DIFF
--- a/dataset/CZQM/positions.json
+++ b/dataset/CZQM/positions.json
@@ -2,409 +2,681 @@
   "positions": [
     {
       "id": "CZQM_TMU",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "118.000",
       "facility_type": "FMP",
       "profile_id": "CZQM"
     },
     {
       "id": "CZQX_TM_TMU",
-      "prefixes": ["CZQX"],
+      "prefixes": [
+        "CZQX"
+      ],
       "frequency": "129.000",
       "facility_type": "FMP",
       "profile_id": "CZQM"
     },
     {
       "id": "CZQM_1_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "123.800",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-1-CTR"
+      ]
     },
     {
       "id": "CZQM_2_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "132.700",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-2-CTR"
+      ]
     },
     {
       "id": "CZQM_3_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "135.650",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-3-CTR"
+      ]
     },
     {
       "id": "CZQM_4_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "123.700",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-4-CTR"
+      ]
     },
     {
       "id": "CZQM_5_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "126.450",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-5-CTR"
+      ]
     },
     {
       "id": "CZQM_6_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "125.750",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-6-CTR"
+      ]
     },
     {
       "id": "CZQM_7_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "132.800",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-7-CTR"
+      ]
     },
     {
       "id": "CZQM_8_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "132.250",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-8-CTR"
+      ]
     },
     {
       "id": "CZQM_CB_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "118.600",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-CB"
+      ]
     },
     {
       "id": "CZQM_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "132.200",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-CTR"
+      ]
     },
     {
       "id": "CZQM_C_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "134.250",
       "facility_type": "CTR",
       "profile_id": "CZQM"
     },
     {
       "id": "CZQM_DG_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "123.900",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-DG"
+      ]
     },
     {
       "id": "CZQM_S_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "134.250",
       "facility_type": "CTR",
       "profile_id": "CZQM"
     },
     {
       "id": "CZQM_ZV_CTR",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "133.350",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-ZV"
+      ]
     },
     {
       "id": "CZQX_1_CTR",
-      "prefixes": ["CZQX"],
+      "prefixes": [
+        "CZQX"
+      ],
       "frequency": "132.300",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-1-CTR"
+      ]
     },
     {
       "id": "CZQX_2_CTR",
-      "prefixes": ["CZQX"],
+      "prefixes": [
+        "CZQX"
+      ],
       "frequency": "133.000",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-2-CTR"
+      ]
     },
     {
       "id": "CZQX_3_CTR",
-      "prefixes": ["CZQX"],
+      "prefixes": [
+        "CZQX"
+      ],
       "frequency": "125.075",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-3-CTR"
+      ]
     },
     {
       "id": "CZQX_4_CTR",
-      "prefixes": ["CZQX"],
+      "prefixes": [
+        "CZQX"
+      ],
       "frequency": "128.175",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-4-CTR"
+      ]
     },
     {
       "id": "CZQX_5_CTR",
-      "prefixes": ["CZQX"],
+      "prefixes": [
+        "CZQX"
+      ],
       "frequency": "132.050",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-5-CTR"
+      ]
     },
     {
       "id": "CZQX_6_CTR",
-      "prefixes": ["CZQX"],
+      "prefixes": [
+        "CZQX"
+      ],
       "frequency": "119.850",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-6-CTR"
+      ]
     },
     {
       "id": "CZQX_7_CTR",
-      "prefixes": ["CZQX"],
+      "prefixes": [
+        "CZQX"
+      ],
       "frequency": "132.500",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-7-CTR"
+      ]
     },
     {
       "id": "CZQX_CTR",
-      "prefixes": ["CZQX"],
+      "prefixes": [
+        "CZQX"
+      ],
       "frequency": "132.100",
       "facility_type": "CTR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-CTR"
+      ]
     },
     {
       "id": "CZQX_G_CTR",
-      "prefixes": ["CZQX"],
+      "prefixes": [
+        "CZQX"
+      ],
       "frequency": "135.150",
       "facility_type": "CTR",
       "profile_id": "CZQM"
     },
     {
       "id": "CZQX_O_CTR",
-      "prefixes": ["CZQX"],
+      "prefixes": [
+        "CZQX"
+      ],
       "frequency": "128.075",
       "facility_type": "CTR",
       "profile_id": "CZQM"
     },
     {
       "id": "CYHZ_APP",
-      "prefixes": ["CYHZ"],
+      "prefixes": [
+        "CYHZ"
+      ],
       "frequency": "119.200",
       "facility_type": "APP",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYHZ-TMA"
+      ]
     },
     {
       "id": "CYHZ_FI_APP",
-      "prefixes": ["CYHZ"],
+      "prefixes": [
+        "CYHZ"
+      ],
       "frequency": "128.550",
       "facility_type": "APP",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYHZ-TMA-FI"
+      ]
     },
     {
       "id": "CYQM_APP",
-      "prefixes": ["CYQM"],
+      "prefixes": [
+        "CYQM"
+      ],
       "frequency": "124.400",
       "facility_type": "APP",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-QM"
+      ]
     },
     {
       "id": "CYQX_APP",
-      "prefixes": ["CYQX"],
+      "prefixes": [
+        "CYQX"
+      ],
       "frequency": "128.500",
       "facility_type": "APP",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYQX-APP"
+      ]
     },
     {
       "id": "CYSJ_APP",
-      "prefixes": ["CYSJ"],
+      "prefixes": [
+        "CYSJ"
+      ],
       "frequency": "124.300",
       "facility_type": "APP",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-SJ"
+      ]
     },
     {
       "id": "CYYR_APP",
-      "prefixes": ["CYYR"],
+      "prefixes": [
+        "CYYR"
+      ],
       "frequency": "119.500",
       "facility_type": "APP",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYYR-APP"
+      ]
     },
     {
       "id": "CYYT_APP",
-      "prefixes": ["CYYT"],
+      "prefixes": [
+        "CYYT"
+      ],
       "frequency": "133.150",
       "facility_type": "APP",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYYT-APP"
+      ]
     },
     {
       "id": "CYZX_APP",
-      "prefixes": ["CYZX"],
+      "prefixes": [
+        "CYZX"
+      ],
       "frequency": "120.600",
       "facility_type": "APP",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYZX-TMA"
+      ]
     },
     {
       "id": "CZQM_L_APP",
-      "prefixes": ["CZQM"],
+      "prefixes": [
+        "CZQM"
+      ],
       "frequency": "124.400",
       "facility_type": "APP",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CZQM-L"
+      ]
     },
     {
       "id": "CYFC_TWR",
-      "prefixes": ["CYFC"],
+      "prefixes": [
+        "CYFC"
+      ],
       "frequency": "119.000",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYFC-TWR"
+      ]
     },
     {
       "id": "CYHZ_TWR",
-      "prefixes": ["CYHZ"],
+      "prefixes": [
+        "CYHZ"
+      ],
       "frequency": "118.400",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYHZ-TWR"
+      ]
     },
     {
       "id": "CYQM_TWR",
-      "prefixes": ["CYQM"],
+      "prefixes": [
+        "CYQM"
+      ],
       "frequency": "120.800",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYQM-TWR"
+      ]
     },
     {
       "id": "CYQX_TWR",
-      "prefixes": ["CYQX"],
+      "prefixes": [
+        "CYQX"
+      ],
       "frequency": "118.100",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYQX-TWR"
+      ]
     },
     {
       "id": "CYYR_TWR",
-      "prefixes": ["CYYR"],
+      "prefixes": [
+        "CYYR"
+      ],
       "frequency": "119.100",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYYR-TWR"
+      ]
     },
     {
       "id": "CYYT_TWR",
-      "prefixes": ["CYYT"],
+      "prefixes": [
+        "CYYT"
+      ],
       "frequency": "120.600",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYYT-TWR"
+      ]
     },
     {
       "id": "CYZX_TWR",
-      "prefixes": ["CYZX"],
+      "prefixes": [
+        "CYZX"
+      ],
       "frequency": "119.500",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYZX-TWR"
+      ]
     },
     {
       "id": "CYFC_GND",
-      "prefixes": ["CYFC"],
+      "prefixes": [
+        "CYFC"
+      ],
       "frequency": "121.700",
       "facility_type": "GND",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYFC-GND"
+      ]
     },
     {
       "id": "CYHZ_GND",
-      "prefixes": ["CYHZ"],
+      "prefixes": [
+        "CYHZ"
+      ],
       "frequency": "121.900",
       "facility_type": "GND",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYHZ-GND"
+      ]
     },
     {
       "id": "CYQM_GND",
-      "prefixes": ["CYQM"],
+      "prefixes": [
+        "CYQM"
+      ],
       "frequency": "121.800",
       "facility_type": "GND",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYQM-GND"
+      ]
     },
     {
       "id": "CYQX_GND",
-      "prefixes": ["CYQX"],
+      "prefixes": [
+        "CYQX"
+      ],
       "frequency": "121.900",
       "facility_type": "GND",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYQX-GND"
+      ]
     },
     {
       "id": "CYYR_GND",
-      "prefixes": ["CYYR"],
+      "prefixes": [
+        "CYYR"
+      ],
       "frequency": "121.900",
       "facility_type": "GND",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYYR-GND"
+      ]
     },
     {
       "id": "CYYT_GND",
-      "prefixes": ["CYYT"],
+      "prefixes": [
+        "CYYT"
+      ],
       "frequency": "121.900",
       "facility_type": "GND",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYYT-GND"
+      ]
     },
     {
       "id": "CYZX_GND",
-      "prefixes": ["CYZX"],
+      "prefixes": [
+        "CYZX"
+      ],
       "frequency": "133.750",
       "facility_type": "GND",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYZX-GND"
+      ]
     },
     {
       "id": "CYHZ_DEL",
-      "prefixes": ["CYHZ"],
+      "prefixes": [
+        "CYHZ"
+      ],
       "frequency": "123.950",
       "facility_type": "DEL",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYHZ-DEL"
+      ]
     },
     {
       "id": "CYYR_DEL",
-      "prefixes": ["CYYR"],
+      "prefixes": [
+        "CYYR"
+      ],
       "frequency": "118.100",
       "facility_type": "DEL",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYYR-DEL"
+      ]
     },
     {
       "id": "CYZX_DEL",
-      "prefixes": ["CYZX"],
+      "prefixes": [
+        "CYZX"
+      ],
       "frequency": "128.025",
       "facility_type": "DEL",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYZX-DEL"
+      ]
     },
     {
       "id": "CYSJ_F_TWR",
-      "prefixes": ["CYSJ"],
+      "prefixes": [
+        "CYSJ"
+      ],
       "frequency": "118.500",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYSJ-MF"
+      ]
     },
     {
       "id": "CYYG_F_TWR",
-      "prefixes": ["CYYG"],
+      "prefixes": [
+        "CYYG"
+      ],
       "frequency": "118.000",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYYG-MF"
+      ]
     },
     {
       "id": "LFVP_APP",
-      "prefixes": ["LFVP"],
+      "prefixes": [
+        "LFVP"
+      ],
       "frequency": "119.100",
       "facility_type": "APP",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "LFVP-APP"
+      ]
     },
     {
       "id": "LFVP_TWR",
-      "prefixes": ["LFVP"],
+      "prefixes": [
+        "LFVP"
+      ],
       "frequency": "118.500",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "LFVP-TWR"
+      ]
     },
     {
       "id": "CYDF_F_TWR",
-      "prefixes": ["CYDF"],
+      "prefixes": [
+        "CYDF"
+      ],
       "frequency": "122.200",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYDF-MF"
+      ]
     },
     {
       "id": "CYJT_F_TWR",
-      "prefixes": ["CYJT"],
+      "prefixes": [
+        "CYJT"
+      ],
       "frequency": "122.100",
       "facility_type": "TWR",
-      "profile_id": "CZQM"
+      "profile_id": "CZQM",
+      "default_call_sources": [
+        "CYJT-MF"
+      ]
     }
   ]
 }

--- a/dataset/CZQM/positions.json
+++ b/dataset/CZQM/positions.json
@@ -130,7 +130,7 @@
       "frequency": "132.300",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": ["CZQM-1-CTR"]
+      "default_call_sources": ["CZQX-1-CTR"]
     },
     {
       "id": "CZQX_2_CTR",
@@ -138,7 +138,7 @@
       "frequency": "133.000",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": ["CZQM-2-CTR"]
+      "default_call_sources": ["CZQX-2-CTR"]
     },
     {
       "id": "CZQX_3_CTR",
@@ -146,7 +146,7 @@
       "frequency": "125.075",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": ["CZQM-3-CTR"]
+      "default_call_sources": ["CZQX-3-CTR"]
     },
     {
       "id": "CZQX_4_CTR",
@@ -154,7 +154,7 @@
       "frequency": "128.175",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": ["CZQM-4-CTR"]
+      "default_call_sources": ["CZQX-4-CTR"]
     },
     {
       "id": "CZQX_5_CTR",
@@ -162,7 +162,7 @@
       "frequency": "132.050",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": ["CZQM-5-CTR"]
+      "default_call_sources": ["CZQX-5-CTR"]
     },
     {
       "id": "CZQX_6_CTR",
@@ -170,7 +170,7 @@
       "frequency": "119.850",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": ["CZQM-6-CTR"]
+      "default_call_sources": ["CZQX-6-CTR"]
     },
     {
       "id": "CZQX_7_CTR",
@@ -178,7 +178,7 @@
       "frequency": "132.500",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": ["CZQM-7-CTR"]
+      "default_call_sources": ["CZQX-7-CTR"]
     },
     {
       "id": "CZQX_CTR",
@@ -186,7 +186,7 @@
       "frequency": "132.100",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": ["CZQM-CTR"]
+      "default_call_sources": ["CZQX-CTR"]
     },
     {
       "id": "CZQX_G_CTR",

--- a/dataset/CZQM/positions.json
+++ b/dataset/CZQM/positions.json
@@ -2,681 +2,461 @@
   "positions": [
     {
       "id": "CZQM_TMU",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "118.000",
       "facility_type": "FMP",
       "profile_id": "CZQM"
     },
     {
       "id": "CZQX_TM_TMU",
-      "prefixes": [
-        "CZQX"
-      ],
+      "prefixes": ["CZQX"],
       "frequency": "129.000",
       "facility_type": "FMP",
       "profile_id": "CZQM"
     },
     {
       "id": "CZQM_1_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "123.800",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-1-CTR"
-      ]
+      "default_call_sources": ["CZQM-1-CTR"]
     },
     {
       "id": "CZQM_2_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "132.700",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-2-CTR"
-      ]
+      "default_call_sources": ["CZQM-2-CTR"]
     },
     {
       "id": "CZQM_3_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "135.650",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-3-CTR"
-      ]
+      "default_call_sources": ["CZQM-3-CTR"]
     },
     {
       "id": "CZQM_4_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "123.700",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-4-CTR"
-      ]
+      "default_call_sources": ["CZQM-4-CTR"]
     },
     {
       "id": "CZQM_5_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "126.450",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-5-CTR"
-      ]
+      "default_call_sources": ["CZQM-5-CTR"]
     },
     {
       "id": "CZQM_6_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "125.750",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-6-CTR"
-      ]
+      "default_call_sources": ["CZQM-6-CTR"]
     },
     {
       "id": "CZQM_7_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "132.800",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-7-CTR"
-      ]
+      "default_call_sources": ["CZQM-7-CTR"]
     },
     {
       "id": "CZQM_8_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "132.250",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-8-CTR"
-      ]
+      "default_call_sources": ["CZQM-8-CTR"]
     },
     {
       "id": "CZQM_CB_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "118.600",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-CB"
-      ]
+      "default_call_sources": ["CZQM-CB"]
     },
     {
       "id": "CZQM_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "132.200",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-CTR"
-      ]
+      "default_call_sources": ["CZQM-CTR"]
     },
     {
       "id": "CZQM_C_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "134.250",
       "facility_type": "CTR",
       "profile_id": "CZQM"
     },
     {
       "id": "CZQM_DG_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "123.900",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-DG"
-      ]
+      "default_call_sources": ["CZQM-DG"]
     },
     {
       "id": "CZQM_S_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "134.250",
       "facility_type": "CTR",
       "profile_id": "CZQM"
     },
     {
       "id": "CZQM_ZV_CTR",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "133.350",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-ZV"
-      ]
+      "default_call_sources": ["CZQM-ZV"]
     },
     {
       "id": "CZQX_1_CTR",
-      "prefixes": [
-        "CZQX"
-      ],
+      "prefixes": ["CZQX"],
       "frequency": "132.300",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-1-CTR"
-      ]
+      "default_call_sources": ["CZQM-1-CTR"]
     },
     {
       "id": "CZQX_2_CTR",
-      "prefixes": [
-        "CZQX"
-      ],
+      "prefixes": ["CZQX"],
       "frequency": "133.000",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-2-CTR"
-      ]
+      "default_call_sources": ["CZQM-2-CTR"]
     },
     {
       "id": "CZQX_3_CTR",
-      "prefixes": [
-        "CZQX"
-      ],
+      "prefixes": ["CZQX"],
       "frequency": "125.075",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-3-CTR"
-      ]
+      "default_call_sources": ["CZQM-3-CTR"]
     },
     {
       "id": "CZQX_4_CTR",
-      "prefixes": [
-        "CZQX"
-      ],
+      "prefixes": ["CZQX"],
       "frequency": "128.175",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-4-CTR"
-      ]
+      "default_call_sources": ["CZQM-4-CTR"]
     },
     {
       "id": "CZQX_5_CTR",
-      "prefixes": [
-        "CZQX"
-      ],
+      "prefixes": ["CZQX"],
       "frequency": "132.050",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-5-CTR"
-      ]
+      "default_call_sources": ["CZQM-5-CTR"]
     },
     {
       "id": "CZQX_6_CTR",
-      "prefixes": [
-        "CZQX"
-      ],
+      "prefixes": ["CZQX"],
       "frequency": "119.850",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-6-CTR"
-      ]
+      "default_call_sources": ["CZQM-6-CTR"]
     },
     {
       "id": "CZQX_7_CTR",
-      "prefixes": [
-        "CZQX"
-      ],
+      "prefixes": ["CZQX"],
       "frequency": "132.500",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-7-CTR"
-      ]
+      "default_call_sources": ["CZQM-7-CTR"]
     },
     {
       "id": "CZQX_CTR",
-      "prefixes": [
-        "CZQX"
-      ],
+      "prefixes": ["CZQX"],
       "frequency": "132.100",
       "facility_type": "CTR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-CTR"
-      ]
+      "default_call_sources": ["CZQM-CTR"]
     },
     {
       "id": "CZQX_G_CTR",
-      "prefixes": [
-        "CZQX"
-      ],
+      "prefixes": ["CZQX"],
       "frequency": "135.150",
       "facility_type": "CTR",
       "profile_id": "CZQM"
     },
     {
       "id": "CZQX_O_CTR",
-      "prefixes": [
-        "CZQX"
-      ],
+      "prefixes": ["CZQX"],
       "frequency": "128.075",
       "facility_type": "CTR",
       "profile_id": "CZQM"
     },
     {
       "id": "CYHZ_APP",
-      "prefixes": [
-        "CYHZ"
-      ],
+      "prefixes": ["CYHZ"],
       "frequency": "119.200",
       "facility_type": "APP",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYHZ-TMA"
-      ]
+      "default_call_sources": ["CYHZ-TMA"]
     },
     {
       "id": "CYHZ_FI_APP",
-      "prefixes": [
-        "CYHZ"
-      ],
+      "prefixes": ["CYHZ"],
       "frequency": "128.550",
       "facility_type": "APP",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYHZ-TMA-FI"
-      ]
+      "default_call_sources": ["CYHZ-TMA-FI"]
     },
     {
       "id": "CYQM_APP",
-      "prefixes": [
-        "CYQM"
-      ],
+      "prefixes": ["CYQM"],
       "frequency": "124.400",
       "facility_type": "APP",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-QM"
-      ]
+      "default_call_sources": ["CZQM-QM"]
     },
     {
       "id": "CYQX_APP",
-      "prefixes": [
-        "CYQX"
-      ],
+      "prefixes": ["CYQX"],
       "frequency": "128.500",
       "facility_type": "APP",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYQX-APP"
-      ]
+      "default_call_sources": ["CYQX-APP"]
     },
     {
       "id": "CYSJ_APP",
-      "prefixes": [
-        "CYSJ"
-      ],
+      "prefixes": ["CYSJ"],
       "frequency": "124.300",
       "facility_type": "APP",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-SJ"
-      ]
+      "default_call_sources": ["CZQM-SJ"]
     },
     {
       "id": "CYYR_APP",
-      "prefixes": [
-        "CYYR"
-      ],
+      "prefixes": ["CYYR"],
       "frequency": "119.500",
       "facility_type": "APP",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYYR-APP"
-      ]
+      "default_call_sources": ["CYYR-APP"]
     },
     {
       "id": "CYYT_APP",
-      "prefixes": [
-        "CYYT"
-      ],
+      "prefixes": ["CYYT"],
       "frequency": "133.150",
       "facility_type": "APP",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYYT-APP"
-      ]
+      "default_call_sources": ["CYYT-APP"]
     },
     {
       "id": "CYZX_APP",
-      "prefixes": [
-        "CYZX"
-      ],
+      "prefixes": ["CYZX"],
       "frequency": "120.600",
       "facility_type": "APP",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYZX-TMA"
-      ]
+      "default_call_sources": ["CYZX-TMA"]
     },
     {
       "id": "CZQM_L_APP",
-      "prefixes": [
-        "CZQM"
-      ],
+      "prefixes": ["CZQM"],
       "frequency": "124.400",
       "facility_type": "APP",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CZQM-L"
-      ]
+      "default_call_sources": ["CZQM-L"]
     },
     {
       "id": "CYFC_TWR",
-      "prefixes": [
-        "CYFC"
-      ],
+      "prefixes": ["CYFC"],
       "frequency": "119.000",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYFC-TWR"
-      ]
+      "default_call_sources": ["CYFC-TWR"]
     },
     {
       "id": "CYHZ_TWR",
-      "prefixes": [
-        "CYHZ"
-      ],
+      "prefixes": ["CYHZ"],
       "frequency": "118.400",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYHZ-TWR"
-      ]
+      "default_call_sources": ["CYHZ-TWR"]
     },
     {
       "id": "CYQM_TWR",
-      "prefixes": [
-        "CYQM"
-      ],
+      "prefixes": ["CYQM"],
       "frequency": "120.800",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYQM-TWR"
-      ]
+      "default_call_sources": ["CYQM-TWR"]
     },
     {
       "id": "CYQX_TWR",
-      "prefixes": [
-        "CYQX"
-      ],
+      "prefixes": ["CYQX"],
       "frequency": "118.100",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYQX-TWR"
-      ]
+      "default_call_sources": ["CYQX-TWR"]
     },
     {
       "id": "CYYR_TWR",
-      "prefixes": [
-        "CYYR"
-      ],
+      "prefixes": ["CYYR"],
       "frequency": "119.100",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYYR-TWR"
-      ]
+      "default_call_sources": ["CYYR-TWR"]
     },
     {
       "id": "CYYT_TWR",
-      "prefixes": [
-        "CYYT"
-      ],
+      "prefixes": ["CYYT"],
       "frequency": "120.600",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYYT-TWR"
-      ]
+      "default_call_sources": ["CYYT-TWR"]
     },
     {
       "id": "CYZX_TWR",
-      "prefixes": [
-        "CYZX"
-      ],
+      "prefixes": ["CYZX"],
       "frequency": "119.500",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYZX-TWR"
-      ]
+      "default_call_sources": ["CYZX-TWR"]
     },
     {
       "id": "CYFC_GND",
-      "prefixes": [
-        "CYFC"
-      ],
+      "prefixes": ["CYFC"],
       "frequency": "121.700",
       "facility_type": "GND",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYFC-GND"
-      ]
+      "default_call_sources": ["CYFC-GND"]
     },
     {
       "id": "CYHZ_GND",
-      "prefixes": [
-        "CYHZ"
-      ],
+      "prefixes": ["CYHZ"],
       "frequency": "121.900",
       "facility_type": "GND",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYHZ-GND"
-      ]
+      "default_call_sources": ["CYHZ-GND"]
     },
     {
       "id": "CYQM_GND",
-      "prefixes": [
-        "CYQM"
-      ],
+      "prefixes": ["CYQM"],
       "frequency": "121.800",
       "facility_type": "GND",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYQM-GND"
-      ]
+      "default_call_sources": ["CYQM-GND"]
     },
     {
       "id": "CYQX_GND",
-      "prefixes": [
-        "CYQX"
-      ],
+      "prefixes": ["CYQX"],
       "frequency": "121.900",
       "facility_type": "GND",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYQX-GND"
-      ]
+      "default_call_sources": ["CYQX-GND"]
     },
     {
       "id": "CYYR_GND",
-      "prefixes": [
-        "CYYR"
-      ],
+      "prefixes": ["CYYR"],
       "frequency": "121.900",
       "facility_type": "GND",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYYR-GND"
-      ]
+      "default_call_sources": ["CYYR-GND"]
     },
     {
       "id": "CYYT_GND",
-      "prefixes": [
-        "CYYT"
-      ],
+      "prefixes": ["CYYT"],
       "frequency": "121.900",
       "facility_type": "GND",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYYT-GND"
-      ]
+      "default_call_sources": ["CYYT-GND"]
     },
     {
       "id": "CYZX_GND",
-      "prefixes": [
-        "CYZX"
-      ],
+      "prefixes": ["CYZX"],
       "frequency": "133.750",
       "facility_type": "GND",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYZX-GND"
-      ]
+      "default_call_sources": ["CYZX-GND"]
     },
     {
       "id": "CYHZ_DEL",
-      "prefixes": [
-        "CYHZ"
-      ],
+      "prefixes": ["CYHZ"],
       "frequency": "123.950",
       "facility_type": "DEL",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYHZ-DEL"
-      ]
+      "default_call_sources": ["CYHZ-DEL"]
     },
     {
       "id": "CYYR_DEL",
-      "prefixes": [
-        "CYYR"
-      ],
+      "prefixes": ["CYYR"],
       "frequency": "118.100",
       "facility_type": "DEL",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYYR-DEL"
-      ]
+      "default_call_sources": ["CYYR-DEL"]
     },
     {
       "id": "CYZX_DEL",
-      "prefixes": [
-        "CYZX"
-      ],
+      "prefixes": ["CYZX"],
       "frequency": "128.025",
       "facility_type": "DEL",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYZX-DEL"
-      ]
+      "default_call_sources": ["CYZX-DEL"]
     },
     {
       "id": "CYSJ_F_TWR",
-      "prefixes": [
-        "CYSJ"
-      ],
+      "prefixes": ["CYSJ"],
       "frequency": "118.500",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYSJ-MF"
-      ]
+      "default_call_sources": ["CYSJ-MF"]
     },
     {
       "id": "CYYG_F_TWR",
-      "prefixes": [
-        "CYYG"
-      ],
+      "prefixes": ["CYYG"],
       "frequency": "118.000",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYYG-MF"
-      ]
+      "default_call_sources": ["CYYG-MF"]
     },
     {
       "id": "LFVP_APP",
-      "prefixes": [
-        "LFVP"
-      ],
+      "prefixes": ["LFVP"],
       "frequency": "119.100",
       "facility_type": "APP",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "LFVP-APP"
-      ]
+      "default_call_sources": ["LFVP-APP"]
     },
     {
       "id": "LFVP_TWR",
-      "prefixes": [
-        "LFVP"
-      ],
+      "prefixes": ["LFVP"],
       "frequency": "118.500",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "LFVP-TWR"
-      ]
+      "default_call_sources": ["LFVP-TWR"]
     },
     {
       "id": "CYDF_F_TWR",
-      "prefixes": [
-        "CYDF"
-      ],
+      "prefixes": ["CYDF"],
       "frequency": "122.200",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYDF-MF"
-      ]
+      "default_call_sources": ["CYDF-MF"]
     },
     {
       "id": "CYJT_F_TWR",
-      "prefixes": [
-        "CYJT"
-      ],
+      "prefixes": ["CYJT"],
       "frequency": "122.100",
       "facility_type": "TWR",
       "profile_id": "CZQM",
-      "default_call_sources": [
-        "CYJT-MF"
-      ]
+      "default_call_sources": ["CYJT-MF"]
     }
   ]
 }

--- a/dataset/CZQM/profiles/CZQM.json
+++ b/dataset/CZQM/profiles/CZQM.json
@@ -19,112 +19,71 @@
             "rows": 6,
             "keys": [
               {
-                "label": [
-                  "CZQO"
-                ],
+                "label": ["CZQO"],
                 "station_id": "Gander"
               },
               {
-                "label": [
-                  "DEL"
-                ],
+                "label": ["DEL"],
                 "station_id": "Gander_DEL"
               },
               {
-                "label": [
-                  ""
-                ]
+                "label": [""]
               },
               {
-                "label": [
-                  ""
-                ]
+                "label": [""]
               },
               {
-                "label": [
-                  ""
-                ]
+                "label": [""]
               },
               {
-                "label": [
-                  ""
-                ]
+                "label": [""]
               },
               {
-                "label": [
-                  "A"
-                ],
+                "label": ["A"],
                 "station_id": "Gander_A"
               },
               {
-                "label": [
-                  "B"
-                ],
+                "label": ["B"],
                 "station_id": "Gander_B"
               },
               {
-                "label": [
-                  "C"
-                ],
+                "label": ["C"],
                 "station_id": "Gander_C"
               },
               {
-                "label": [
-                  "D"
-                ],
+                "label": ["D"],
                 "station_id": "Gander_D"
               },
               {
-                "label": [
-                  "F"
-                ],
+                "label": ["F"],
                 "station_id": "Gander_F"
               },
               {
-                "label": [
-                  "G"
-                ],
+                "label": ["G"],
                 "station_id": "Gander_G"
               },
               {
-                "label": [
-                  "DEL",
-                  "A"
-                ],
+                "label": ["DEL", "A"],
                 "station_id": "Gander_DEL_A"
               },
               {
-                "label": [
-                  "DEL",
-                  "B"
-                ],
+                "label": ["DEL", "B"],
                 "station_id": "Gander_DEL_B"
               },
               {
-                "label": [
-                  "DEL",
-                  "C"
-                ],
+                "label": ["DEL", "C"],
                 "station_id": "Gander_DEL_C"
               },
               {
-                "label": [
-                  "DEL",
-                  "D"
-                ],
+                "label": ["DEL", "D"],
                 "station_id": "Gander_DEL_D"
               },
               {
-                "label": [
-                  "DEL",
-                  "F"
-                ],
+                "label": ["DEL", "F"],
                 "station_id": "Gander_DEL_F"
               },
               {
-                "label": [
-                  ""
-                ]
+                "label": [""]
               }
             ]
           }
@@ -135,10 +94,7 @@
           "page": {
             "rows": 5,
             "client_page": {
-              "include": [
-                "CZUL_*",
-                "MTL_*"
-              ]
+              "include": ["CZUL_*", "MTL_*"]
             }
           }
         },
@@ -148,9 +104,7 @@
           "page": {
             "rows": 5,
             "client_page": {
-              "include": [
-                "BOS_*"
-              ]
+              "include": ["BOS_*"]
             }
           }
         },
@@ -160,13 +114,9 @@
           "page": {
             "rows": 5,
             "client_page": {
-              "include": [
-                "NY*_*"
-              ],
+              "include": ["NY*_*"],
               "frequencies": "ShowAll",
-              "priority": [
-                "*_FSS"
-              ],
+              "priority": ["*_FSS"],
               "grouping": "Fir"
             }
           }
@@ -191,46 +141,29 @@
               "gap": 0.5,
               "children": [
                 {
-                  "label": [
-                    "QM",
-                    "Moncton"
-                  ],
+                  "label": ["QM", "Moncton"],
                   "size": 12,
                   "page": {
                     "rows": 5,
                     "keys": [
                       {
-                        "label": [
-                          "QM"
-                        ],
+                        "label": ["QM"],
                         "station_id": "CZQM-CTR"
                       },
                       {
-                        "label": [
-                          "QM",
-                          "LO"
-                        ],
+                        "label": ["QM", "LO"],
                         "station_id": "CZQM-QM"
                       },
                       {
-                        "label": [
-                          "SJ",
-                          "LO"
-                        ],
+                        "label": ["SJ", "LO"],
                         "station_id": "CZQM-SJ"
                       },
                       {
-                        "label": [
-                          "QM",
-                          "DG"
-                        ],
+                        "label": ["QM", "DG"],
                         "station_id": "CZQM-DG"
                       },
                       {
-                        "label": [
-                          "QM",
-                          "ZV"
-                        ],
+                        "label": ["QM", "ZV"],
                         "station_id": "CZQM-ZV"
                       },
                       {
@@ -249,31 +182,19 @@
                         "label": ""
                       },
                       {
-                        "label": [
-                          "QM",
-                          "4"
-                        ],
+                        "label": ["QM", "4"],
                         "station_id": "CZQM-4-CTR"
                       },
                       {
-                        "label": [
-                          "QM",
-                          "3"
-                        ],
+                        "label": ["QM", "3"],
                         "station_id": "CZQM-3-CTR"
                       },
                       {
-                        "label": [
-                          "QM",
-                          "2"
-                        ],
+                        "label": ["QM", "2"],
                         "station_id": "CZQM-2-CTR"
                       },
                       {
-                        "label": [
-                          "QM",
-                          "1"
-                        ],
+                        "label": ["QM", "1"],
                         "station_id": "CZQM-1-CTR"
                       },
                       {
@@ -287,78 +208,50 @@
                   "justify_content": "space-around",
                   "children": [
                     {
-                      "label": [
-                        "CYHZ"
-                      ],
+                      "label": ["CYHZ"],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": [
-                              "HZ",
-                              "APP"
-                            ],
+                            "label": ["HZ", "APP"],
                             "station_id": "CYHZ-TMA"
                           },
                           {
-                            "label": [
-                              "HZ",
-                              "FI"
-                            ],
+                            "label": ["HZ", "FI"],
                             "station_id": "CYHZ-TMA-FI"
                           },
                           {
-                            "label": [
-                              "HZ",
-                              "TWR"
-                            ],
+                            "label": ["HZ", "TWR"],
                             "station_id": "CYHZ-TWR"
                           },
                           {
-                            "label": [
-                              "HZ",
-                              "GND"
-                            ],
+                            "label": ["HZ", "GND"],
                             "station_id": "CYHZ-GND"
                           },
                           {
-                            "label": [
-                              "HZ",
-                              "DEL"
-                            ],
+                            "label": ["HZ", "DEL"],
                             "station_id": "CYHZ-DEL"
                           }
                         ]
                       }
                     },
                     {
-                      "label": [
-                        "CYQM"
-                      ],
+                      "label": ["CYQM"],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": [
-                              "QM",
-                              "LO"
-                            ],
+                            "label": ["QM", "LO"],
                             "station_id": "CZQM-QM"
                           },
                           {
-                            "label": [
-                              "QM",
-                              "TWR"
-                            ],
+                            "label": ["QM", "TWR"],
                             "station_id": "CYQM-TWR"
                           },
                           {
-                            "label": [
-                              "QM",
-                              "GND"
-                            ],
+                            "label": ["QM", "GND"],
                             "station_id": "CYQM-GND"
                           },
                           {
@@ -379,32 +272,21 @@
                   "align_items": "center",
                   "children": [
                     {
-                      "label": [
-                        "CYFC"
-                      ],
+                      "label": ["CYFC"],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": [
-                              "SJ",
-                              "LO"
-                            ],
+                            "label": ["SJ", "LO"],
                             "station_id": "CZQM-SJ"
                           },
                           {
-                            "label": [
-                              "FC",
-                              "TWR"
-                            ],
+                            "label": ["FC", "TWR"],
                             "station_id": "CYFC-TWR"
                           },
                           {
-                            "label": [
-                              "FC",
-                              "GND"
-                            ],
+                            "label": ["FC", "GND"],
                             "station_id": "CYFC-GND"
                           },
                           {
@@ -425,18 +307,13 @@
               "gap": 0.5,
               "children": [
                 {
-                  "label": [
-                    "QX",
-                    "Gander"
-                  ],
+                  "label": ["QX", "Gander"],
                   "size": 12,
                   "page": {
                     "rows": 5,
                     "keys": [
                       {
-                        "label": [
-                          "QX"
-                        ],
+                        "label": ["QX"],
                         "station_id": "CZQX-CTR"
                       },
                       {
@@ -452,17 +329,11 @@
                         "label": ""
                       },
                       {
-                        "label": [
-                          "QX",
-                          "7"
-                        ],
+                        "label": ["QX", "7"],
                         "station_id": "CZQX-7-CTR"
                       },
                       {
-                        "label": [
-                          "QX",
-                          "6"
-                        ],
+                        "label": ["QX", "6"],
                         "station_id": "CZQX-6-CTR"
                       },
                       {
@@ -475,38 +346,23 @@
                         "label": ""
                       },
                       {
-                        "label": [
-                          "QX",
-                          "5"
-                        ],
+                        "label": ["QX", "5"],
                         "station_id": "CZQX-5-CTR"
                       },
                       {
-                        "label": [
-                          "QX",
-                          "4"
-                        ],
+                        "label": ["QX", "4"],
                         "station_id": "CZQX-4-CTR"
                       },
                       {
-                        "label": [
-                          "QX",
-                          "3"
-                        ],
+                        "label": ["QX", "3"],
                         "station_id": "CZQX-3-CTR"
                       },
                       {
-                        "label": [
-                          "QX",
-                          "2"
-                        ],
+                        "label": ["QX", "2"],
                         "station_id": "CZQX-2-CTR"
                       },
                       {
-                        "label": [
-                          "QX",
-                          "1"
-                        ],
+                        "label": ["QX", "1"],
                         "station_id": "CZQX-1-CTR"
                       }
                     ]
@@ -517,32 +373,21 @@
                   "justify_content": "space-around",
                   "children": [
                     {
-                      "label": [
-                        "CYQX"
-                      ],
+                      "label": ["CYQX"],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": [
-                              "QX",
-                              "APP"
-                            ],
+                            "label": ["QX", "APP"],
                             "station_id": "CYQX-APP"
                           },
                           {
-                            "label": [
-                              "QX",
-                              "TWR"
-                            ],
+                            "label": ["QX", "TWR"],
                             "station_id": "CYQX-TWR"
                           },
                           {
-                            "label": [
-                              "QX",
-                              "GND"
-                            ],
+                            "label": ["QX", "GND"],
                             "station_id": "CYQX-GND"
                           },
                           {
@@ -555,32 +400,21 @@
                       }
                     },
                     {
-                      "label": [
-                        "CYYT"
-                      ],
+                      "label": ["CYYT"],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": [
-                              "YT",
-                              "APP"
-                            ],
+                            "label": ["YT", "APP"],
                             "station_id": "CYYT-APP"
                           },
                           {
-                            "label": [
-                              "YT",
-                              "TWR"
-                            ],
+                            "label": ["YT", "TWR"],
                             "station_id": "CYYT-TWR"
                           },
                           {
-                            "label": [
-                              "YT",
-                              "GND"
-                            ],
+                            "label": ["YT", "GND"],
                             "station_id": "CYYT-GND"
                           },
                           {
@@ -599,25 +433,17 @@
                   "justify_content": "space-around",
                   "children": [
                     {
-                      "label": [
-                        "LFVP"
-                      ],
+                      "label": ["LFVP"],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": [
-                              "LFVP",
-                              "APP"
-                            ],
+                            "label": ["LFVP", "APP"],
                             "station_id": "LFVP-APP"
                           },
                           {
-                            "label": [
-                              "LFVP",
-                              "TWR"
-                            ],
+                            "label": ["LFVP", "TWR"],
                             "station_id": "LFVP-TWR"
                           },
                           {
@@ -650,17 +476,8 @@
           "size": 6,
           "page": {
             "client_page": {
-              "include": [
-                "CZQM",
-                "CZQX"
-              ],
-              "exclude": [
-                "*_DEL",
-                "*_GND",
-                "*_TWR",
-                "*_APP",
-                "*_CTR"
-              ]
+              "include": ["CZQM", "CZQX"],
+              "exclude": ["*_DEL", "*_GND", "*_TWR", "*_APP", "*_CTR"]
             },
             "rows": 5
           }
@@ -672,27 +489,19 @@
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "PAGE",
-                  "INOP"
-                ]
+                "label": ["PAGE", "INOP"]
               }
             ]
           }
         },
         {
-          "label": [
-            "MF"
-          ],
+          "label": ["MF"],
           "size": 6,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "PAGE",
-                  "INOP"
-                ]
+                "label": ["PAGE", "INOP"]
               }
             ]
           }

--- a/dataset/CZQM/profiles/CZQM.json
+++ b/dataset/CZQM/profiles/CZQM.json
@@ -19,71 +19,112 @@
             "rows": 6,
             "keys": [
               {
-                "label": ["CZQO"],
+                "label": [
+                  "CZQO"
+                ],
                 "station_id": "Gander"
               },
               {
-                "label": ["DEL"],
+                "label": [
+                  "DEL"
+                ],
                 "station_id": "Gander_DEL"
               },
               {
-                "label": [""]
+                "label": [
+                  ""
+                ]
               },
               {
-                "label": [""]
+                "label": [
+                  ""
+                ]
               },
               {
-                "label": [""]
+                "label": [
+                  ""
+                ]
               },
               {
-                "label": [""]
+                "label": [
+                  ""
+                ]
               },
               {
-                "label": ["A"],
+                "label": [
+                  "A"
+                ],
                 "station_id": "Gander_A"
               },
               {
-                "label": ["B"],
+                "label": [
+                  "B"
+                ],
                 "station_id": "Gander_B"
               },
               {
-                "label": ["C"],
+                "label": [
+                  "C"
+                ],
                 "station_id": "Gander_C"
               },
               {
-                "label": ["D"],
+                "label": [
+                  "D"
+                ],
                 "station_id": "Gander_D"
               },
               {
-                "label": ["F"],
+                "label": [
+                  "F"
+                ],
                 "station_id": "Gander_F"
               },
               {
-                "label": ["G"],
+                "label": [
+                  "G"
+                ],
                 "station_id": "Gander_G"
               },
               {
-                "label": ["DEL", "A"],
+                "label": [
+                  "DEL",
+                  "A"
+                ],
                 "station_id": "Gander_DEL_A"
               },
               {
-                "label": ["DEL", "B"],
+                "label": [
+                  "DEL",
+                  "B"
+                ],
                 "station_id": "Gander_DEL_B"
               },
               {
-                "label": ["DEL", "C"],
+                "label": [
+                  "DEL",
+                  "C"
+                ],
                 "station_id": "Gander_DEL_C"
               },
               {
-                "label": ["DEL", "D"],
+                "label": [
+                  "DEL",
+                  "D"
+                ],
                 "station_id": "Gander_DEL_D"
               },
               {
-                "label": ["DEL", "F"],
+                "label": [
+                  "DEL",
+                  "F"
+                ],
                 "station_id": "Gander_DEL_F"
               },
               {
-                "label": [""]
+                "label": [
+                  ""
+                ]
               }
             ]
           }
@@ -94,7 +135,10 @@
           "page": {
             "rows": 5,
             "client_page": {
-              "include": ["CZUL_*", "MTL_*"]
+              "include": [
+                "CZUL_*",
+                "MTL_*"
+              ]
             }
           }
         },
@@ -104,7 +148,9 @@
           "page": {
             "rows": 5,
             "client_page": {
-              "include": ["BOS_*"]
+              "include": [
+                "BOS_*"
+              ]
             }
           }
         },
@@ -114,9 +160,13 @@
           "page": {
             "rows": 5,
             "client_page": {
-              "include": ["NY*_*"],
+              "include": [
+                "NY*_*"
+              ],
               "frequencies": "ShowAll",
-              "priority": ["*_FSS"],
+              "priority": [
+                "*_FSS"
+              ],
               "grouping": "Fir"
             }
           }
@@ -141,29 +191,46 @@
               "gap": 0.5,
               "children": [
                 {
-                  "label": ["QM", "Moncton"],
+                  "label": [
+                    "QM",
+                    "Moncton"
+                  ],
                   "size": 12,
                   "page": {
                     "rows": 5,
                     "keys": [
                       {
-                        "label": ["QM"],
+                        "label": [
+                          "QM"
+                        ],
                         "station_id": "CZQM-CTR"
                       },
                       {
-                        "label": ["QM", "LO"],
+                        "label": [
+                          "QM",
+                          "LO"
+                        ],
                         "station_id": "CZQM-QM"
                       },
                       {
-                        "label": ["SJ", "LO"],
+                        "label": [
+                          "SJ",
+                          "LO"
+                        ],
                         "station_id": "CZQM-SJ"
                       },
                       {
-                        "label": ["QM", "DG"],
+                        "label": [
+                          "QM",
+                          "DG"
+                        ],
                         "station_id": "CZQM-DG"
                       },
                       {
-                        "label": ["QM", "ZV"],
+                        "label": [
+                          "QM",
+                          "ZV"
+                        ],
                         "station_id": "CZQM-ZV"
                       },
                       {
@@ -182,19 +249,31 @@
                         "label": ""
                       },
                       {
-                        "label": ["QM", "4"],
+                        "label": [
+                          "QM",
+                          "4"
+                        ],
                         "station_id": "CZQM-4-CTR"
                       },
                       {
-                        "label": ["QM", "3"],
+                        "label": [
+                          "QM",
+                          "3"
+                        ],
                         "station_id": "CZQM-3-CTR"
                       },
                       {
-                        "label": ["QM", "2"],
+                        "label": [
+                          "QM",
+                          "2"
+                        ],
                         "station_id": "CZQM-2-CTR"
                       },
                       {
-                        "label": ["QM", "1"],
+                        "label": [
+                          "QM",
+                          "1"
+                        ],
                         "station_id": "CZQM-1-CTR"
                       },
                       {
@@ -208,50 +287,78 @@
                   "justify_content": "space-around",
                   "children": [
                     {
-                      "label": ["CYHZ"],
+                      "label": [
+                        "CYHZ"
+                      ],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": ["HZ", "APP"],
+                            "label": [
+                              "HZ",
+                              "APP"
+                            ],
                             "station_id": "CYHZ-TMA"
                           },
                           {
-                            "label": ["HZ", "FI"],
+                            "label": [
+                              "HZ",
+                              "FI"
+                            ],
                             "station_id": "CYHZ-TMA-FI"
                           },
                           {
-                            "label": ["HZ", "TWR"],
+                            "label": [
+                              "HZ",
+                              "TWR"
+                            ],
                             "station_id": "CYHZ-TWR"
                           },
                           {
-                            "label": ["HZ", "GND"],
+                            "label": [
+                              "HZ",
+                              "GND"
+                            ],
                             "station_id": "CYHZ-GND"
                           },
                           {
-                            "label": ["HZ", "DEL"],
+                            "label": [
+                              "HZ",
+                              "DEL"
+                            ],
                             "station_id": "CYHZ-DEL"
                           }
                         ]
                       }
                     },
                     {
-                      "label": ["CYQM"],
+                      "label": [
+                        "CYQM"
+                      ],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": ["QM", "LO"],
+                            "label": [
+                              "QM",
+                              "LO"
+                            ],
                             "station_id": "CZQM-QM"
                           },
                           {
-                            "label": ["QM", "TWR"],
+                            "label": [
+                              "QM",
+                              "TWR"
+                            ],
                             "station_id": "CYQM-TWR"
                           },
                           {
-                            "label": ["QM", "GND"],
+                            "label": [
+                              "QM",
+                              "GND"
+                            ],
                             "station_id": "CYQM-GND"
                           },
                           {
@@ -272,21 +379,32 @@
                   "align_items": "center",
                   "children": [
                     {
-                      "label": ["CYFC"],
+                      "label": [
+                        "CYFC"
+                      ],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": ["SJ", "LO"],
+                            "label": [
+                              "SJ",
+                              "LO"
+                            ],
                             "station_id": "CZQM-SJ"
                           },
                           {
-                            "label": ["FC", "TWR"],
+                            "label": [
+                              "FC",
+                              "TWR"
+                            ],
                             "station_id": "CYFC-TWR"
                           },
                           {
-                            "label": ["FC", "GND"],
+                            "label": [
+                              "FC",
+                              "GND"
+                            ],
                             "station_id": "CYFC-GND"
                           },
                           {
@@ -307,25 +425,45 @@
               "gap": 0.5,
               "children": [
                 {
-                  "label": ["QX", "Gander"],
+                  "label": [
+                    "QX",
+                    "Gander"
+                  ],
                   "size": 12,
                   "page": {
                     "rows": 5,
                     "keys": [
                       {
-                        "label": ["QX"],
+                        "label": [
+                          "QX"
+                        ],
                         "station_id": "CZQX-CTR"
                       },
                       {
                         "label": ""
                       },
                       {
-                        "label": ["QX", "G"],
-                        "station_id": "CZQX-G-CTR"
+                        "label": ""
                       },
                       {
-                        "label": ["QX", "O"],
-                        "station_id": "CZQX-O-CTR"
+                        "label": ""
+                      },
+                      {
+                        "label": ""
+                      },
+                      {
+                        "label": [
+                          "QX",
+                          "7"
+                        ],
+                        "station_id": "CZQX-7-CTR"
+                      },
+                      {
+                        "label": [
+                          "QX",
+                          "6"
+                        ],
+                        "station_id": "CZQX-6-CTR"
                       },
                       {
                         "label": ""
@@ -337,32 +475,38 @@
                         "label": ""
                       },
                       {
-                        "label": ""
-                      },
-                      {
-                        "label": ""
-                      },
-                      {
-                        "label": ""
-                      },
-                      {
-                        "label": ["QX", "5"],
+                        "label": [
+                          "QX",
+                          "5"
+                        ],
                         "station_id": "CZQX-5-CTR"
                       },
                       {
-                        "label": ["QX", "4"],
+                        "label": [
+                          "QX",
+                          "4"
+                        ],
                         "station_id": "CZQX-4-CTR"
                       },
                       {
-                        "label": ["QX", "3"],
+                        "label": [
+                          "QX",
+                          "3"
+                        ],
                         "station_id": "CZQX-3-CTR"
                       },
                       {
-                        "label": ["QX", "2"],
+                        "label": [
+                          "QX",
+                          "2"
+                        ],
                         "station_id": "CZQX-2-CTR"
                       },
                       {
-                        "label": ["QX", "1"],
+                        "label": [
+                          "QX",
+                          "1"
+                        ],
                         "station_id": "CZQX-1-CTR"
                       }
                     ]
@@ -373,21 +517,32 @@
                   "justify_content": "space-around",
                   "children": [
                     {
-                      "label": ["CYQX"],
+                      "label": [
+                        "CYQX"
+                      ],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": ["QX", "APP"],
+                            "label": [
+                              "QX",
+                              "APP"
+                            ],
                             "station_id": "CYQX-APP"
                           },
                           {
-                            "label": ["QX", "TWR"],
+                            "label": [
+                              "QX",
+                              "TWR"
+                            ],
                             "station_id": "CYQX-TWR"
                           },
                           {
-                            "label": ["QX", "GND"],
+                            "label": [
+                              "QX",
+                              "GND"
+                            ],
                             "station_id": "CYQX-GND"
                           },
                           {
@@ -400,21 +555,32 @@
                       }
                     },
                     {
-                      "label": ["CYYT"],
+                      "label": [
+                        "CYYT"
+                      ],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": ["YT", "APP"],
+                            "label": [
+                              "YT",
+                              "APP"
+                            ],
                             "station_id": "CYYT-APP"
                           },
                           {
-                            "label": ["YT", "TWR"],
+                            "label": [
+                              "YT",
+                              "TWR"
+                            ],
                             "station_id": "CYYT-TWR"
                           },
                           {
-                            "label": ["YT", "GND"],
+                            "label": [
+                              "YT",
+                              "GND"
+                            ],
                             "station_id": "CYYT-GND"
                           },
                           {
@@ -433,17 +599,25 @@
                   "justify_content": "space-around",
                   "children": [
                     {
-                      "label": ["LFVP"],
+                      "label": [
+                        "LFVP"
+                      ],
                       "size": 6,
                       "page": {
                         "rows": 5,
                         "keys": [
                           {
-                            "label": ["LFVP", "APP"],
+                            "label": [
+                              "LFVP",
+                              "APP"
+                            ],
                             "station_id": "LFVP-APP"
                           },
                           {
-                            "label": ["LFVP", "TWR"],
+                            "label": [
+                              "LFVP",
+                              "TWR"
+                            ],
                             "station_id": "LFVP-TWR"
                           },
                           {
@@ -476,8 +650,17 @@
           "size": 6,
           "page": {
             "client_page": {
-              "include": ["CZQM", "CZQX"],
-              "exclude": ["*_DEL", "*_GND", "*_TWR", "*_APP", "*_CTR"]
+              "include": [
+                "CZQM",
+                "CZQX"
+              ],
+              "exclude": [
+                "*_DEL",
+                "*_GND",
+                "*_TWR",
+                "*_APP",
+                "*_CTR"
+              ]
             },
             "rows": 5
           }
@@ -489,19 +672,27 @@
             "rows": 5,
             "keys": [
               {
-                "label": ["PAGE", "INOP"]
+                "label": [
+                  "PAGE",
+                  "INOP"
+                ]
               }
             ]
           }
         },
         {
-          "label": ["MF"],
+          "label": [
+            "MF"
+          ],
           "size": 6,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": ["PAGE", "INOP"]
+                "label": [
+                  "PAGE",
+                  "INOP"
+                ]
               }
             ]
           }

--- a/dataset/CZQM/stations.json
+++ b/dataset/CZQM/stations.json
@@ -2,261 +2,381 @@
   "stations": [
     {
       "id": "CZQM-CTR",
-      "controlled_by": ["CZQM_CTR", "CZQX_CTR"]
+      "controlled_by": [
+        "CZQM_CTR",
+        "CZQX_CTR"
+      ]
     },
     {
       "id": "CZQX-CTR",
-      "controlled_by": ["CZQX_CTR", "CZQM_CTR"]
+      "controlled_by": [
+        "CZQX_CTR",
+        "CZQM_CTR"
+      ]
     },
     {
       "id": "CZQM-1-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_1_CTR", "CZQX_1_CTR"]
+      "controlled_by": [
+        "CZQM_1_CTR",
+        "CZQX_1_CTR"
+      ]
     },
     {
       "id": "CZQM-2-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_2_CTR", "CZQX_2_CTR"]
+      "controlled_by": [
+        "CZQM_2_CTR",
+        "CZQX_2_CTR"
+      ]
     },
     {
       "id": "CZQM-3-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_3_CTR", "CZQX_3_CTR"]
+      "controlled_by": [
+        "CZQM_3_CTR",
+        "CZQX_3_CTR"
+      ]
     },
     {
       "id": "CZQM-4-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_4_CTR", "CZQX_4_CTR"]
+      "controlled_by": [
+        "CZQM_4_CTR",
+        "CZQX_4_CTR"
+      ]
     },
     {
       "id": "CZQM-5-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_5_CTR", "CZQX_5_CTR"]
+      "controlled_by": [
+        "CZQM_5_CTR",
+        "CZQX_5_CTR"
+      ]
     },
     {
       "id": "CZQM-6-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_6_CTR", "CZQX_6_CTR"]
+      "controlled_by": [
+        "CZQM_6_CTR",
+        "CZQX_6_CTR"
+      ]
     },
     {
       "id": "CZQM-7-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_7_CTR", "CZQX_7_CTR"]
+      "controlled_by": [
+        "CZQM_7_CTR",
+        "CZQX_7_CTR"
+      ]
     },
     {
       "id": "CZQM-8-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_8_CTR", "CZQX_8_CTR"]
+      "controlled_by": [
+        "CZQM_8_CTR"
+      ]
     },
     {
       "id": "CZQX-1-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CZQX_1_CTR", "CZQM_1_CTR"]
+      "controlled_by": [
+        "CZQX_1_CTR",
+        "CZQM_1_CTR"
+      ]
     },
     {
       "id": "CZQX-2-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CZQX_2_CTR", "CZQM_2_CTR"]
+      "controlled_by": [
+        "CZQX_2_CTR",
+        "CZQM_2_CTR"
+      ]
     },
     {
       "id": "CZQX-3-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CZQX_3_CTR", "CZQM_3_CTR"]
+      "controlled_by": [
+        "CZQX_3_CTR",
+        "CZQM_3_CTR"
+      ]
     },
     {
       "id": "CZQX-4-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CZQX_4_CTR", "CZQM_4_CTR"]
+      "controlled_by": [
+        "CZQX_4_CTR",
+        "CZQM_4_CTR"
+      ]
     },
     {
       "id": "CZQX-5-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CZQX_5_CTR", "CZQM_5_CTR"]
+      "controlled_by": [
+        "CZQX_5_CTR",
+        "CZQM_5_CTR"
+      ]
     },
     {
       "id": "CZQX-6-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CZQX_6_CTR", "CZQM_6_CTR"]
+      "controlled_by": [
+        "CZQX_6_CTR",
+        "CZQM_6_CTR"
+      ]
     },
     {
       "id": "CZQX-7-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CZQX_7_CTR", "CZQM_7_CTR"]
+      "controlled_by": [
+        "CZQX_7_CTR",
+        "CZQM_7_CTR"
+      ]
     },
     {
       "id": "CZQM-L",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_L_APP"]
+      "controlled_by": [
+        "CZQM_L_APP"
+      ]
     },
     {
       "id": "CYHZ-TMA",
       "parent_id": "CZQM-L",
-      "controlled_by": ["CYHZ_APP"]
+      "controlled_by": [
+        "CYHZ_APP"
+      ]
     },
     {
       "id": "CYHZ-TMA-FI",
       "parent_id": "CYHZ-TMA",
-      "controlled_by": ["CYHZ_FI_APP"]
+      "controlled_by": [
+        "CYHZ_FI_APP"
+      ]
     },
     {
       "id": "CYHZ-TWR",
       "parent_id": "CYHZ-TMA-FI",
-      "controlled_by": ["CYHZ_TWR"]
+      "controlled_by": [
+        "CYHZ_TWR"
+      ]
     },
     {
       "id": "CYHZ-GND",
       "parent_id": "CYHZ-TWR",
-      "controlled_by": ["CYHZ_GND"]
+      "controlled_by": [
+        "CYHZ_GND"
+      ]
     },
     {
       "id": "CYHZ-DEL",
       "parent_id": "CYHZ-GND",
-      "controlled_by": ["CYHZ_DEL"]
+      "controlled_by": [
+        "CYHZ_DEL"
+      ]
     },
     {
       "id": "CYZX-TMA",
       "parent_id": "CYHZ-TMA",
-      "controlled_by": ["CYZX_APP"]
+      "controlled_by": [
+        "CYZX_APP"
+      ]
     },
     {
       "id": "CYZX-TWR",
       "parent_id": "CYZX-TMA",
-      "controlled_by": ["CYZX_TWR"]
+      "controlled_by": [
+        "CYZX_TWR"
+      ]
     },
     {
       "id": "CYZX-GND",
       "parent_id": "CYZX-TWR",
-      "controlled_by": ["CYZX_GND"]
+      "controlled_by": [
+        "CYZX_GND"
+      ]
     },
     {
       "id": "CYZX-DEL",
       "parent_id": "CYZX-GND",
-      "controlled_by": ["CYZX_DEL"]
+      "controlled_by": [
+        "CYZX_DEL"
+      ]
     },
     {
       "id": "CZQM-QM",
       "parent_id": "CZQM-L",
-      "controlled_by": ["CYQM_APP"]
+      "controlled_by": [
+        "CYQM_APP"
+      ]
     },
     {
       "id": "CYQM-TWR",
       "parent_id": "CZQM-QM",
-      "controlled_by": ["CYQM_TWR"]
+      "controlled_by": [
+        "CYQM_TWR"
+      ]
     },
     {
       "id": "CYQM-GND",
       "parent_id": "CYQM-TWR",
-      "controlled_by": ["CYQM_GND"]
+      "controlled_by": [
+        "CYQM_GND"
+      ]
     },
     {
       "id": "CZQM-SJ",
       "parent_id": "CZQM-QM",
-      "controlled_by": ["CYSJ_APP"]
+      "controlled_by": [
+        "CYSJ_APP"
+      ]
     },
     {
       "id": "CYFC-TWR",
       "parent_id": "CZQM-SJ",
-      "controlled_by": ["CYFC_TWR"]
+      "controlled_by": [
+        "CYFC_TWR"
+      ]
     },
     {
       "id": "CYFC-GND",
       "parent_id": "CYFC-TWR",
-      "controlled_by": ["CYFC_GND"]
+      "controlled_by": [
+        "CYFC_GND"
+      ]
     },
     {
       "id": "CYSJ-MF",
       "parent_id": "CZQM-SJ",
-      "controlled_by": ["CYSJ_F_TWR"]
+      "controlled_by": [
+        "CYSJ_F_TWR"
+      ]
     },
     {
       "id": "CYYG-MF",
       "parent_id": "CZQM-QM",
-      "controlled_by": ["CYYG_F_TWR"]
+      "controlled_by": [
+        "CYYG_F_TWR"
+      ]
     },
     {
       "id": "CZQM-DG",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_DG_CTR"]
+      "controlled_by": [
+        "CZQM_DG_CTR"
+      ]
     },
     {
       "id": "CZQM-ZV",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_ZV_CTR"]
+      "controlled_by": [
+        "CZQM_ZV_CTR"
+      ]
     },
     {
       "id": "CZQM-CB",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_CB_CTR"]
+      "controlled_by": [
+        "CZQM_CB_CTR"
+      ]
     },
     {
       "id": "CYQX-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CYQX_APP"]
+      "controlled_by": [
+        "CYQX_APP"
+      ]
     },
     {
       "id": "CYQX-TWR",
       "parent_id": "CYQX-APP",
-      "controlled_by": ["CYQX_TWR"]
+      "controlled_by": [
+        "CYQX_TWR"
+      ]
     },
     {
       "id": "CYQX-GND",
       "parent_id": "CYQX-TWR",
-      "controlled_by": ["CYQX_GND"]
+      "controlled_by": [
+        "CYQX_GND"
+      ]
     },
     {
       "id": "CYYT-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CYYT_APP"]
+      "controlled_by": [
+        "CYYT_APP"
+      ]
     },
     {
       "id": "CYYT-TWR",
       "parent_id": "CYYT-APP",
-      "controlled_by": ["CYYT_TWR"]
+      "controlled_by": [
+        "CYYT_TWR"
+      ]
     },
     {
       "id": "CYYT-GND",
       "parent_id": "CYYT-TWR",
-      "controlled_by": ["CYYT_GND"]
+      "controlled_by": [
+        "CYYT_GND"
+      ]
     },
     {
       "id": "CYYR-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CYYR_APP"]
+      "controlled_by": [
+        "CYYR_APP"
+      ]
     },
     {
       "id": "CYYR-TWR",
       "parent_id": "CYYR-APP",
-      "controlled_by": ["CYYR_TWR"]
+      "controlled_by": [
+        "CYYR_TWR"
+      ]
     },
     {
       "id": "CYYR-GND",
       "parent_id": "CYYR-TWR",
-      "controlled_by": ["CYYR_GND"]
+      "controlled_by": [
+        "CYYR_GND"
+      ]
     },
     {
       "id": "CYYR-DEL",
       "parent_id": "CYYR-GND",
-      "controlled_by": ["CYYR_DEL"]
+      "controlled_by": [
+        "CYYR_DEL"
+      ]
     },
     {
       "id": "LFVP-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["LFVP_APP"]
+      "controlled_by": [
+        "LFVP_APP"
+      ]
     },
     {
       "id": "LFVP-TWR",
       "parent_id": "LFVP-APP",
-      "controlled_by": ["LFVP_TWR"]
+      "controlled_by": [
+        "LFVP_TWR"
+      ]
     },
     {
       "id": "CYDF-MF",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CYDF_F_TWR"]
+      "controlled_by": [
+        "CYDF_F_TWR"
+      ]
     },
     {
       "id": "CYJT-MF",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CYJT_F_TWR"]
+      "controlled_by": [
+        "CYJT_F_TWR"
+      ]
     }
   ]
 }

--- a/dataset/CZQM/stations.json
+++ b/dataset/CZQM/stations.json
@@ -2,382 +2,261 @@
   "stations": [
     {
       "id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_CTR",
-        "CZQX_CTR"
-      ]
+      "controlled_by": ["CZQM_CTR", "CZQX_CTR"]
     },
     {
       "id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_CTR",
-        "CZQM_CTR"
-      ]
+      "controlled_by": ["CZQX_CTR", "CZQM_CTR"]
     },
     {
       "id": "CZQM-1-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_1_CTR",
-        "CZQX_1_CTR"
-      ]
+      "controlled_by": ["CZQM_1_CTR", "CZQX_1_CTR"]
     },
     {
       "id": "CZQM-2-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_2_CTR",
-        "CZQX_2_CTR"
-      ]
+      "controlled_by": ["CZQM_2_CTR", "CZQX_2_CTR"]
     },
     {
       "id": "CZQM-3-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_3_CTR",
-        "CZQX_3_CTR"
-      ]
+      "controlled_by": ["CZQM_3_CTR", "CZQX_3_CTR"]
     },
     {
       "id": "CZQM-4-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_4_CTR",
-        "CZQX_4_CTR"
-      ]
+      "controlled_by": ["CZQM_4_CTR", "CZQX_4_CTR"]
     },
     {
       "id": "CZQM-5-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_5_CTR",
-        "CZQX_5_CTR"
-      ]
+      "controlled_by": ["CZQM_5_CTR", "CZQX_5_CTR"]
     },
     {
       "id": "CZQM-6-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_6_CTR",
-        "CZQX_6_CTR"
-      ]
+      "controlled_by": ["CZQM_6_CTR", "CZQX_6_CTR"]
     },
     {
       "id": "CZQM-7-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_7_CTR",
-        "CZQX_7_CTR"
-      ]
+      "controlled_by": ["CZQM_7_CTR", "CZQX_7_CTR"]
     },
     {
       "id": "CZQM-8-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_8_CTR",
-        "CZQX_8_CTR"
-      ]
+      "controlled_by": ["CZQM_8_CTR", "CZQX_8_CTR"]
     },
     {
       "id": "CZQX-1-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_1_CTR",
-        "CZQM_1_CTR"
-      ]
+      "controlled_by": ["CZQX_1_CTR", "CZQM_1_CTR"]
     },
     {
       "id": "CZQX-2-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_2_CTR",
-        "CZQM_2_CTR"
-      ]
+      "controlled_by": ["CZQX_2_CTR", "CZQM_2_CTR"]
     },
     {
       "id": "CZQX-3-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_3_CTR",
-        "CZQM_3_CTR"
-      ]
+      "controlled_by": ["CZQX_3_CTR", "CZQM_3_CTR"]
     },
     {
       "id": "CZQX-4-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_4_CTR",
-        "CZQM_4_CTR"
-      ]
+      "controlled_by": ["CZQX_4_CTR", "CZQM_4_CTR"]
     },
     {
       "id": "CZQX-5-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_5_CTR",
-        "CZQM_5_CTR"
-      ]
+      "controlled_by": ["CZQX_5_CTR", "CZQM_5_CTR"]
     },
     {
       "id": "CZQX-6-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_6_CTR",
-        "CZQM_6_CTR"
-      ]
+      "controlled_by": ["CZQX_6_CTR", "CZQM_6_CTR"]
     },
     {
       "id": "CZQX-7-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_7_CTR",
-        "CZQM_7_CTR"
-      ]
+      "controlled_by": ["CZQX_7_CTR", "CZQM_7_CTR"]
     },
     {
       "id": "CZQM-L",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_L_APP"
-      ]
+      "controlled_by": ["CZQM_L_APP"]
     },
     {
       "id": "CYHZ-TMA",
       "parent_id": "CZQM-L",
-      "controlled_by": [
-        "CYHZ_APP"
-      ]
+      "controlled_by": ["CYHZ_APP"]
     },
     {
       "id": "CYHZ-TMA-FI",
       "parent_id": "CYHZ-TMA",
-      "controlled_by": [
-        "CYHZ_FI_APP"
-      ]
+      "controlled_by": ["CYHZ_FI_APP"]
     },
     {
       "id": "CYHZ-TWR",
       "parent_id": "CYHZ-TMA-FI",
-      "controlled_by": [
-        "CYHZ_TWR"
-      ]
+      "controlled_by": ["CYHZ_TWR"]
     },
     {
       "id": "CYHZ-GND",
       "parent_id": "CYHZ-TWR",
-      "controlled_by": [
-        "CYHZ_GND"
-      ]
+      "controlled_by": ["CYHZ_GND"]
     },
     {
       "id": "CYHZ-DEL",
       "parent_id": "CYHZ-GND",
-      "controlled_by": [
-        "CYHZ_DEL"
-      ]
+      "controlled_by": ["CYHZ_DEL"]
     },
     {
       "id": "CYZX-TMA",
       "parent_id": "CYHZ-TMA",
-      "controlled_by": [
-        "CYZX_APP"
-      ]
+      "controlled_by": ["CYZX_APP"]
     },
     {
       "id": "CYZX-TWR",
       "parent_id": "CYZX-TMA",
-      "controlled_by": [
-        "CYZX_TWR"
-      ]
+      "controlled_by": ["CYZX_TWR"]
     },
     {
       "id": "CYZX-GND",
       "parent_id": "CYZX-TWR",
-      "controlled_by": [
-        "CYZX_GND"
-      ]
+      "controlled_by": ["CYZX_GND"]
     },
     {
       "id": "CYZX-DEL",
       "parent_id": "CYZX-GND",
-      "controlled_by": [
-        "CYZX_DEL"
-      ]
+      "controlled_by": ["CYZX_DEL"]
     },
     {
       "id": "CZQM-QM",
       "parent_id": "CZQM-L",
-      "controlled_by": [
-        "CYQM_APP"
-      ]
+      "controlled_by": ["CYQM_APP"]
     },
     {
       "id": "CYQM-TWR",
       "parent_id": "CZQM-QM",
-      "controlled_by": [
-        "CYQM_TWR"
-      ]
+      "controlled_by": ["CYQM_TWR"]
     },
     {
       "id": "CYQM-GND",
       "parent_id": "CYQM-TWR",
-      "controlled_by": [
-        "CYQM_GND"
-      ]
+      "controlled_by": ["CYQM_GND"]
     },
     {
       "id": "CZQM-SJ",
       "parent_id": "CZQM-QM",
-      "controlled_by": [
-        "CYSJ_APP"
-      ]
+      "controlled_by": ["CYSJ_APP"]
     },
     {
       "id": "CYFC-TWR",
       "parent_id": "CZQM-SJ",
-      "controlled_by": [
-        "CYFC_TWR"
-      ]
+      "controlled_by": ["CYFC_TWR"]
     },
     {
       "id": "CYFC-GND",
       "parent_id": "CYFC-TWR",
-      "controlled_by": [
-        "CYFC_GND"
-      ]
+      "controlled_by": ["CYFC_GND"]
     },
     {
       "id": "CYSJ-MF",
       "parent_id": "CZQM-SJ",
-      "controlled_by": [
-        "CYSJ_F_TWR"
-      ]
+      "controlled_by": ["CYSJ_F_TWR"]
     },
     {
       "id": "CYYG-MF",
       "parent_id": "CZQM-QM",
-      "controlled_by": [
-        "CYYG_F_TWR"
-      ]
+      "controlled_by": ["CYYG_F_TWR"]
     },
     {
       "id": "CZQM-DG",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_DG_CTR"
-      ]
+      "controlled_by": ["CZQM_DG_CTR"]
     },
     {
       "id": "CZQM-ZV",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_ZV_CTR"
-      ]
+      "controlled_by": ["CZQM_ZV_CTR"]
     },
     {
       "id": "CZQM-CB",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_CB_CTR"
-      ]
+      "controlled_by": ["CZQM_CB_CTR"]
     },
     {
       "id": "CYQX-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CYQX_APP"
-      ]
+      "controlled_by": ["CYQX_APP"]
     },
     {
       "id": "CYQX-TWR",
       "parent_id": "CYQX-APP",
-      "controlled_by": [
-        "CYQX_TWR"
-      ]
+      "controlled_by": ["CYQX_TWR"]
     },
     {
       "id": "CYQX-GND",
       "parent_id": "CYQX-TWR",
-      "controlled_by": [
-        "CYQX_GND"
-      ]
+      "controlled_by": ["CYQX_GND"]
     },
     {
       "id": "CYYT-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CYYT_APP"
-      ]
+      "controlled_by": ["CYYT_APP"]
     },
     {
       "id": "CYYT-TWR",
       "parent_id": "CYYT-APP",
-      "controlled_by": [
-        "CYYT_TWR"
-      ]
+      "controlled_by": ["CYYT_TWR"]
     },
     {
       "id": "CYYT-GND",
       "parent_id": "CYYT-TWR",
-      "controlled_by": [
-        "CYYT_GND"
-      ]
+      "controlled_by": ["CYYT_GND"]
     },
     {
       "id": "CYYR-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CYYR_APP"
-      ]
+      "controlled_by": ["CYYR_APP"]
     },
     {
       "id": "CYYR-TWR",
       "parent_id": "CYYR-APP",
-      "controlled_by": [
-        "CYYR_TWR"
-      ]
+      "controlled_by": ["CYYR_TWR"]
     },
     {
       "id": "CYYR-GND",
       "parent_id": "CYYR-TWR",
-      "controlled_by": [
-        "CYYR_GND"
-      ]
+      "controlled_by": ["CYYR_GND"]
     },
     {
       "id": "CYYR-DEL",
       "parent_id": "CYYR-GND",
-      "controlled_by": [
-        "CYYR_DEL"
-      ]
+      "controlled_by": ["CYYR_DEL"]
     },
     {
       "id": "LFVP-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "LFVP_APP"
-      ]
+      "controlled_by": ["LFVP_APP"]
     },
     {
       "id": "LFVP-TWR",
       "parent_id": "LFVP-APP",
-      "controlled_by": [
-        "LFVP_TWR"
-      ]
+      "controlled_by": ["LFVP_TWR"]
     },
     {
       "id": "CYDF-MF",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CYDF_F_TWR"
-      ]
+      "controlled_by": ["CYDF_F_TWR"]
     },
     {
       "id": "CYJT-MF",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CYJT_F_TWR"
-      ]
+      "controlled_by": ["CYJT_F_TWR"]
     }
   ]
 }

--- a/dataset/CZQM/stations.json
+++ b/dataset/CZQM/stations.json
@@ -4,14 +4,6 @@
       "id": "CZQM-CTR",
       "controlled_by": [
         "CZQM_CTR",
-        "CZQM_1_CTR",
-        "CZQM_2_CTR",
-        "CZQM_3_CTR",
-        "CZQM_4_CTR",
-        "CZQM_5_CTR",
-        "CZQM_6_CTR",
-        "CZQM_7_CTR",
-        "CZQM_8_CTR",
         "CZQX_CTR"
       ]
     },
@@ -19,260 +11,373 @@
       "id": "CZQX-CTR",
       "controlled_by": [
         "CZQX_CTR",
-        "CZQX_1_CTR",
-        "CZQX_2_CTR",
-        "CZQX_3_CTR",
-        "CZQX_4_CTR",
-        "CZQX_5_CTR",
-        "CZQX_6_CTR",
-        "CZQX_7_CTR",
-        "CZQX_G_CTR",
-        "CZQX_O_CTR",
         "CZQM_CTR"
       ]
     },
     {
       "id": "CZQM-1-CTR",
-      "parent_id": "CZQM-CTR"
+      "parent_id": "CZQM-CTR",
+      "controlled_by": [
+        "CZQM_1_CTR",
+        "CZQX_1_CTR"
+      ]
     },
     {
       "id": "CZQM-2-CTR",
-      "parent_id": "CZQM-CTR"
+      "parent_id": "CZQM-CTR",
+      "controlled_by": [
+        "CZQM_2_CTR",
+        "CZQX_2_CTR"
+      ]
     },
     {
       "id": "CZQM-3-CTR",
-      "parent_id": "CZQM-CTR"
+      "parent_id": "CZQM-CTR",
+      "controlled_by": [
+        "CZQM_3_CTR",
+        "CZQX_3_CTR"
+      ]
     },
     {
       "id": "CZQM-4-CTR",
-      "parent_id": "CZQM-CTR"
+      "parent_id": "CZQM-CTR",
+      "controlled_by": [
+        "CZQM_4_CTR",
+        "CZQX_4_CTR"
+      ]
     },
     {
       "id": "CZQM-5-CTR",
-      "parent_id": "CZQM-CTR"
+      "parent_id": "CZQM-CTR",
+      "controlled_by": [
+        "CZQM_5_CTR",
+        "CZQX_5_CTR"
+      ]
     },
     {
       "id": "CZQM-6-CTR",
-      "parent_id": "CZQM-CTR"
+      "parent_id": "CZQM-CTR",
+      "controlled_by": [
+        "CZQM_6_CTR",
+        "CZQX_6_CTR"
+      ]
     },
     {
       "id": "CZQM-7-CTR",
-      "parent_id": "CZQM-CTR"
+      "parent_id": "CZQM-CTR",
+      "controlled_by": [
+        "CZQM_7_CTR",
+        "CZQX_7_CTR"
+      ]
     },
     {
       "id": "CZQM-8-CTR",
-      "parent_id": "CZQM-CTR"
+      "parent_id": "CZQM-CTR",
+      "controlled_by": [
+        "CZQM_8_CTR",
+        "CZQX_8_CTR"
+      ]
     },
     {
       "id": "CZQX-1-CTR",
-      "parent_id": "CZQX-CTR"
+      "parent_id": "CZQX-CTR",
+      "controlled_by": [
+        "CZQX_1_CTR",
+        "CZQM_1_CTR"
+      ]
     },
     {
       "id": "CZQX-2-CTR",
-      "parent_id": "CZQX-CTR"
+      "parent_id": "CZQX-CTR",
+      "controlled_by": [
+        "CZQX_2_CTR",
+        "CZQM_2_CTR"
+      ]
     },
     {
       "id": "CZQX-3-CTR",
-      "parent_id": "CZQX-CTR"
+      "parent_id": "CZQX-CTR",
+      "controlled_by": [
+        "CZQX_3_CTR",
+        "CZQM_3_CTR"
+      ]
     },
     {
       "id": "CZQX-4-CTR",
-      "parent_id": "CZQX-CTR"
+      "parent_id": "CZQX-CTR",
+      "controlled_by": [
+        "CZQX_4_CTR",
+        "CZQM_4_CTR"
+      ]
     },
     {
       "id": "CZQX-5-CTR",
-      "parent_id": "CZQX-CTR"
+      "parent_id": "CZQX-CTR",
+      "controlled_by": [
+        "CZQX_5_CTR",
+        "CZQM_5_CTR"
+      ]
     },
     {
       "id": "CZQX-6-CTR",
-      "parent_id": "CZQX-CTR"
+      "parent_id": "CZQX-CTR",
+      "controlled_by": [
+        "CZQX_6_CTR",
+        "CZQM_6_CTR"
+      ]
     },
     {
       "id": "CZQX-7-CTR",
-      "parent_id": "CZQX-CTR"
-    },
-    {
-      "id": "CZQX-G-CTR",
-      "parent_id": "CZQX-CTR"
-    },
-    {
-      "id": "CZQX-O-CTR",
-      "parent_id": "CZQX-CTR"
+      "parent_id": "CZQX-CTR",
+      "controlled_by": [
+        "CZQX_7_CTR",
+        "CZQM_7_CTR"
+      ]
     },
     {
       "id": "CZQM-L",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_L_APP"]
+      "controlled_by": [
+        "CZQM_L_APP"
+      ]
     },
     {
       "id": "CYHZ-TMA",
       "parent_id": "CZQM-L",
-      "controlled_by": ["CYHZ_APP"]
+      "controlled_by": [
+        "CYHZ_APP"
+      ]
     },
     {
       "id": "CYHZ-TMA-FI",
       "parent_id": "CYHZ-TMA",
-      "controlled_by": ["CYHZ_FI_APP"]
+      "controlled_by": [
+        "CYHZ_FI_APP"
+      ]
     },
     {
       "id": "CYHZ-TWR",
       "parent_id": "CYHZ-TMA-FI",
-      "controlled_by": ["CYHZ_TWR"]
+      "controlled_by": [
+        "CYHZ_TWR"
+      ]
     },
     {
       "id": "CYHZ-GND",
       "parent_id": "CYHZ-TWR",
-      "controlled_by": ["CYHZ_GND"]
+      "controlled_by": [
+        "CYHZ_GND"
+      ]
     },
     {
       "id": "CYHZ-DEL",
       "parent_id": "CYHZ-GND",
-      "controlled_by": ["CYHZ_DEL"]
+      "controlled_by": [
+        "CYHZ_DEL"
+      ]
     },
     {
       "id": "CYZX-TMA",
       "parent_id": "CYHZ-TMA",
-      "controlled_by": ["CYZX_APP"]
+      "controlled_by": [
+        "CYZX_APP"
+      ]
     },
     {
       "id": "CYZX-TWR",
       "parent_id": "CYZX-TMA",
-      "controlled_by": ["CYZX_TWR"]
+      "controlled_by": [
+        "CYZX_TWR"
+      ]
     },
     {
       "id": "CYZX-GND",
       "parent_id": "CYZX-TWR",
-      "controlled_by": ["CYZX_GND"]
+      "controlled_by": [
+        "CYZX_GND"
+      ]
     },
     {
       "id": "CYZX-DEL",
       "parent_id": "CYZX-GND",
-      "controlled_by": ["CYZX_DEL"]
+      "controlled_by": [
+        "CYZX_DEL"
+      ]
     },
     {
       "id": "CZQM-QM",
       "parent_id": "CZQM-L",
-      "controlled_by": ["CYQM_APP"]
+      "controlled_by": [
+        "CYQM_APP"
+      ]
     },
     {
       "id": "CYQM-TWR",
       "parent_id": "CZQM-QM",
-      "controlled_by": ["CYQM_TWR"]
+      "controlled_by": [
+        "CYQM_TWR"
+      ]
     },
     {
       "id": "CYQM-GND",
       "parent_id": "CYQM-TWR",
-      "controlled_by": ["CYQM_GND"]
+      "controlled_by": [
+        "CYQM_GND"
+      ]
     },
     {
       "id": "CZQM-SJ",
       "parent_id": "CZQM-QM",
-      "controlled_by": ["CYSJ_APP"]
+      "controlled_by": [
+        "CYSJ_APP"
+      ]
     },
     {
       "id": "CYFC-TWR",
       "parent_id": "CZQM-SJ",
-      "controlled_by": ["CYFC_TWR"]
+      "controlled_by": [
+        "CYFC_TWR"
+      ]
     },
     {
       "id": "CYFC-GND",
       "parent_id": "CYFC-TWR",
-      "controlled_by": ["CYFC_GND"]
+      "controlled_by": [
+        "CYFC_GND"
+      ]
     },
     {
       "id": "CYSJ-MF",
       "parent_id": "CZQM-SJ",
-      "controlled_by": ["CYSJ_F_TWR"]
+      "controlled_by": [
+        "CYSJ_F_TWR"
+      ]
     },
     {
       "id": "CYYG-MF",
       "parent_id": "CZQM-QM",
-      "controlled_by": ["CYYG_F_TWR"]
+      "controlled_by": [
+        "CYYG_F_TWR"
+      ]
     },
     {
       "id": "CZQM-DG",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_DG_CTR"]
+      "controlled_by": [
+        "CZQM_DG_CTR"
+      ]
     },
     {
       "id": "CZQM-ZV",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_ZV_CTR"]
+      "controlled_by": [
+        "CZQM_ZV_CTR"
+      ]
     },
     {
       "id": "CZQM-CB",
       "parent_id": "CZQM-CTR",
-      "controlled_by": ["CZQM_CB_CTR"]
+      "controlled_by": [
+        "CZQM_CB_CTR"
+      ]
     },
     {
       "id": "CYQX-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CYQX_APP"]
+      "controlled_by": [
+        "CYQX_APP"
+      ]
     },
     {
       "id": "CYQX-TWR",
       "parent_id": "CYQX-APP",
-      "controlled_by": ["CYQX_TWR"]
+      "controlled_by": [
+        "CYQX_TWR"
+      ]
     },
     {
       "id": "CYQX-GND",
       "parent_id": "CYQX-TWR",
-      "controlled_by": ["CYQX_GND"]
+      "controlled_by": [
+        "CYQX_GND"
+      ]
     },
     {
       "id": "CYYT-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CYYT_APP"]
+      "controlled_by": [
+        "CYYT_APP"
+      ]
     },
     {
       "id": "CYYT-TWR",
       "parent_id": "CYYT-APP",
-      "controlled_by": ["CYYT_TWR"]
+      "controlled_by": [
+        "CYYT_TWR"
+      ]
     },
     {
       "id": "CYYT-GND",
       "parent_id": "CYYT-TWR",
-      "controlled_by": ["CYYT_GND"]
+      "controlled_by": [
+        "CYYT_GND"
+      ]
     },
     {
       "id": "CYYR-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CYYR_APP"]
+      "controlled_by": [
+        "CYYR_APP"
+      ]
     },
     {
       "id": "CYYR-TWR",
       "parent_id": "CYYR-APP",
-      "controlled_by": ["CYYR_TWR"]
+      "controlled_by": [
+        "CYYR_TWR"
+      ]
     },
     {
       "id": "CYYR-GND",
       "parent_id": "CYYR-TWR",
-      "controlled_by": ["CYYR_GND"]
+      "controlled_by": [
+        "CYYR_GND"
+      ]
     },
     {
       "id": "CYYR-DEL",
       "parent_id": "CYYR-GND",
-      "controlled_by": ["CYYR_DEL"]
+      "controlled_by": [
+        "CYYR_DEL"
+      ]
     },
     {
       "id": "LFVP-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["LFVP_APP"]
+      "controlled_by": [
+        "LFVP_APP"
+      ]
     },
     {
       "id": "LFVP-TWR",
       "parent_id": "LFVP-APP",
-      "controlled_by": ["LFVP_TWR"]
+      "controlled_by": [
+        "LFVP_TWR"
+      ]
     },
     {
       "id": "CYDF-MF",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CYDF_F_TWR"]
+      "controlled_by": [
+        "CYDF_F_TWR"
+      ]
     },
     {
       "id": "CYJT-MF",
       "parent_id": "CZQX-CTR",
-      "controlled_by": ["CYJT_F_TWR"]
+      "controlled_by": [
+        "CYJT_F_TWR"
+      ]
     }
   ]
 }

--- a/dataset/CZQM/stations.json
+++ b/dataset/CZQM/stations.json
@@ -2,381 +2,261 @@
   "stations": [
     {
       "id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_CTR",
-        "CZQX_CTR"
-      ]
+      "controlled_by": ["CZQM_CTR", "CZQX_CTR"]
     },
     {
       "id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_CTR",
-        "CZQM_CTR"
-      ]
+      "controlled_by": ["CZQX_CTR", "CZQM_CTR"]
     },
     {
       "id": "CZQM-1-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_1_CTR",
-        "CZQX_1_CTR"
-      ]
+      "controlled_by": ["CZQM_1_CTR", "CZQX_1_CTR"]
     },
     {
       "id": "CZQM-2-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_2_CTR",
-        "CZQX_2_CTR"
-      ]
+      "controlled_by": ["CZQM_2_CTR", "CZQX_2_CTR"]
     },
     {
       "id": "CZQM-3-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_3_CTR",
-        "CZQX_3_CTR"
-      ]
+      "controlled_by": ["CZQM_3_CTR", "CZQX_3_CTR"]
     },
     {
       "id": "CZQM-4-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_4_CTR",
-        "CZQX_4_CTR"
-      ]
+      "controlled_by": ["CZQM_4_CTR", "CZQX_4_CTR"]
     },
     {
       "id": "CZQM-5-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_5_CTR",
-        "CZQX_5_CTR"
-      ]
+      "controlled_by": ["CZQM_5_CTR", "CZQX_5_CTR"]
     },
     {
       "id": "CZQM-6-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_6_CTR",
-        "CZQX_6_CTR"
-      ]
+      "controlled_by": ["CZQM_6_CTR", "CZQX_6_CTR"]
     },
     {
       "id": "CZQM-7-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_7_CTR",
-        "CZQX_7_CTR"
-      ]
+      "controlled_by": ["CZQM_7_CTR", "CZQX_7_CTR"]
     },
     {
       "id": "CZQM-8-CTR",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_8_CTR"
-      ]
+      "controlled_by": ["CZQM_8_CTR"]
     },
     {
       "id": "CZQX-1-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_1_CTR",
-        "CZQM_1_CTR"
-      ]
+      "controlled_by": ["CZQX_1_CTR", "CZQM_1_CTR"]
     },
     {
       "id": "CZQX-2-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_2_CTR",
-        "CZQM_2_CTR"
-      ]
+      "controlled_by": ["CZQX_2_CTR", "CZQM_2_CTR"]
     },
     {
       "id": "CZQX-3-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_3_CTR",
-        "CZQM_3_CTR"
-      ]
+      "controlled_by": ["CZQX_3_CTR", "CZQM_3_CTR"]
     },
     {
       "id": "CZQX-4-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_4_CTR",
-        "CZQM_4_CTR"
-      ]
+      "controlled_by": ["CZQX_4_CTR", "CZQM_4_CTR"]
     },
     {
       "id": "CZQX-5-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_5_CTR",
-        "CZQM_5_CTR"
-      ]
+      "controlled_by": ["CZQX_5_CTR", "CZQM_5_CTR"]
     },
     {
       "id": "CZQX-6-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_6_CTR",
-        "CZQM_6_CTR"
-      ]
+      "controlled_by": ["CZQX_6_CTR", "CZQM_6_CTR"]
     },
     {
       "id": "CZQX-7-CTR",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CZQX_7_CTR",
-        "CZQM_7_CTR"
-      ]
+      "controlled_by": ["CZQX_7_CTR", "CZQM_7_CTR"]
     },
     {
       "id": "CZQM-L",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_L_APP"
-      ]
+      "controlled_by": ["CZQM_L_APP"]
     },
     {
       "id": "CYHZ-TMA",
       "parent_id": "CZQM-L",
-      "controlled_by": [
-        "CYHZ_APP"
-      ]
+      "controlled_by": ["CYHZ_APP"]
     },
     {
       "id": "CYHZ-TMA-FI",
       "parent_id": "CYHZ-TMA",
-      "controlled_by": [
-        "CYHZ_FI_APP"
-      ]
+      "controlled_by": ["CYHZ_FI_APP"]
     },
     {
       "id": "CYHZ-TWR",
       "parent_id": "CYHZ-TMA-FI",
-      "controlled_by": [
-        "CYHZ_TWR"
-      ]
+      "controlled_by": ["CYHZ_TWR"]
     },
     {
       "id": "CYHZ-GND",
       "parent_id": "CYHZ-TWR",
-      "controlled_by": [
-        "CYHZ_GND"
-      ]
+      "controlled_by": ["CYHZ_GND"]
     },
     {
       "id": "CYHZ-DEL",
       "parent_id": "CYHZ-GND",
-      "controlled_by": [
-        "CYHZ_DEL"
-      ]
+      "controlled_by": ["CYHZ_DEL"]
     },
     {
       "id": "CYZX-TMA",
       "parent_id": "CYHZ-TMA",
-      "controlled_by": [
-        "CYZX_APP"
-      ]
+      "controlled_by": ["CYZX_APP"]
     },
     {
       "id": "CYZX-TWR",
       "parent_id": "CYZX-TMA",
-      "controlled_by": [
-        "CYZX_TWR"
-      ]
+      "controlled_by": ["CYZX_TWR"]
     },
     {
       "id": "CYZX-GND",
       "parent_id": "CYZX-TWR",
-      "controlled_by": [
-        "CYZX_GND"
-      ]
+      "controlled_by": ["CYZX_GND"]
     },
     {
       "id": "CYZX-DEL",
       "parent_id": "CYZX-GND",
-      "controlled_by": [
-        "CYZX_DEL"
-      ]
+      "controlled_by": ["CYZX_DEL"]
     },
     {
       "id": "CZQM-QM",
       "parent_id": "CZQM-L",
-      "controlled_by": [
-        "CYQM_APP"
-      ]
+      "controlled_by": ["CYQM_APP"]
     },
     {
       "id": "CYQM-TWR",
       "parent_id": "CZQM-QM",
-      "controlled_by": [
-        "CYQM_TWR"
-      ]
+      "controlled_by": ["CYQM_TWR"]
     },
     {
       "id": "CYQM-GND",
       "parent_id": "CYQM-TWR",
-      "controlled_by": [
-        "CYQM_GND"
-      ]
+      "controlled_by": ["CYQM_GND"]
     },
     {
       "id": "CZQM-SJ",
       "parent_id": "CZQM-QM",
-      "controlled_by": [
-        "CYSJ_APP"
-      ]
+      "controlled_by": ["CYSJ_APP"]
     },
     {
       "id": "CYFC-TWR",
       "parent_id": "CZQM-SJ",
-      "controlled_by": [
-        "CYFC_TWR"
-      ]
+      "controlled_by": ["CYFC_TWR"]
     },
     {
       "id": "CYFC-GND",
       "parent_id": "CYFC-TWR",
-      "controlled_by": [
-        "CYFC_GND"
-      ]
+      "controlled_by": ["CYFC_GND"]
     },
     {
       "id": "CYSJ-MF",
       "parent_id": "CZQM-SJ",
-      "controlled_by": [
-        "CYSJ_F_TWR"
-      ]
+      "controlled_by": ["CYSJ_F_TWR"]
     },
     {
       "id": "CYYG-MF",
       "parent_id": "CZQM-QM",
-      "controlled_by": [
-        "CYYG_F_TWR"
-      ]
+      "controlled_by": ["CYYG_F_TWR"]
     },
     {
       "id": "CZQM-DG",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_DG_CTR"
-      ]
+      "controlled_by": ["CZQM_DG_CTR"]
     },
     {
       "id": "CZQM-ZV",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_ZV_CTR"
-      ]
+      "controlled_by": ["CZQM_ZV_CTR"]
     },
     {
       "id": "CZQM-CB",
       "parent_id": "CZQM-CTR",
-      "controlled_by": [
-        "CZQM_CB_CTR"
-      ]
+      "controlled_by": ["CZQM_CB_CTR"]
     },
     {
       "id": "CYQX-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CYQX_APP"
-      ]
+      "controlled_by": ["CYQX_APP"]
     },
     {
       "id": "CYQX-TWR",
       "parent_id": "CYQX-APP",
-      "controlled_by": [
-        "CYQX_TWR"
-      ]
+      "controlled_by": ["CYQX_TWR"]
     },
     {
       "id": "CYQX-GND",
       "parent_id": "CYQX-TWR",
-      "controlled_by": [
-        "CYQX_GND"
-      ]
+      "controlled_by": ["CYQX_GND"]
     },
     {
       "id": "CYYT-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CYYT_APP"
-      ]
+      "controlled_by": ["CYYT_APP"]
     },
     {
       "id": "CYYT-TWR",
       "parent_id": "CYYT-APP",
-      "controlled_by": [
-        "CYYT_TWR"
-      ]
+      "controlled_by": ["CYYT_TWR"]
     },
     {
       "id": "CYYT-GND",
       "parent_id": "CYYT-TWR",
-      "controlled_by": [
-        "CYYT_GND"
-      ]
+      "controlled_by": ["CYYT_GND"]
     },
     {
       "id": "CYYR-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CYYR_APP"
-      ]
+      "controlled_by": ["CYYR_APP"]
     },
     {
       "id": "CYYR-TWR",
       "parent_id": "CYYR-APP",
-      "controlled_by": [
-        "CYYR_TWR"
-      ]
+      "controlled_by": ["CYYR_TWR"]
     },
     {
       "id": "CYYR-GND",
       "parent_id": "CYYR-TWR",
-      "controlled_by": [
-        "CYYR_GND"
-      ]
+      "controlled_by": ["CYYR_GND"]
     },
     {
       "id": "CYYR-DEL",
       "parent_id": "CYYR-GND",
-      "controlled_by": [
-        "CYYR_DEL"
-      ]
+      "controlled_by": ["CYYR_DEL"]
     },
     {
       "id": "LFVP-APP",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "LFVP_APP"
-      ]
+      "controlled_by": ["LFVP_APP"]
     },
     {
       "id": "LFVP-TWR",
       "parent_id": "LFVP-APP",
-      "controlled_by": [
-        "LFVP_TWR"
-      ]
+      "controlled_by": ["LFVP_TWR"]
     },
     {
       "id": "CYDF-MF",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CYDF_F_TWR"
-      ]
+      "controlled_by": ["CYDF_F_TWR"]
     },
     {
       "id": "CYJT-MF",
       "parent_id": "CZQX-CTR",
-      "controlled_by": [
-        "CYJT_F_TWR"
-      ]
+      "controlled_by": ["CYJT_F_TWR"]
     }
   ]
 }

--- a/dataset/NAT/profiles/NAT.json
+++ b/dataset/NAT/profiles/NAT.json
@@ -13,46 +13,79 @@
       "gap": 0.75,
       "children": [
         {
-          "label": ["Edmonton", "(INOP)"],
+          "label": [
+            "Edmonton",
+            "(INOP)"
+          ],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": ["INOP"]
+                "label": [
+                  "INOP"
+                ]
               }
             ]
           }
         },
         {
-          "label": ["Montreal", "(INOP)"],
+          "label": [
+            "Montreal",
+            "(INOP)"
+          ],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": ["INOP"]
+                "label": [
+                  "INOP"
+                ]
               }
             ]
           }
         },
         {
-          "label": ["Gander", "Domestic"],
+          "label": [
+            "Gander",
+            "Domestic"
+          ],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": ["Gander", "Domestic"],
+                "label": [
+                  "Gander",
+                  "Domestic"
+                ],
                 "station_id": "CZQX-CTR"
               },
               {
-                "label": ["GOTA", "North", "(G)"],
-                "station_id": "CZQX-G-CTR"
+                "label": [
+                  "GOTA",
+                  "North",
+                  "QX 7"
+                ],
+                "station_id": "CZQX-7-CTR"
               },
               {
-                "label": ["GOTA", "South", "(O)"],
-                "station_id": "CZQX-O-CTR"
+                "label": [
+                  "GOTA",
+                  "South",
+                  "QX 6"
+                ],
+                "station_id": "CZQX-6-CTR"
+              },
+              {
+                "label": []
+              },
+              {
+                "label": []
+              },
+              {
+                "label": []
               },
               {
                 "label": []
@@ -67,45 +100,56 @@
                 "label": []
               },
               {
-                "label": []
-              },
-              {
-                "label": []
-              },
-              {
-                "label": []
-              },
-              {
-                "label": ["QX", "5"],
+                "label": [
+                  "QX",
+                  "5"
+                ],
                 "station_id": "CZQX-5-CTR"
               },
               {
-                "label": ["QX", "4"],
+                "label": [
+                  "QX",
+                  "4"
+                ],
                 "station_id": "CZQX-4-CTR"
               },
               {
-                "label": ["QX", "3"],
+                "label": [
+                  "QX",
+                  "3"
+                ],
                 "station_id": "CZQX-3-CTR"
               },
               {
-                "label": ["QX", "2"],
+                "label": [
+                  "QX",
+                  "2"
+                ],
                 "station_id": "CZQX-2-CTR"
               },
               {
-                "label": ["QX", "1"],
+                "label": [
+                  "QX",
+                  "1"
+                ],
                 "station_id": "CZQX-1-CTR"
               }
             ]
           }
         },
         {
-          "label": ["New York", "(INOP)"],
+          "label": [
+            "New York",
+            "(INOP)"
+          ],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": ["INOP"]
+                "label": [
+                  "INOP"
+                ]
               }
             ]
           }
@@ -123,46 +167,97 @@
           "justify_content": "center",
           "children": [
             {
-              "label": ["Reykjavík", "(INOP)"],
+              "label": [
+                "Reykjavík",
+                "(INOP)"
+              ],
               "size": 7,
               "page": {
                 "rows": 4,
                 "keys": [
                   {
-                    "label": ["West", "Upper", "365-660"]
+                    "label": [
+                      "West",
+                      "Upper",
+                      "365-660"
+                    ]
                   },
                   {
-                    "label": ["West", "Middle", "355-365"]
+                    "label": [
+                      "West",
+                      "Middle",
+                      "355-365"
+                    ]
                   },
                   {
-                    "label": ["West", "Middle", "345-355"]
+                    "label": [
+                      "West",
+                      "Middle",
+                      "345-355"
+                    ]
                   },
                   {
-                    "label": ["West", "Lower", "55-345"]
+                    "label": [
+                      "West",
+                      "Lower",
+                      "55-345"
+                    ]
                   },
                   {
-                    "label": ["South", "Upper", "365-660"]
+                    "label": [
+                      "South",
+                      "Upper",
+                      "365-660"
+                    ]
                   },
                   {
-                    "label": ["South", "Middle", "355-365"]
+                    "label": [
+                      "South",
+                      "Middle",
+                      "355-365"
+                    ]
                   },
                   {
-                    "label": ["South", "Middle", "345-355"]
+                    "label": [
+                      "South",
+                      "Middle",
+                      "345-355"
+                    ]
                   },
                   {
-                    "label": ["South", "Lower", "55-345"]
+                    "label": [
+                      "South",
+                      "Lower",
+                      "55-345"
+                    ]
                   },
                   {
-                    "label": ["East", "Upper", "365-660"]
+                    "label": [
+                      "East",
+                      "Upper",
+                      "365-660"
+                    ]
                   },
                   {
-                    "label": ["East", "Middle", "355-365"]
+                    "label": [
+                      "East",
+                      "Middle",
+                      "355-365"
+                    ]
                   },
                   {
-                    "label": ["East", "Middle", "345-355"]
+                    "label": [
+                      "East",
+                      "Middle",
+                      "345-355"
+                    ]
                   },
                   {
-                    "label": ["East", "Lower", "55-345"]
+                    "label": [
+                      "East",
+                      "Lower",
+                      "55-345"
+                    ]
                   }
                 ]
               }
@@ -174,56 +269,85 @@
           "gap": 3,
           "children": [
             {
-              "label": ["Gander"],
+              "label": [
+                "Gander"
+              ],
               "size": 12,
               "page": {
                 "rows": 6,
                 "keys": [
                   {
-                    "label": ["DEL", "A"],
+                    "label": [
+                      "DEL",
+                      "A"
+                    ],
                     "station_id": "Gander_DEL_A"
                   },
                   {
-                    "label": ["DEL", "B"],
+                    "label": [
+                      "DEL",
+                      "B"
+                    ],
                     "station_id": "Gander_DEL_B"
                   },
                   {
-                    "label": ["DEL", "C"],
+                    "label": [
+                      "DEL",
+                      "C"
+                    ],
                     "station_id": "Gander_DEL_C"
                   },
                   {
-                    "label": ["DEL", "D"],
+                    "label": [
+                      "DEL",
+                      "D"
+                    ],
                     "station_id": "Gander_DEL_D"
                   },
                   {
-                    "label": ["DEL", "F"],
+                    "label": [
+                      "DEL",
+                      "F"
+                    ],
                     "station_id": "Gander_DEL_F"
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": ["A"],
+                    "label": [
+                      "A"
+                    ],
                     "station_id": "Gander_A"
                   },
                   {
-                    "label": ["B"],
+                    "label": [
+                      "B"
+                    ],
                     "station_id": "Gander_B"
                   },
                   {
-                    "label": ["C"],
+                    "label": [
+                      "C"
+                    ],
                     "station_id": "Gander_C"
                   },
                   {
-                    "label": ["D"],
+                    "label": [
+                      "D"
+                    ],
                     "station_id": "Gander_D"
                   },
                   {
-                    "label": ["F"],
+                    "label": [
+                      "F"
+                    ],
                     "station_id": "Gander_F"
                   },
                   {
-                    "label": ["G"],
+                    "label": [
+                      "G"
+                    ],
                     "station_id": "Gander_G"
                   },
                   {
@@ -233,11 +357,15 @@
                     "label": []
                   },
                   {
-                    "label": ["Gander"],
+                    "label": [
+                      "Gander"
+                    ],
                     "station_id": "Gander"
                   },
                   {
-                    "label": ["DEL"],
+                    "label": [
+                      "DEL"
+                    ],
                     "station_id": "Gander_DEL"
                   },
                   {
@@ -250,49 +378,76 @@
               }
             },
             {
-              "label": ["Shanwick"],
+              "label": [
+                "Shanwick"
+              ],
               "size": 12,
               "page": {
                 "rows": 5,
                 "keys": [
                   {
-                    "label": ["DEL", "A"],
+                    "label": [
+                      "DEL",
+                      "A"
+                    ],
                     "station_id": "Shanwick_DEL_A"
                   },
                   {
-                    "label": ["DEL", "B"],
+                    "label": [
+                      "DEL",
+                      "B"
+                    ],
                     "station_id": "Shanwick_DEL_B"
                   },
                   {
-                    "label": ["DEL", "C"],
+                    "label": [
+                      "DEL",
+                      "C"
+                    ],
                     "station_id": "Shanwick_DEL_C"
                   },
                   {
-                    "label": ["DEL", "D"],
+                    "label": [
+                      "DEL",
+                      "D"
+                    ],
                     "station_id": "Shanwick_DEL_D"
                   },
                   {
-                    "label": ["DEL", "F"],
+                    "label": [
+                      "DEL",
+                      "F"
+                    ],
                     "station_id": "Shanwick_DEL_F"
                   },
                   {
-                    "label": ["A"],
+                    "label": [
+                      "A"
+                    ],
                     "station_id": "Shanwick_A"
                   },
                   {
-                    "label": ["B"],
+                    "label": [
+                      "B"
+                    ],
                     "station_id": "Shanwick_B"
                   },
                   {
-                    "label": ["C"],
+                    "label": [
+                      "C"
+                    ],
                     "station_id": "Shanwick_C"
                   },
                   {
-                    "label": ["D"],
+                    "label": [
+                      "D"
+                    ],
                     "station_id": "Shanwick_D"
                   },
                   {
-                    "label": ["F"],
+                    "label": [
+                      "F"
+                    ],
                     "station_id": "Shanwick_F"
                   },
                   {
@@ -302,11 +457,15 @@
                     "label": []
                   },
                   {
-                    "label": ["Shanwick"],
+                    "label": [
+                      "Shanwick"
+                    ],
                     "station_id": "Shanwick"
                   },
                   {
-                    "label": ["DEL"],
+                    "label": [
+                      "DEL"
+                    ],
                     "station_id": "Shanwick_DEL"
                   },
                   {
@@ -322,34 +481,56 @@
           "justify_content": "center",
           "children": [
             {
-              "label": ["Santa", "Maria", "(INOP)"],
+              "label": [
+                "Santa",
+                "Maria",
+                "(INOP)"
+              ],
               "size": 7,
               "page": {
                 "rows": 3,
                 "keys": [
                   {
-                    "label": ["Oceanic", "clearance"]
+                    "label": [
+                      "Oceanic",
+                      "clearance"
+                    ]
                   },
                   {
-                    "label": ["Oceanic", "clearance", "2"]
-                  },
-                  {
-                    "label": []
-                  },
-                  {
-                    "label": ["Radio", "1"]
-                  },
-                  {
-                    "label": ["Radio", "2"]
-                  },
-                  {
-                    "label": ["Radio", "3"]
+                    "label": [
+                      "Oceanic",
+                      "clearance",
+                      "2"
+                    ]
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": ["Radio"]
+                    "label": [
+                      "Radio",
+                      "1"
+                    ]
+                  },
+                  {
+                    "label": [
+                      "Radio",
+                      "2"
+                    ]
+                  },
+                  {
+                    "label": [
+                      "Radio",
+                      "3"
+                    ]
+                  },
+                  {
+                    "label": []
+                  },
+                  {
+                    "label": [
+                      "Radio"
+                    ]
                   },
                   {
                     "label": []
@@ -368,65 +549,110 @@
       "gap": 0.75,
       "children": [
         {
-          "label": ["Scottish"],
+          "label": [
+            "Scottish"
+          ],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": ["North"],
+                "label": [
+                  "North"
+                ],
                 "station_id": "SCO_N_CTR"
               },
               {
-                "label": ["West"],
+                "label": [
+                  "West"
+                ],
                 "station_id": "SCO_W_CTR"
               }
             ]
           }
         },
         {
-          "label": ["Shannon", "Control"],
+          "label": [
+            "Shannon",
+            "Control"
+          ],
           "size": 7,
           "page": {
             "rows": 4,
             "keys": [
               {
-                "label": ["NOTA", "Super", "355+"],
+                "label": [
+                  "NOTA",
+                  "Super",
+                  "355+"
+                ],
                 "station_id": "EISN_NS_CTR"
               },
               {
-                "label": ["West", "Super", "355+"],
+                "label": [
+                  "West",
+                  "Super",
+                  "355+"
+                ],
                 "station_id": "EISN_WS_CTR"
               },
               {
-                "label": ["Ocean", "Super", "355+"],
+                "label": [
+                  "Ocean",
+                  "Super",
+                  "355+"
+                ],
                 "station_id": "EISN_SS_CTR"
               },
               {
-                "label": ["SOTA", "Super", "355+"],
+                "label": [
+                  "SOTA",
+                  "Super",
+                  "355+"
+                ],
                 "station_id": "EISN_SS_CTR"
               },
               {
-                "label": ["NOTA", "Upper", "245-355"],
+                "label": [
+                  "NOTA",
+                  "Upper",
+                  "245-355"
+                ],
                 "station_id": "EISN_N_CTR"
               },
               {
-                "label": ["West", "Upper", "245-355"],
+                "label": [
+                  "West",
+                  "Upper",
+                  "245-355"
+                ],
                 "station_id": "EISN_W_CTR"
               },
               {
-                "label": ["Ocean", "Upper", "245-355"],
+                "label": [
+                  "Ocean",
+                  "Upper",
+                  "245-355"
+                ],
                 "station_id": "EISN_O_CTR"
               },
               {
-                "label": ["SOTA", "Upper", "245-255"],
+                "label": [
+                  "SOTA",
+                  "Upper",
+                  "245-255"
+                ],
                 "station_id": "EISN_S_CTR"
               },
               {
                 "label": []
               },
               {
-                "label": ["Low", "Level", "245-"],
+                "label": [
+                  "Low",
+                  "Level",
+                  "245-"
+                ],
                 "station_id": "EISN_LS_CTR"
               },
               {
@@ -439,25 +665,40 @@
           }
         },
         {
-          "label": ["Brest", "(INOP)"],
+          "label": [
+            "Brest",
+            "(INOP)"
+          ],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": ["West", "255+"]
+                "label": [
+                  "West",
+                  "255+"
+                ]
               },
               {
-                "label": ["AU", "355-660"]
+                "label": [
+                  "AU",
+                  "355-660"
+                ]
               },
               {
                 "label": []
               },
               {
-                "label": ["AS", "255-355"]
+                "label": [
+                  "AS",
+                  "255-355"
+                ]
               },
               {
-                "label": ["Lower", "255-"]
+                "label": [
+                  "Lower",
+                  "255-"
+                ]
               },
               {
                 "label": []
@@ -466,16 +707,25 @@
           }
         },
         {
-          "label": ["Madrid", "(INOP)"],
+          "label": [
+            "Madrid",
+            "(INOP)"
+          ],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": ["Upper", "245-660"]
+                "label": [
+                  "Upper",
+                  "245-660"
+                ]
               },
               {
-                "label": ["Lower", "245-"]
+                "label": [
+                  "Lower",
+                  "245-"
+                ]
               }
             ]
           }

--- a/dataset/NAT/profiles/NAT.json
+++ b/dataset/NAT/profiles/NAT.json
@@ -13,69 +13,45 @@
       "gap": 0.75,
       "children": [
         {
-          "label": [
-            "Edmonton",
-            "(INOP)"
-          ],
+          "label": ["Edmonton", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "INOP"
-                ]
+                "label": ["INOP"]
               }
             ]
           }
         },
         {
-          "label": [
-            "Montreal",
-            "(INOP)"
-          ],
+          "label": ["Montreal", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "INOP"
-                ]
+                "label": ["INOP"]
               }
             ]
           }
         },
         {
-          "label": [
-            "Gander",
-            "Domestic"
-          ],
+          "label": ["Gander", "Domestic"],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "Gander",
-                  "Domestic"
-                ],
+                "label": ["Gander", "Domestic"],
                 "station_id": "CZQX-CTR"
               },
               {
-                "label": [
-                  "GOTA",
-                  "North",
-                  "QX 7"
-                ],
+                "label": ["GOTA", "North", "QX 7"],
                 "station_id": "CZQX-7-CTR"
               },
               {
-                "label": [
-                  "GOTA",
-                  "South",
-                  "QX 6"
-                ],
+                "label": ["GOTA", "South", "QX 6"],
                 "station_id": "CZQX-6-CTR"
               },
               {
@@ -100,56 +76,36 @@
                 "label": []
               },
               {
-                "label": [
-                  "QX",
-                  "5"
-                ],
+                "label": ["QX", "5"],
                 "station_id": "CZQX-5-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "4"
-                ],
+                "label": ["QX", "4"],
                 "station_id": "CZQX-4-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "3"
-                ],
+                "label": ["QX", "3"],
                 "station_id": "CZQX-3-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "2"
-                ],
+                "label": ["QX", "2"],
                 "station_id": "CZQX-2-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "1"
-                ],
+                "label": ["QX", "1"],
                 "station_id": "CZQX-1-CTR"
               }
             ]
           }
         },
         {
-          "label": [
-            "New York",
-            "(INOP)"
-          ],
+          "label": ["New York", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "INOP"
-                ]
+                "label": ["INOP"]
               }
             ]
           }
@@ -167,97 +123,46 @@
           "justify_content": "center",
           "children": [
             {
-              "label": [
-                "Reykjavík",
-                "(INOP)"
-              ],
+              "label": ["Reykjavík", "(INOP)"],
               "size": 7,
               "page": {
                 "rows": 4,
                 "keys": [
                   {
-                    "label": [
-                      "West",
-                      "Upper",
-                      "365-660"
-                    ]
+                    "label": ["West", "Upper", "365-660"]
                   },
                   {
-                    "label": [
-                      "West",
-                      "Middle",
-                      "355-365"
-                    ]
+                    "label": ["West", "Middle", "355-365"]
                   },
                   {
-                    "label": [
-                      "West",
-                      "Middle",
-                      "345-355"
-                    ]
+                    "label": ["West", "Middle", "345-355"]
                   },
                   {
-                    "label": [
-                      "West",
-                      "Lower",
-                      "55-345"
-                    ]
+                    "label": ["West", "Lower", "55-345"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Upper",
-                      "365-660"
-                    ]
+                    "label": ["South", "Upper", "365-660"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Middle",
-                      "355-365"
-                    ]
+                    "label": ["South", "Middle", "355-365"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Middle",
-                      "345-355"
-                    ]
+                    "label": ["South", "Middle", "345-355"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Lower",
-                      "55-345"
-                    ]
+                    "label": ["South", "Lower", "55-345"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Upper",
-                      "365-660"
-                    ]
+                    "label": ["East", "Upper", "365-660"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Middle",
-                      "355-365"
-                    ]
+                    "label": ["East", "Middle", "355-365"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Middle",
-                      "345-355"
-                    ]
+                    "label": ["East", "Middle", "345-355"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Lower",
-                      "55-345"
-                    ]
+                    "label": ["East", "Lower", "55-345"]
                   }
                 ]
               }
@@ -269,85 +174,56 @@
           "gap": 3,
           "children": [
             {
-              "label": [
-                "Gander"
-              ],
+              "label": ["Gander"],
               "size": 12,
               "page": {
                 "rows": 6,
                 "keys": [
                   {
-                    "label": [
-                      "DEL",
-                      "A"
-                    ],
+                    "label": ["DEL", "A"],
                     "station_id": "Gander_DEL_A"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "B"
-                    ],
+                    "label": ["DEL", "B"],
                     "station_id": "Gander_DEL_B"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "C"
-                    ],
+                    "label": ["DEL", "C"],
                     "station_id": "Gander_DEL_C"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "D"
-                    ],
+                    "label": ["DEL", "D"],
                     "station_id": "Gander_DEL_D"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "F"
-                    ],
+                    "label": ["DEL", "F"],
                     "station_id": "Gander_DEL_F"
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": [
-                      "A"
-                    ],
+                    "label": ["A"],
                     "station_id": "Gander_A"
                   },
                   {
-                    "label": [
-                      "B"
-                    ],
+                    "label": ["B"],
                     "station_id": "Gander_B"
                   },
                   {
-                    "label": [
-                      "C"
-                    ],
+                    "label": ["C"],
                     "station_id": "Gander_C"
                   },
                   {
-                    "label": [
-                      "D"
-                    ],
+                    "label": ["D"],
                     "station_id": "Gander_D"
                   },
                   {
-                    "label": [
-                      "F"
-                    ],
+                    "label": ["F"],
                     "station_id": "Gander_F"
                   },
                   {
-                    "label": [
-                      "G"
-                    ],
+                    "label": ["G"],
                     "station_id": "Gander_G"
                   },
                   {
@@ -357,15 +233,11 @@
                     "label": []
                   },
                   {
-                    "label": [
-                      "Gander"
-                    ],
+                    "label": ["Gander"],
                     "station_id": "Gander"
                   },
                   {
-                    "label": [
-                      "DEL"
-                    ],
+                    "label": ["DEL"],
                     "station_id": "Gander_DEL"
                   },
                   {
@@ -378,76 +250,49 @@
               }
             },
             {
-              "label": [
-                "Shanwick"
-              ],
+              "label": ["Shanwick"],
               "size": 12,
               "page": {
                 "rows": 5,
                 "keys": [
                   {
-                    "label": [
-                      "DEL",
-                      "A"
-                    ],
+                    "label": ["DEL", "A"],
                     "station_id": "Shanwick_DEL_A"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "B"
-                    ],
+                    "label": ["DEL", "B"],
                     "station_id": "Shanwick_DEL_B"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "C"
-                    ],
+                    "label": ["DEL", "C"],
                     "station_id": "Shanwick_DEL_C"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "D"
-                    ],
+                    "label": ["DEL", "D"],
                     "station_id": "Shanwick_DEL_D"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "F"
-                    ],
+                    "label": ["DEL", "F"],
                     "station_id": "Shanwick_DEL_F"
                   },
                   {
-                    "label": [
-                      "A"
-                    ],
+                    "label": ["A"],
                     "station_id": "Shanwick_A"
                   },
                   {
-                    "label": [
-                      "B"
-                    ],
+                    "label": ["B"],
                     "station_id": "Shanwick_B"
                   },
                   {
-                    "label": [
-                      "C"
-                    ],
+                    "label": ["C"],
                     "station_id": "Shanwick_C"
                   },
                   {
-                    "label": [
-                      "D"
-                    ],
+                    "label": ["D"],
                     "station_id": "Shanwick_D"
                   },
                   {
-                    "label": [
-                      "F"
-                    ],
+                    "label": ["F"],
                     "station_id": "Shanwick_F"
                   },
                   {
@@ -457,15 +302,11 @@
                     "label": []
                   },
                   {
-                    "label": [
-                      "Shanwick"
-                    ],
+                    "label": ["Shanwick"],
                     "station_id": "Shanwick"
                   },
                   {
-                    "label": [
-                      "DEL"
-                    ],
+                    "label": ["DEL"],
                     "station_id": "Shanwick_DEL"
                   },
                   {
@@ -481,56 +322,34 @@
           "justify_content": "center",
           "children": [
             {
-              "label": [
-                "Santa",
-                "Maria",
-                "(INOP)"
-              ],
+              "label": ["Santa", "Maria", "(INOP)"],
               "size": 7,
               "page": {
                 "rows": 3,
                 "keys": [
                   {
-                    "label": [
-                      "Oceanic",
-                      "clearance"
-                    ]
+                    "label": ["Oceanic", "clearance"]
                   },
                   {
-                    "label": [
-                      "Oceanic",
-                      "clearance",
-                      "2"
-                    ]
+                    "label": ["Oceanic", "clearance", "2"]
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": [
-                      "Radio",
-                      "1"
-                    ]
+                    "label": ["Radio", "1"]
                   },
                   {
-                    "label": [
-                      "Radio",
-                      "2"
-                    ]
+                    "label": ["Radio", "2"]
                   },
                   {
-                    "label": [
-                      "Radio",
-                      "3"
-                    ]
+                    "label": ["Radio", "3"]
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": [
-                      "Radio"
-                    ]
+                    "label": ["Radio"]
                   },
                   {
                     "label": []
@@ -549,110 +368,65 @@
       "gap": 0.75,
       "children": [
         {
-          "label": [
-            "Scottish"
-          ],
+          "label": ["Scottish"],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": [
-                  "North"
-                ],
+                "label": ["North"],
                 "station_id": "SCO_N_CTR"
               },
               {
-                "label": [
-                  "West"
-                ],
+                "label": ["West"],
                 "station_id": "SCO_W_CTR"
               }
             ]
           }
         },
         {
-          "label": [
-            "Shannon",
-            "Control"
-          ],
+          "label": ["Shannon", "Control"],
           "size": 7,
           "page": {
             "rows": 4,
             "keys": [
               {
-                "label": [
-                  "NOTA",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["NOTA", "Super", "355+"],
                 "station_id": "EISN_NS_CTR"
               },
               {
-                "label": [
-                  "West",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["West", "Super", "355+"],
                 "station_id": "EISN_WS_CTR"
               },
               {
-                "label": [
-                  "Ocean",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["Ocean", "Super", "355+"],
                 "station_id": "EISN_SS_CTR"
               },
               {
-                "label": [
-                  "SOTA",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["SOTA", "Super", "355+"],
                 "station_id": "EISN_SS_CTR"
               },
               {
-                "label": [
-                  "NOTA",
-                  "Upper",
-                  "245-355"
-                ],
+                "label": ["NOTA", "Upper", "245-355"],
                 "station_id": "EISN_N_CTR"
               },
               {
-                "label": [
-                  "West",
-                  "Upper",
-                  "245-355"
-                ],
+                "label": ["West", "Upper", "245-355"],
                 "station_id": "EISN_W_CTR"
               },
               {
-                "label": [
-                  "Ocean",
-                  "Upper",
-                  "245-355"
-                ],
+                "label": ["Ocean", "Upper", "245-355"],
                 "station_id": "EISN_O_CTR"
               },
               {
-                "label": [
-                  "SOTA",
-                  "Upper",
-                  "245-255"
-                ],
+                "label": ["SOTA", "Upper", "245-255"],
                 "station_id": "EISN_S_CTR"
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "Low",
-                  "Level",
-                  "245-"
-                ],
+                "label": ["Low", "Level", "245-"],
                 "station_id": "EISN_LS_CTR"
               },
               {
@@ -665,40 +439,25 @@
           }
         },
         {
-          "label": [
-            "Brest",
-            "(INOP)"
-          ],
+          "label": ["Brest", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": [
-                  "West",
-                  "255+"
-                ]
+                "label": ["West", "255+"]
               },
               {
-                "label": [
-                  "AU",
-                  "355-660"
-                ]
+                "label": ["AU", "355-660"]
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "AS",
-                  "255-355"
-                ]
+                "label": ["AS", "255-355"]
               },
               {
-                "label": [
-                  "Lower",
-                  "255-"
-                ]
+                "label": ["Lower", "255-"]
               },
               {
                 "label": []
@@ -707,25 +466,16 @@
           }
         },
         {
-          "label": [
-            "Madrid",
-            "(INOP)"
-          ],
+          "label": ["Madrid", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": [
-                  "Upper",
-                  "245-660"
-                ]
+                "label": ["Upper", "245-660"]
               },
               {
-                "label": [
-                  "Lower",
-                  "245-"
-                ]
+                "label": ["Lower", "245-"]
               }
             ]
           }


### PR DESCRIPTION
- Updated JSON structure for CZQM and CZQX profiles to improve readability by formatting labels as arrays.
- Added controlled_by relationships for CZQM and CZQX stations to enhance clarity on station control.
- Removed redundant entries from controlled_by lists for CZQM and CZQX stations.
- Ensured consistent formatting across all station entries for better maintainability.

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
