### PR TITLE
feat(LO): add LK stations to profiles

### DIFF
--- a/dataset/LO/profiles/LOVV.json
+++ b/dataset/LO/profiles/LOVV.json
@@ -213,7 +213,8 @@
                     "label": []
                   },
                   {
-                    "label": ["PRA", "FIC", "WEST"]
+                    "label": ["PRA", "FIC", "WEST"],
+                    "station_id": "LKAA FIC"
                   },
                   {
                     "label": ["LOWW", "AIS", "ARO"]
@@ -232,7 +233,8 @@
                     "label": []
                   },
                   {
-                    "label": ["PRA", "FIC", "EAST"]
+                    "label": ["PRA", "FIC", "EAST"],
+                    "station_id": "LKAA FIC"
                   },
                   {
                     "label": ["LOWW", "TWR", "COO"],
@@ -253,7 +255,8 @@
                     "label": []
                   },
                   {
-                    "label": ["PRA", "FIC", "MORAVA"]
+                    "label": ["PRA", "FIC", "MORAVA"],
+                    "station_id": "LKAA FIC"
                   },
                   {
                     "label": ["APP", "TFI", "PLC"],
@@ -757,40 +760,52 @@
               "page": {
                 "keys": [
                   {
-                    "label": ["PRA", "TW", "380+"]
+                    "label": ["PRA", "TW", "380+"],
+                    "station_id": "LKAA WU"
                   },
                   {
-                    "label": ["PRA", "HW", "360-370"]
+                    "label": ["PRA", "HW", "360-370"],
+                    "station_id": "LKAA WU"
                   },
                   {
-                    "label": ["PRA", "UW", "350"]
+                    "label": ["PRA", "UW", "350"],
+                    "station_id": "LKAA WU"
                   },
                   {
-                    "label": ["PRA", "MW", "310-340"]
+                    "label": ["PRA", "MW", "310-340"],
+                    "station_id": "LKAA WU"
                   },
                   {
-                    "label": ["PRA", "LW", "300-"]
+                    "label": ["PRA", "LW", "300-"],
+                    "station_id": "LKAA WL"
                   },
                   {
-                    "label": ["PRA", "KV", "125-"]
+                    "label": ["PRA", "KV", "125-"],
+                    "station_id": "LKAA KV"
                   },
                   {
-                    "label": ["PRA", "TS", "380+"]
+                    "label": ["PRA", "TS", "380+"],
+                    "station_id": "LKAA SU"
                   },
                   {
-                    "label": ["PRA", "HS", "360-370"]
+                    "label": ["PRA", "HS", "360-370"],
+                    "station_id": "LKAA SU"
                   },
                   {
-                    "label": ["PRA", "US", "350"]
+                    "label": ["PRA", "US", "350"],
+                    "station_id": "LKAA SU"
                   },
                   {
-                    "label": ["PRA", "MS", "310-340"]
+                    "label": ["PRA", "MS", "310-340"],
+                    "station_id": "LKAA SU"
                   },
                   {
-                    "label": ["PRA", "LS", "300-"]
+                    "label": ["PRA", "LS", "300-"],
+                    "station_id": "LKAA SL"
                   },
                   {
-                    "label": ["PRA", "TB", "125-"]
+                    "label": ["PRA", "TB", "125-"],
+                    "station_id": "LKAA TB"
                   }
                 ],
                 "rows": 6

--- a/dataset/LO/profiles/LOWW.json
+++ b/dataset/LO/profiles/LOWW.json
@@ -8,16 +8,20 @@
         "rows": 6,
         "keys": [
           {
-            "label": ["PRA", "LW", "EC"]
+            "label": ["PRA", "LW", "EC"],
+            "station_id": "LKAA WL"
           },
           {
-            "label": ["PRA", "LS", "EC"]
+            "label": ["PRA", "LS", "EC"],
+            "station_id": "LKAA SL"
           },
           {
-            "label": ["PRA", "TB", "EC"]
+            "label": ["PRA", "TB", "EC"],
+            "station_id": "LKAA TB"
           },
           {
-            "label": ["PRA", "KV", "EC"]
+            "label": ["PRA", "KV", "EC"],
+            "station_id": "LKAA KV"
           },
           {
             "label": ["APP", "VD1"],
@@ -128,16 +132,20 @@
         "rows": 6,
         "keys": [
           {
-            "label": ["PRA", "LW", "PLC"]
+            "label": ["PRA", "LW", "PLC"],
+            "station_id": "LKAA WL"
           },
           {
-            "label": ["PRA", "LS", "PLC"]
+            "label": ["PRA", "LS", "PLC"],
+            "station_id": "LKAA SL"
           },
           {
-            "label": ["PRA", "TB", "PLC"]
+            "label": ["PRA", "TB", "PLC"],
+            "station_id": "LKAA TB"
           },
           {
-            "label": ["PRA", "KV", "PLC"]
+            "label": ["PRA", "KV", "PLC"],
+            "station_id": "LKAA KV"
           },
           {
             "label": ["APP", "SAP"]
@@ -254,7 +262,8 @@
             "station_id": "LOAV_TWR"
           },
           {
-            "label": ["PRA", "FIC", "WEST"]
+            "label": ["PRA", "FIC", "WEST"],
+            "station_id": "LKAA FIC"
           },
           {
             "label": ["APP", "SAP"]
@@ -276,7 +285,8 @@
             "station_id": "LOAN_TWR"
           },
           {
-            "label": ["PRA", "FIC", "EAST"]
+            "label": ["PRA", "FIC", "EAST"],
+            "station_id": "LKAA FIC"
           },
           {
             "label": ["ARO"]
@@ -297,10 +307,12 @@
             "label": ["LOXN", "TWR"]
           },
           {
-            "label": ["PRA", "FIC", "MOR"]
+            "label": ["PRA", "FIC", "MOR"],
+            "station_id": "LKAA FIC"
           },
           {
-            "label": ["PRA", "TB", "PLC"]
+            "label": ["PRA", "TB", "PLC"],
+            "station_id": "LKAA TB"
           },
           {
             "label": ["APP", "TFI", "EC"],


### PR DESCRIPTION
### Description

Adds LK stations to `LOVV` and `LOWW` profiles.
Station assignments for vertical splits not available on VATSIM are according to LoA.

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [X] Dataset files are in the correct `dataset/{FIR}/` directory.
- [X] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
