### PR TITLE
feat(LK): add initial dataset with stations and positions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@ CONTRIBUTING.md @vacs-project/maintainers
 /dataset/LH/ @vacs-project/dataset-maintainers-lh
 /dataset/LI/ @vacs-project/dataset-maintainers-li
 /dataset/LJ/ @vacs-project/dataset-maintainers-adr
+/dataset/LK/ @vacs-project/dataset-maintainers-lk
 /dataset/LM/ @vacs-project/dataset-maintainers-lm
 /dataset/LO/ @vacs-project/dataset-maintainers-lo
 /dataset/LPPC/ @vacs-project/dataset-maintainers-lppc

--- a/dataset/LK/positions.toml
+++ b/dataset/LK/positions.toml
@@ -1,0 +1,197 @@
+[[positions]]
+id = "LKAA_CTR"
+prefixes = ["LKAA"]
+frequency = "127.125"
+facility_type = "CTR"
+
+[[positions]]
+id = "LKAA_U_CTR"
+prefixes = ["LKAA"]
+frequency = "124.775"
+facility_type = "CTR"
+
+[[positions]]
+id = "LKAA_L_CTR"
+prefixes = ["LKAA"]
+frequency = "135.135"
+facility_type = "CTR"
+
+[[positions]]
+id = "LKAA_R_CTR"
+prefixes = ["LKAA"]
+frequency = "124.050"
+facility_type = "CTR"
+
+[[positions]]
+id = "LKAA_N_CTR"
+prefixes = ["LKAA"]
+frequency = "127.825"
+facility_type = "CTR"
+
+[[positions]]
+id = "LKAA_S_CTR"
+prefixes = ["LKAA"]
+frequency = "133.410"
+facility_type = "CTR"
+
+[[positions]]
+id = "LKAA_W_CTR"
+prefixes = ["LKAA"]
+frequency = "120.275"
+facility_type = "CTR"
+
+[[positions]]
+id = "LKAA_I_CTR"
+prefixes = ["LKAA"]
+frequency = "126.100"
+facility_type = "CTR"
+
+[[positions]]
+id = "LKPR_APP"
+prefixes = ["LKPR"]
+frequency = "127.580"
+facility_type = "APP"
+
+[[positions]]
+id = "LKPR_D_APP"
+prefixes = ["LKPR"]
+frequency = "119.010"
+facility_type = "APP"
+
+[[positions]]
+id = "LKPR_DEP"
+prefixes = ["LKPR"]
+frequency = "120.530"
+facility_type = "DEP"
+
+[[positions]]
+id = "LKCV_APP"
+prefixes = ["LKCV"]
+frequency = "130.280"
+facility_type = "APP"
+
+[[positions]]
+id = "LKKB_APP"
+prefixes = ["LKKB"]
+frequency = "124.680"
+facility_type = "APP"
+
+[[positions]]
+id = "LKKV_APP"
+prefixes = ["LKKV"]
+frequency = "118.650"
+facility_type = "APP"
+
+[[positions]]
+id = "LKMT_APP"
+prefixes = ["LKMT"]
+frequency = "119.375"
+facility_type = "APP"
+
+[[positions]]
+id = "LKNA_APP"
+prefixes = ["LKNA"]
+frequency = "118.155"
+facility_type = "APP"
+
+[[positions]]
+id = "LKPD_APP"
+prefixes = ["LKPD"]
+frequency = "128.365"
+facility_type = "APP"
+
+[[positions]]
+id = "LKTB_APP"
+prefixes = ["LKTB"]
+frequency = "127.350"
+facility_type = "APP"
+
+[[positions]]
+id = "LKVO_APP"
+prefixes = ["LKVO"]
+frequency = "127.480"
+facility_type = "APP"
+
+[[positions]]
+id = "LKCS_I_TWR"
+prefixes = ["LKCS"]
+frequency = "135.930"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKCV_TWR"
+prefixes = ["LKCV"]
+frequency = "134.205"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKKB_TWR"
+prefixes = ["LKKB"]
+frequency = "120.880"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKKU_TWR"
+prefixes = ["LKKU"]
+frequency = "120.105"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKKV_TWR"
+prefixes = ["LKKV"]
+frequency = "121.230"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKLT_I_TWR"
+prefixes = ["LKLT"]
+frequency = "120.335"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKMT_TWR"
+prefixes = ["LKMT"]
+frequency = "120.805"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKNA_TWR"
+prefixes = ["LKNA"]
+frequency = "126.505"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKPD_TWR"
+prefixes = ["LKPD"]
+frequency = "120.155"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKPR_TWR"
+prefixes = ["LKPR"]
+frequency = "134.560"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKTB_TWR"
+prefixes = ["LKTB"]
+frequency = "119.605"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKVO_TWR"
+prefixes = ["LKVO"]
+frequency = "133.080"
+facility_type = "TWR"
+
+[[positions]]
+id = "LKPR_GND"
+prefixes = ["LKPR"]
+frequency = "121.910"
+facility_type = "GND"
+
+[[positions]]
+id = "LKPR_DEL"
+prefixes = ["LKPR"]
+frequency = "120.060"
+facility_type = "DEL"

