### PR TITLE
CZQM Fix

### DIFF
--- a/dataset/CZQM/profiles/CYFC.json
+++ b/dataset/CZQM/profiles/CYFC.json
@@ -24,7 +24,8 @@
             "station_id": "CYFC-GND"
           },
           {
-            "label": ""
+            "label": ["YG", "MF"],
+            "station_id": "CYYG-MF"
           }
         ]
       }

--- a/dataset/CZQM/profiles/CYHZ.json
+++ b/dataset/CZQM/profiles/CYHZ.json
@@ -28,7 +28,8 @@
             "station_id": "CYHZ-DEL"
           },
           {
-            "label": ""
+            "label": ["QM", "DG"],
+            "station_id": "CZQM-DG"
           },
           {
             "label": ["HZ", "FI"],
@@ -44,7 +45,8 @@
             "label": ""
           },
           {
-            "label": ""
+            "label": ["QM", "CB"],
+            "station_id": "CZQM-CB"
           },
           {
             "label": ""

--- a/dataset/CZQM/profiles/CYQM-APP.json
+++ b/dataset/CZQM/profiles/CYQM-APP.json
@@ -28,7 +28,8 @@
             "station_id": "CYSJ-MF"
           },
           {
-            "label": ""
+            "label": ["QM", "DG"],
+            "station_id": "CZQM-DG"
           },
           {
             "label": ["SJ", "LO"],
@@ -45,6 +46,39 @@
           {
             "label": ["YG", "MF"],
             "station_id": "CYYG-MF"
+          },
+          {
+            "label": ["QM", "CB"],
+            "station_id": "CZQM-CB"
+          },
+          {
+            "label": ["HZ", "APP"],
+            "station_id": "CYHZ-TMA"
+          },
+          {
+            "label": ""
+          },
+          {
+            "label": ""
+          },
+          {
+            "label": ""
+          },
+          {
+            "label": ""
+          },
+          {
+            "label": ["ZX", "APP"],
+            "station_id": "CYZX-TMA"
+          },
+          {
+            "label": ""
+          },
+          {
+            "label": ""
+          },
+          {
+            "label": ""
           }
         ]
       }

--- a/dataset/CZQM/profiles/CZQM-L.json
+++ b/dataset/CZQM/profiles/CZQM-L.json
@@ -28,7 +28,8 @@
             "station_id": "CYSJ-MF"
           },
           {
-            "label": ""
+            "label": ["QM", "DG"],
+            "station_id": "CZQM-DG"
           },
           {
             "label": ["SJ", "LO"],
@@ -47,7 +48,8 @@
             "station_id": "CYYG-MF"
           },
           {
-            "label": ""
+            "label": ["QM", "CB"],
+            "station_id": "CZQM-CB"
           },
           {
             "label": ["HZ", "APP"],


### PR DESCRIPTION
### Description

Fixes missing stations on some of the profiles

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
