### PR TITLE
Updated LBSR profile

### DIFF
--- a/dataset/LB/profiles/LBSR.json
+++ b/dataset/LB/profiles/LBSR.json
@@ -107,13 +107,16 @@
         "rows": 4,
         "keys": [
           {
-            "label": []
+            "label": ["BEO", "CTR", "335+"],
+            "station_id": "LYBA-UPPER-EAST"
           },
           {
-            "label": ["BEO", "CTR"]
+            "label": ["BEO", "CTR", "(Main)"],
+            "station_id": "LYBA-EAST"
           },
           {
-            "label": ["SKO", "CTR"]
+            "label": ["SKO", "CTR", ""],
+            "station_id": "LWSS-ACC"
           },
           {
             "label": []
@@ -182,10 +185,12 @@
             "label": ["IST", "APP", "(EAST)"]
           },
           {
-            "label": ["LYBE", "APP"]
+            "label": ["LYBE", "APP"],
+            "station_id": "LYBE_APP"
           },
           {
-            "label": ["LYNI", "APP"]
+            "label": ["LYNI", "APP"],
+            "station_id": "LYNI_APP"
           },
           {
             "label": ["LROP", "APP"],


### PR DESCRIPTION
### Description

Updated LBSR profile definitions

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [x] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