--- a/dataset/LK/stations.toml
+++ b/dataset/LK/stations.toml
@@ -1,0 +1,233 @@
+[[stations]]
+id = "LKAA KV"
+controlled_by = [
+  "LKKV_APP",
+  "LKAA_R_CTR",
+  "LKAA_W_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKAA WL"
+controlled_by = ["LKAA_W_CTR", "LKAA_L_CTR", "LKAA_CTR"]
+
+[[stations]]
+id = "LKAA WU"
+controlled_by = ["LKAA_U_CTR", "LKAA_W_CTR", "LKAA_CTR"]
+
+[[stations]]
+id = "LKAA MT"
+controlled_by = [
+  "LKMT_APP",
+  "LKAA_R_CTR",
+  "LKAA_N_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKAA NL"
+controlled_by = ["LKAA_N_CTR", "LKAA_L_CTR", "LKAA_CTR"]
+
+[[stations]]
+id = "LKAA NU"
+controlled_by = ["LKAA_U_CTR", "LKAA_N_CTR", "LKAA_CTR"]
+
+[[stations]]
+id = "LKAA TB"
+controlled_by = [
+  "LKTB_APP",
+  "LKAA_R_CTR",
+  "LKAA_S_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKAA SL"
+controlled_by = ["LKAA_S_CTR", "LKAA_L_CTR", "LKAA_CTR"]
+
+[[stations]]
+id = "LKAA SU"
+controlled_by = ["LKAA_U_CTR", "LKAA_S_CTR", "LKAA_CTR"]
+
+[[stations]]
+id = "LKAA FIC"
+controlled_by = ["LKAA_I_CTR"]
+
+[[stations]]
+id = "LKPR ARR"
+controlled_by = ["LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
+
+[[stations]]
+id = "LKPR DEP"
+controlled_by = ["LKPR_DEP", "LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
+
+[[stations]]
+id = "LKPR DIR"
+controlled_by = ["LKPR_D_APP", "LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
+
+[[stations]]
+id = "LKPR TWR"
+controlled_by = ["LKPR_TWR", "LKPR_D_APP", "LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
+
+[[stations]]
+id = "LKPR GND"
+controlled_by = [
+  "LKPR_GND",
+  "LKPR_TWR",
+  "LKPR_D_APP",
+  "LKPR_APP",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKPR DEL"
+controlled_by = [
+  "LKPR_DEL",
+  "LKPR_GND",
+  "LKPR_TWR",
+  "LKPR_D_APP",
+  "LKPR_APP",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKPD APP"
+controlled_by = [
+  "LKPD_APP",
+  "LKMT_APP",
+  "LKAA_R_CTR",
+  "LKAA_N_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKPD TWR"
+controlled_by = [
+  "LKPD_TWR",
+  "LKPD_APP",
+  "LKMT_APP",
+  "LKAA_R_CTR",
+  "LKAA_N_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKCV APP"
+controlled_by = [
+  "LKCV_APP",
+  "LKMT_APP",
+  "LKAA_R_CTR",
+  "LKAA_N_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKCV TWR"
+controlled_by = [
+  "LKCV_TWR",
+  "LKCV_APP",
+  "LKMT_APP",
+  "LKAA_R_CTR",
+  "LKAA_N_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKNA APP"
+controlled_by = [
+  "LKNA_APP",
+  "LKTB_APP",
+  "LKAA_R_CTR",
+  "LKAA_S_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKNA TWR"
+controlled_by = [
+  "LKNA_TWR",
+  "LKNA_APP",
+  "LKTB_APP",
+  "LKAA_R_CTR",
+  "LKAA_S_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKKB APP"
+controlled_by = ["LKKB_APP"]
+
+[[stations]]
+id = "LKKB TWR"
+controlled_by = ["LKKB_TWR", "LKKB_APP"]
+
+[[stations]]
+id = "LKVO APP"
+controlled_by = ["LKVO_APP"]
+
+[[stations]]
+id = "LKVO TWR"
+controlled_by = ["LKVO_TWR", "LKVO_APP"]
+
+[[stations]]
+id = "LKKV TWR"
+controlled_by = [
+  "LKKV_TWR",
+  "LKKV_APP",
+  "LKAA_R_CTR",
+  "LKAA_W_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKMT TWR"
+controlled_by = [
+  "LKMT_TWR",
+  "LKMT_APP",
+  "LKAA_R_CTR",
+  "LKAA_N_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKTB TWR"
+controlled_by = [
+  "LKTB_TWR",
+  "LKTB_APP",
+  "LKAA_R_CTR",
+  "LKAA_S_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKKU TWR"
+controlled_by = [
+  "LKKU_TWR",
+  "LKTB_APP",
+  "LKAA_R_CTR",
+  "LKAA_S_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR",
+]
+
+[[stations]]
+id = "LKCS AFIS"
+controlled_by = ["LKCS_I_TWR"]
+
+[[stations]]
+id = "LKLT RDO"
+controlled_by = ["LKLT_I_TWR"]


### PR DESCRIPTION
### Description

Initial dataset containing LK stations and positions, committed on behalf of ACCCZ32

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [X] Dataset files are in the correct `dataset/{FIR}/` directory.
- [X] I have verified the data is correct.
- [X] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
