### PR TITLE
Create UK FMP profile

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -3184,77 +3184,77 @@ id = "UK_FMP"
 prefixes = ["UK"]
 frequency = "199.998"
 facility_type = "FMP"
-profile_id = "EG-UK_ALL"
+profile_id = "EG-FMP"
 
 [[positions]]
 id = "UK_A_FMP"
 prefixes = ["UK"]
 frequency = "199.998"
 facility_type = "FMP"
-profile_id = "EG-UK_ALL"
+profile_id = "EG-FMP"
 
 [[positions]]
 id = "UK_B_FMP"
 prefixes = ["UK"]
 frequency = "199.998"
 facility_type = "FMP"
-profile_id = "EG-UK_ALL"
+profile_id = "EG-FMP"
 
 [[positions]]
 id = "MAN_FMP"
 prefixes = ["MAN"]
 frequency = "199.998"
 facility_type = "FMP"
-profile_id = "EG-UK_ALL"
+profile_id = "EG-FMP"
 
 [[positions]]
 id = "LTC_FMP"
 prefixes = ["LTC"]
 frequency = "199.998"
 facility_type = "FMP"
-profile_id = "EG-UK_ALL"
+profile_id = "EG-FMP"
 
 [[positions]]
 id = "SCL_FMP"
 prefixes = ["SCL"]
 frequency = "199.998"
 facility_type = "FMP"
-profile_id = "EG-UK_ALL"
+profile_id = "EG-FMP"
 
 [[positions]]
 id = "LON_GS_CTR"
 prefixes = ["LON"]
 frequency = "199.998"
 facility_type = "CTR"
-profile_id = "EG-UK_ALL"
+profile_id = "EG-FMP"
 
 [[positions]]
 id = "LTC_GS_CTR"
 prefixes = ["LTC"]
 frequency = "199.998"
 facility_type = "CTR"
-profile_id = "EG-UK_ALL"
+profile_id = "EG-FMP"
 
 [[positions]]
 id = "SCO_GS_CTR"
 prefixes = ["SCO"]
 frequency = "199.998"
 facility_type = "CTR"
-profile_id = "EG-UK_ALL"
+profile_id = "EG-FMP"
 
 [[positions]]
 id = "SCL_GS_CTR"
 prefixes = ["SCL"]
 frequency = "199.998"
 facility_type = "CTR"
-profile_id = "EG-UK_ALL"
+profile_id = "EG-FMP"
 
 [[positions]]
 id = "MAN_GS_CTR"
 prefixes = ["MAN"]
 frequency = "199.998"
 facility_type = "CTR"
-profile_id = "EG-UK_ALL"
+profile_id = "EG-FMP"
 
 #######################
 # Non-domestic owned

--- a/dataset/EG/profiles/EG-FMP.json
+++ b/dataset/EG/profiles/EG-FMP.json
@@ -7,18 +7,27 @@
       "page": {
         "rows": 6,
         "client_page": {
-            "include": [
-                "LON_GS*",
-                "LTC_GS*",
-                "MAN_GS*",
-                "SCO_GS*",
-                "SCL_GS*",
-                "*FMP"
-            ],
-            "exclude": [],
-            "priority": ["*GS*CTR", "UK_*", "SCO*", "SCL*", "MAN*", "LON*", "LTC*", "*_FMP"],
-            "frequencies": "HideAll",
-            "grouping": "None"
+          "include": [
+            "LON_GS*",
+            "LTC_GS*",
+            "MAN_GS*",
+            "SCO_GS*",
+            "SCL_GS*",
+            "*FMP"
+          ],
+          "exclude": [],
+          "priority": [
+            "*GS*CTR",
+            "UK_*",
+            "SCO*",
+            "SCL*",
+            "MAN*",
+            "LON*",
+            "LTC*",
+            "*_FMP"
+          ],
+          "frequencies": "HideAll",
+          "grouping": "None"
         }
       }
     },
