### PR TITLE
Shanwick/EGLL GMP (PLN) buttons for Concorde

### DIFF
--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -222,8 +222,7 @@
             "station_id": "EGLF_APP"
           },
           {
-            "label": ["EGGX", "DEL"],
-            "station_id": "Shanwick_DEL"
+            "label": []
           },
           {
             "label": []

--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -80,7 +80,8 @@
             "label": []
           },
           {
-            "label": []
+            "label": ["EGGX", "DEL"],
+            "station_id": "Shanwick_DEL"
           },
           {
             "label": []
@@ -221,7 +222,8 @@
             "station_id": "EGLF_APP"
           },
           {
-            "label": []
+            "label": ["EGGX", "DEL"],
+            "station_id": "Shanwick_DEL"
           },
           {
             "label": []

--- a/dataset/NAT/profiles/NAT.json
+++ b/dataset/NAT/profiles/NAT.json
@@ -396,12 +396,11 @@
                 "label": []
               },
               {
-                "label": ["EGLL", "GMP"],
-                "station_id": "EGLL_DEL"
+                "label": ["EGLL", "PLN"],
+                "station_id": "EGLL_P_GND"
               },
               {
-                "label": ["EGLL", "GMP", "Assist"],
-                "station_id": "EGLL_A_DEL"
+                "label": []
               }
             ]
           }

--- a/dataset/NAT/profiles/NAT.json
+++ b/dataset/NAT/profiles/NAT.json
@@ -368,7 +368,7 @@
       "gap": 0.75,
       "children": [
         {
-          "label": ["Scottish"],
+          "label": ["Scottish/", "EGLL"],
           "size": 7,
           "page": {
             "rows": 2,
@@ -388,6 +388,20 @@
               {
                 "label": ["Central", "DB-255"],
                 "station_id": "EG-Westcoast-Central"
+              },
+              {
+                "label": []
+              },
+              {
+                "label": []
+              },
+              {
+                "label": ["EGLL", "GMP"],
+                "station_id": "EGLL_DEL"
+              },
+              {
+                "label": ["EGLL", "GMP", "Assist"],
+                "station_id": "EGLL_A_DEL"
               }
             ]
           }

--- a/dataset/NAT/profiles/NAT.json
+++ b/dataset/NAT/profiles/NAT.json
@@ -393,7 +393,7 @@
           }
         },
         {
-          "label": ["Shannon", "Control"],
+          "label": ["Shannon"],
           "size": 7,
           "page": {
             "rows": 4,


### PR DESCRIPTION
As suggested in https://github.com/vacs-project/vacs-data/pull/287#issuecomment-4236655314 by @JYang365, adds EGLL PLN to NAT profile, and EGGX DEL to the EGLL profile.

Also fixes a bug in external naming regarding Shannon being labelled as 'Shannon Control', and not 'Shannon'; inconsistent with all other adjacent positions.

Documentation reference: [Concorde Information Sheet](https://docs.vatsim.uk/Aerodrome/EGLL%20%28London%20Heathrow%29/9-Concorde/), [vMATS Pt 2](https://docs.vatsim.uk/Aerodrome/EGLL%20%28London%20Heathrow%29/0-vMATS/) (ADC 1.5)

# Views

## NAT

### Overall

<img width="1737" height="1235" alt="image" src="https://github.com/user-attachments/assets/97f2b93b-45a8-48e0-b805-07ec49743b3b" />

### Scottish/EGLL

<img width="1737" height="1228" alt="image" src="https://github.com/user-attachments/assets/9bd2217e-69d3-4ebe-bc21-f4bcc2f47ff0" />

## EGLL

### ADC

<img width="1737" height="1225" alt="image" src="https://github.com/user-attachments/assets/ad742de3-f807-4395-b0f4-0100287e8529" />

