### PR TITLE
Add EGLL APC Supervisor for CTP 26E

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -743,30 +743,6 @@ profile_id = "EGLF"
 [[positions]]
 id = "EGLL_P_APP"
 prefixes = ["EGLL"]
-frequency = "120.400"
-facility_type = "APP"
-profile_id = "EGLL"
-default_call_sources = ["EGLL_P_APP"]
-
-[[positions]]
-id = "EGLL_P_APP"
-prefixes = ["EGLL"]
-frequency = "119.730"
-facility_type = "APP"
-profile_id = "EGLL"
-default_call_sources = ["EGLL_P_APP"]
-
-[[positions]]
-id = "EGLL_P_APP"
-prefixes = ["EGLL"]
-frequency = "134.980"
-facility_type = "APP"
-profile_id = "EGLL"
-default_call_sources = ["EGLL_P_APP"]
-
-[[positions]]
-id = "EGLL_P_APP"
-prefixes = ["EGLL"]
 frequency = "199.998"
 facility_type = "APP"
 profile_id = "EGLL"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -746,6 +746,7 @@ prefixes = ["EGLL"]
 frequency = "120.400"
 facility_type = "APP"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_P_APP"]
 
 [[positions]]
 id = "EGLL_P_APP"
@@ -753,6 +754,7 @@ prefixes = ["EGLL"]
 frequency = "119.730"
 facility_type = "APP"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_P_APP"]
 
 [[positions]]
 id = "EGLL_P_APP"
@@ -760,6 +762,7 @@ prefixes = ["EGLL"]
 frequency = "134.980"
 facility_type = "APP"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_P_APP"]
 
 [[positions]]
 id = "EGLL_P_APP"
@@ -767,6 +770,7 @@ prefixes = ["EGLL"]
 frequency = "199.998"
 facility_type = "APP"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_P_APP"]
 
 [[positions]]
 id = "EGLL_F_APP"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -741,6 +741,34 @@ facility_type = "GND"
 profile_id = "EGLF"
 
 [[positions]]
+id = "EGLL_P_APP"
+prefixes = ["EGLL"]
+frequency = "120.400"
+facility_type = "APP"
+profile_id = "EGLL"
+
+[[positions]]
+id = "EGLL_P_APP"
+prefixes = ["EGLL"]
+frequency = "119.730"
+facility_type = "APP"
+profile_id = "EGLL"
+
+[[positions]]
+id = "EGLL_P_APP"
+prefixes = ["EGLL"]
+frequency = "134.980"
+facility_type = "APP"
+profile_id = "EGLL"
+
+[[positions]]
+id = "EGLL_P_APP"
+prefixes = ["EGLL"]
+frequency = "199.998"
+facility_type = "APP"
+profile_id = "EGLL"
+
+[[positions]]
 id = "EGLL_F_APP"
 prefixes = ["EGLL"]
 frequency = "120.400"

--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -71,7 +71,8 @@
             "label": []
           },
           {
-            "label": []
+            "label": ["APC", "Supvisr"],
+            "station_id": "EGLL_P_APP"
           },
           {
             "label": []
@@ -169,7 +170,8 @@
             "label": []
           },
           {
-            "label": []
+            "label": ["APC", "Supvisr"],
+            "station_id": "EGLL_P_APP"
           },
           {
             "label": ["EGLW"],

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -1147,6 +1147,10 @@ parent_id = "EGLL_N_APP"
 controlled_by = ["EGLL_F_APP"]
 
 [[stations]]
+id = "EGLL_P_APP"
+controlled_by = ["EGLL_P_APP"]
+
+[[stations]]
 id = "EGLM_R_TWR"
 controlled_by = ["EGLM_R_TWR"]
 


### PR DESCRIPTION
As per title.

Also, for it to work, they ***MUST NOT*** be primed in ES.

This change is intended to be reverted at the end of the CTP roster (so will open a reversion PR once merged, to await the end of CTP).

<img width="1741" height="1232" alt="image" src="https://github.com/user-attachments/assets/4965f728-5a62-48e9-876a-7ade7851f466" />

<img width="1736" height="1232" alt="image" src="https://github.com/user-attachments/assets/9f80242e-eb64-460d-bfd5-6707631fbc2e" />