@@ -27,12 +36,7 @@
       "page": {
         "rows": 10,
         "client_page": {
-          "include": [
-            "SCO_*",
-            "SCL_*",
-            "EGA*",
-            "EGP*"
-          ],
+          "include": ["SCO_*", "SCL_*", "EGA*", "EGP*"],
           "exclude": ["*FMP", "*GS*CTR"],
           "priority": ["*_CTR", "*_APP", "*_TWR", "*_GND", "*_DEL"],
           "frequencies": "HideAll",

--- a/dataset/EG/profiles/EG-FMP.json
+++ b/dataset/EG/profiles/EG-FMP.json
@@ -80,7 +80,7 @@
             "EI*"
           ],
           "exclude": ["*FMP"],
-          "priority": ["*_CTR", "*_APP", "*_TWR", "*_GND", "*_DEL"],
+          "priority": ["*_FSS", "*_CTR", "*_APP", "*_TWR", "*_GND", "*_DEL"],
           "frequencies": "HideAll",
           "grouping": "FirAndIcao"
         }

--- a/dataset/EG/profiles/EG-FMP.json
+++ b/dataset/EG/profiles/EG-FMP.json
@@ -1,0 +1,90 @@
+{
+  "id": "EG-FMP",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["SUP", "FMP"],
+      "page": {
+        "rows": 6,
+        "client_page": {
+            "include": [
+                "LON_GS*",
+                "LTC_GS*",
+                "MAN_GS*",
+                "SCO_GS*",
+                "SCL_GS*",
+                "*FMP"
+            ],
+            "exclude": [],
+            "priority": ["*GS*CTR", "UK_*", "SCO*", "SCL*", "MAN*", "LON*", "LTC*", "*_FMP"],
+            "frequencies": "HideAll",
+            "grouping": "None"
+        }
+      }
+    },
+    {
+      "label": "Scottish",
+      "page": {
+        "rows": 10,
+        "client_page": {
+          "include": [
+            "SCO_*",
+            "SCL_*",
+            "EGA*",
+            "EGP*"
+          ],
+          "exclude": ["*FMP", "*GS*CTR"],
+          "priority": ["*_CTR", "*_APP", "*_TWR", "*_GND", "*_DEL"],
+          "frequencies": "HideAll",
+          "grouping": "None"
+        }
+      }
+    },
+    {
+      "label": "London",
+      "page": {
+        "rows": 10,
+        "client_page": {
+          "include": [
+            "LON_*",
+            "LTC_*",
+            "EG*_*",
+            "SOLENT*",
+            "THAMES*",
+            "ESSEX*"
+          ],
+          "exclude": ["*FMP", "*GS*CTR", "EGA*", "EGP*"],
+          "priority": ["*_CTR", "*_APP", "*_TWR", "*_GND", "*_DEL"],
+          "frequencies": "HideAll",
+          "grouping": "None"
+        }
+      }
+    },
+    {
+      "label": "External",
+      "page": {
+        "rows": 10,
+        "client_page": {
+          "include": [
+            "BI*",
+            "EGGX*",
+            "CZQO*",
+            "NAT*",
+            "EN*",
+            "EK*",
+            "ED*",
+            "EH*",
+            "EB*",
+            "LF*",
+            "PAR*",
+            "EI*"
+          ],
+          "exclude": ["*FMP"],
+          "priority": ["*_CTR", "*_APP", "*_TWR", "*_GND", "*_DEL"],
+          "frequencies": "HideAll",
+          "grouping": "FirAndIcao"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
As per title.

Not the most sure on the external tab. Might be worth keeping only CTR/FSS positions and not the rest.
Thought it might be more useful than the generic UK_ALL profile by splitting it into Scottish/London, having a dedicated FMP page, and a dedicated external page.
It is intentional to include all FMP positions on the FMP page, but it could be possible to not include FMP positions *very* far away from us, not sure it is currently worth the effort.

No views provided as it's all dynamic.