### PR TITLE
Revert "Add EGLL APC Supervisor for CTP 26E (#337)"

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -741,14 +741,6 @@ facility_type = "GND"
 profile_id = "EGLF"
 
 [[positions]]
-id = "EGLL_P_APP"
-prefixes = ["EGLL"]
-frequency = "199.998"
-facility_type = "APP"
-profile_id = "EGLL"
-default_call_sources = ["EGLL_P_APP"]
-
-[[positions]]
 id = "EGLL_F_APP"
 prefixes = ["EGLL"]
 frequency = "120.400"

--- a/dataset/EG/profiles/EGLL.json
+++ b/dataset/EG/profiles/EGLL.json
@@ -71,8 +71,7 @@
             "label": []
           },
           {
-            "label": ["APC", "Supvisr"],
-            "station_id": "EGLL_P_APP"
+            "label": []
           },
           {
             "label": []
@@ -170,8 +169,7 @@
             "label": []
           },
           {
-            "label": ["APC", "Supvisr"],
-            "station_id": "EGLL_P_APP"
+            "label": []
           },
           {
             "label": ["EGLW"],

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -1147,10 +1147,6 @@ parent_id = "EGLL_N_APP"
 controlled_by = ["EGLL_F_APP"]
 
 [[stations]]
-id = "EGLL_P_APP"
-controlled_by = ["EGLL_P_APP"]
-
-[[stations]]
 id = "EGLM_R_TWR"
 controlled_by = ["EGLM_R_TWR"]
 


### PR DESCRIPTION
This reverts commit f709c0c825886879e17306d91dac9ef7ddcb8f66.

Per the prior PR (https://github.com/vacs-project/vacs-data/pull/337), this PR intends to remove the LL APC Supervisor position from VACS after CTP arrivals are completed.

Will be merged manually (probably just after midnight).