### PR TITLE
Add RJTT and RJAA for Japan

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,10 +64,9 @@ CONTRIBUTING.md @vacs-project/maintainers
 /dataset/NAT/ @vacs-project/dataset-maintainers-nat
 /dataset/OM/ @vacs-project/dataset-maintainers-arb
 /dataset/OT/ @vacs-project/dataset-maintainers-arb
+/dataset/RJ/ @vacs-project/dataset-maintainers-rjjj
 /dataset/TN/ @vacs-project/dataset-maintainers-tncf
 /dataset/TQ/ @vacs-project/dataset-maintainers-tncf
 /dataset/UL/ @vacs-project/dataset-maintainers-ul
 /dataset/VH/ @vacs-project/dataset-maintainers-vh
 /dataset/WS/ @vacs-project/dataset-maintainers-ws
-/dataset/RJ/ @vacs-project/dataset-maintainers-rjjj
-/dataset/RO/ @vacs-project/dataset-maintainers-rjjj

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,3 +69,5 @@ CONTRIBUTING.md @vacs-project/maintainers
 /dataset/UL/ @vacs-project/dataset-maintainers-ul
 /dataset/VH/ @vacs-project/dataset-maintainers-vh
 /dataset/WS/ @vacs-project/dataset-maintainers-ws
+/dataset/RJ/ @vacs-project/dataset-maintainers-rjjj
+/dataset/RO/ @vacs-project/dataset-maintainers-rjjj

--- a/dataset/RJ/positions.toml
+++ b/dataset/RJ/positions.toml
@@ -1,0 +1,287 @@
+[[positions]]
+id = "RJTT_APP"
+prefixes = ["RJTT"]
+frequency = "119.100"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_APP", "RJTT_N_APP", "RJTT_S_APP", "RJTT_DEP"]
+
+[[positions]]
+id = "RJTT_N_APP"
+prefixes = ["RJTT"]
+frequency = "119.400"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_N_APP", "RJTT_K_APP", "RJTT_APP"]
+
+[[positions]]
+id = "RJTT_K_APP"
+prefixes = ["RJTT"]
+frequency = "125.400"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_K_APP", "RJTT_N_APP", "RJTT_APP"]
+
+[[positions]]
+id = "RJTT_S_APP"
+prefixes = ["RJTT"]
+frequency = "119.100"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_S_APP", "RJTT_F_APP", "RJTT_Z_APP", "RJTT_APP"]
+
+[[positions]]
+id = "RJTT_F_APP"
+prefixes = ["RJTT"]
+frequency = "119.650"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_F_APP", "RJTT_R_APP", "RJTT_S_APP"]
+
+[[positions]]
+id = "RJTT_R_APP"
+prefixes = ["RJTT"]
+frequency = "126.500"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_R_APP", "RJTT_F_APP", "RJTT_S_APP"]
+
+[[positions]]
+id = "RJTT_H_APP"
+prefixes = ["RJTT"]
+frequency = "119.700"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_H_APP", "RJTT_APP"]
+
+[[positions]]
+id = "RJTT_Z_APP"
+prefixes = ["RJTT"]
+frequency = "124.000"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_Z_APP", "RJTT_S_APP", "RJTT_APP"]
+
+[[positions]]
+id = "RJTT_DEP"
+prefixes = ["RJTT"]
+frequency = "126.000"
+facility_type = "DEP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_DEP", "RJTT_N_DEP", "RJTT_S_DEP"]
+
+[[positions]]
+id = "RJTT_N_DEP"
+prefixes = ["RJTT"]
+frequency = "120.800"
+facility_type = "DEP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_N_DEP", "RJTT_DEP"]
+
+[[positions]]
+id = "RJTT_S_DEP"
+prefixes = ["RJTT"]
+frequency = "126.000"
+facility_type = "DEP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_S_DEP", "RJTT_DEP"]
+
+[[positions]]
+id = "RJTT_V_APP"
+prefixes = ["RJTT"]
+frequency = "124.750"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJTT_V_APP", "RJTT_APP"]
+
+[[positions]]
+id = "RJTT_N_TWR"
+prefixes = ["RJTT"]
+frequency = "118.575"
+facility_type = "TWR"
+profile_id = "RJ"
+default_call_sources = ["RJTT_N_TWR"]
+
+[[positions]]
+id = "RJTT_E_TWR"
+prefixes = ["RJTT"]
+frequency = "124.350"
+facility_type = "TWR"
+profile_id = "RJ"
+default_call_sources = ["RJTT_E_TWR"]
+
+[[positions]]
+id = "RJTT_S_TWR"
+prefixes = ["RJTT"]
+frequency = "118.750"
+facility_type = "TWR"
+profile_id = "RJ"
+default_call_sources = ["RJTT_S_TWR"]
+
+[[positions]]
+id = "RJTT_W_TWR"
+prefixes = ["RJTT"]
+frequency = "118.100"
+facility_type = "TWR"
+profile_id = "RJ"
+default_call_sources = ["RJTT_W_TWR"]
+
+[[positions]]
+id = "RJTT_K_GND"
+prefixes = ["RJTT"]
+frequency = "121.625"
+facility_type = "GND"
+profile_id = "RJ"
+default_call_sources = ["RJTT_K_GND"]
+
+[[positions]]
+id = "RJTT_W_GND"
+prefixes = ["RJTT"]
+frequency = "121.700"
+facility_type = "GND"
+profile_id = "RJ"
+default_call_sources = ["RJTT_W_GND"]
+
+[[positions]]
+id = "RJTT_N_GND"
+prefixes = ["RJTT"]
+frequency = "122.075"
+facility_type = "GND"
+profile_id = "RJ"
+default_call_sources = ["RJTT_N_GND"]
+
+[[positions]]
+id = "RJTT_E_GND"
+prefixes = ["RJTT"]
+frequency = "118.225"
+facility_type = "GND"
+profile_id = "RJ"
+default_call_sources = ["RJTT_E_GND"]
+
+[[positions]]
+id = "RJTT_S_GND"
+prefixes = ["RJTT"]
+frequency = "121.975"
+facility_type = "GND"
+profile_id = "RJ"
+default_call_sources = ["RJTT_S_GND"]
+
+[[positions]]
+id = "RJTT_DEL"
+prefixes = ["RJTT"]
+frequency = "121.825"
+facility_type = "DEL"
+profile_id = "RJ"
+default_call_sources = ["RJTT_DEL"]
+
+[[positions]]
+id = "RJAA_APP"
+prefixes = ["RJAA"]
+frequency = "124.400"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_APP", "RJAA_S_APP", "RJAA_DEP"]
+
+[[positions]]
+id = "RJAA_S_APP"
+prefixes = ["RJAA"]
+frequency = "124.400"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_S_APP", "RJAA_APP"]
+
+[[positions]]
+id = "RJAA_R_APP"
+prefixes = ["RJAA"]
+frequency = "120.200"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_R_APP", "RJAA_S_APP", "RJAA_APP"]
+
+[[positions]]
+id = "RJAA_B_APP"
+prefixes = ["RJAA"]
+frequency = "121.275"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_B_APP", "RJAA_S_APP", "RJAA_APP"]
+
+[[positions]]
+id = "RJAA_E_APP"
+prefixes = ["RJAA"]
+frequency = "127.700"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_E_APP", "RJAA_APP"]
+
+[[positions]]
+id = "RJAA_A_APP"
+prefixes = ["RJAA"]
+frequency = "125.200"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_A_APP", "RJAA_APP"]
+
+[[positions]]
+id = "RJAA_DEP"
+prefixes = ["RJAA"]
+frequency = "124.200"
+facility_type = "DEP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_DEP", "RJAA_A_DEP", "RJAA_B_DEP"]
+
+[[positions]]
+id = "RJAA_A_DEP"
+prefixes = ["RJAA"]
+frequency = "124.200"
+facility_type = "DEP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_A_DEP", "RJAA_DEP"]
+
+[[positions]]
+id = "RJAA_B_DEP"
+prefixes = ["RJAA"]
+frequency = "119.600"
+facility_type = "DEP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_B_DEP", "RJAA_DEP"]
+
+[[positions]]
+id = "RJAA_R_DEP"
+prefixes = ["RJAA"]
+frequency = "119.025"
+facility_type = "DEP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_R_DEP", "RJAA_DEP"]
+
+[[positions]]
+id = "RJAA_S_DEP"
+prefixes = ["RJAA"]
+frequency = "120.600"
+facility_type = "DEP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_S_DEP", "RJAA_DEP"]
+
+[[positions]]
+id = "RJAA_N_DEP"
+prefixes = ["RJAA"]
+frequency = "125.525"
+facility_type = "DEP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_N_DEP", "RJAA_DEP"]
+
+[[positions]]
+id = "RJAA_W_DEP"
+prefixes = ["RJAA"]
+frequency = "125.100"
+facility_type = "DEP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_W_DEP", "RJAA_DEP"]
+
+[[positions]]
+id = "RJAA_V_APP"
+prefixes = ["RJAA"]
+frequency = "119.450"
+facility_type = "APP"
+profile_id = "RJ"
+default_call_sources = ["RJAA_V_APP", "RJAA_APP"]

--- a/dataset/RJ/profiles/RJ.json
+++ b/dataset/RJ/profiles/RJ.json
@@ -1,0 +1,281 @@
+{
+  "id": "RJ",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": "RJTT",
+      "page": {
+        "rows": 5,
+        "keys": [
+          {
+            "label": ["HS"],
+            "station_id": "RJTT_S_APP",
+            "color": "azure"
+          },
+          {
+            "label": ["HF"],
+            "station_id": "RJTT_F_APP",
+            "color": "azure"
+          },
+          {
+            "label": ["HR"],
+            "station_id": "RJTT_R_APP",
+            "color": "azure"
+          },
+          {
+            "label": ["HZ"],
+            "station_id": "RJTT_Z_APP",
+            "color": "azure"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["HN"],
+            "station_id": "RJTT_N_APP",
+            "color": "cadet"
+          },
+          {
+            "label": ["HK"],
+            "station_id": "RJTT_K_APP",
+            "color": "cadet"
+          },
+          {
+            "label": ["HH"],
+            "station_id": "RJTT_H_APP",
+            "color": "cadet"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["DEP", "HN"],
+            "station_id": "RJTT_N_DEP",
+            "color": "blush"
+          },
+          {
+            "label": ["DEP", "HS"],
+            "station_id": "RJTT_S_DEP",
+            "color": "blush"
+          },
+          {
+            "label": ["HV"],
+            "station_id": "RJTT_V_APP",
+            "color": "lilac"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["LN"],
+            "station_id": "RJTT_N_TWR",
+            "color": "mint"
+          },
+          {
+            "label": ["LE"],
+            "station_id": "RJTT_E_TWR",
+            "color": "mint"
+          },
+          {
+            "label": ["LS"],
+            "station_id": "RJTT_S_TWR",
+            "color": "mint"
+          },
+          {
+            "label": ["LW"],
+            "station_id": "RJTT_W_TWR",
+            "color": "mint"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["GN"],
+            "station_id": "RJTT_N_GND",
+            "color": "lagoon"
+          },
+          {
+            "label": ["GE"],
+            "station_id": "RJTT_E_GND",
+            "color": "lagoon"
+          },
+          {
+            "label": ["GS"],
+            "station_id": "RJTT_S_GND",
+            "color": "lagoon"
+          },
+          {
+            "label": ["GW"],
+            "station_id": "RJTT_W_GND",
+            "color": "lagoon"
+          },
+          {
+            "label": ["GK"],
+            "station_id": "RJTT_K_GND",
+            "color": "lagoon"
+          },
+          {
+            "label": ["DEL"],
+            "station_id": "RJTT_DEL",
+            "color": "taupe"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          }
+        ]
+      }
+    },
+    {
+      "label": "RJAA",
+      "page": {
+        "rows": 5,
+        "keys": [
+          {
+            "label": ["NS"],
+            "station_id": "RJAA_S_APP",
+            "color": "azure"
+          },
+          {
+            "label": ["NR"],
+            "station_id": "RJAA_R_APP",
+            "color": "azure"
+          },
+          {
+            "label": ["NB"],
+            "station_id": "RJAA_B_APP",
+            "color": "azure"
+          },
+          {
+            "label": ["NA"],
+            "station_id": "RJAA_A_APP",
+            "color": "azure"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["NE"],
+            "station_id": "RJAA_E_APP",
+            "color": "cadet"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["DEP", "NA"],
+            "station_id": "RJAA_A_DEP",
+            "color": "blush"
+          },
+          {
+            "label": ["DEP", "NB"],
+            "station_id": "RJAA_B_DEP",
+            "color": "blush"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["DEP", "NS"],
+            "station_id": "RJAA_S_DEP",
+            "color": "umber"
+          },
+          {
+            "label": ["DEP", "NN"],
+            "station_id": "RJAA_N_DEP",
+            "color": "umber"
+          },
+          {
+            "label": ["DEP", "NW"],
+            "station_id": "RJAA_W_DEP",
+            "color": "umber"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["NK"],
+            "station_id": "RJAA_R_DEP",
+            "color": "lilac"
+          },
+          {
+            "label": ["NV"],
+            "station_id": "RJAA_V_APP",
+            "color": "lilac"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dataset/RJ/stations.toml
+++ b/dataset/RJ/stations.toml
@@ -1,0 +1,182 @@
+[[stations]]
+id = "RJTT_APP"
+controlled_by = ["RJTT_APP"]
+
+[[stations]]
+id = "RJTT_N_APP"
+parent_id = "RJTT_APP"
+controlled_by = ["RJTT_N_APP"]
+
+[[stations]]
+id = "RJTT_K_APP"
+parent_id = "RJTT_N_APP"
+controlled_by = ["RJTT_K_APP"]
+
+[[stations]]
+id = "RJTT_S_APP"
+parent_id = "RJTT_APP"
+controlled_by = ["RJTT_S_APP"]
+
+[[stations]]
+id = "RJTT_F_APP"
+parent_id = "RJTT_S_APP"
+controlled_by = ["RJTT_F_APP"]
+
+[[stations]]
+id = "RJTT_R_APP"
+parent_id = "RJTT_F_APP"
+controlled_by = ["RJTT_R_APP"]
+
+[[stations]]
+id = "RJTT_H_APP"
+parent_id = "RJTT_APP"
+controlled_by = ["RJTT_H_APP"]
+
+[[stations]]
+id = "RJTT_Z_APP"
+parent_id = "RJTT_S_APP"
+controlled_by = ["RJTT_Z_APP"]
+
+[[stations]]
+id = "RJTT_DEP"
+parent_id = "RJTT_APP"
+controlled_by = ["RJTT_DEP"]
+
+[[stations]]
+id = "RJTT_N_DEP"
+parent_id = "RJTT_DEP"
+controlled_by = ["RJTT_N_DEP"]
+
+[[stations]]
+id = "RJTT_S_DEP"
+parent_id = "RJTT_DEP"
+controlled_by = ["RJTT_S_DEP"]
+
+[[stations]]
+id = "RJTT_V_APP"
+parent_id = "RJTT_APP"
+controlled_by = ["RJTT_V_APP"]
+
+[[stations]]
+id = "RJTT_N_TWR"
+parent_id = "RJTT_TWR"
+controlled_by = ["RJTT_N_TWR"]
+
+[[stations]]
+id = "RJTT_E_TWR"
+parent_id = "RJTT_TWR"
+controlled_by = ["RJTT_E_TWR"]
+
+[[stations]]
+id = "RJTT_S_TWR"
+parent_id = "RJTT_TWR"
+controlled_by = ["RJTT_S_TWR"]
+
+[[stations]]
+id = "RJTT_W_TWR"
+parent_id = "RJTT_TWR"
+controlled_by = ["RJTT_W_TWR"]
+
+[[stations]]
+id = "RJTT_K_GND"
+parent_id = "RJTT_W_TWR"
+controlled_by = ["RJTT_K_GND"]
+
+[[stations]]
+id = "RJTT_W_GND"
+parent_id = "RJTT_W_TWR"
+controlled_by = ["RJTT_W_GND"]
+
+[[stations]]
+id = "RJTT_N_GND"
+parent_id = "RJTT_N_TWR"
+controlled_by = ["RJTT_N_GND"]
+
+[[stations]]
+id = "RJTT_E_GND"
+parent_id = "RJTT_E_TWR"
+controlled_by = ["RJTT_E_GND"]
+
+[[stations]]
+id = "RJTT_S_GND"
+parent_id = "RJTT_S_TWR"
+controlled_by = ["RJTT_S_GND"]
+
+[[stations]]
+id = "RJTT_DEL"
+parent_id = "RJTT_K_GND"
+controlled_by = ["RJTT_DEL"]
+
+[[stations]]
+id = "RJAA_APP"
+controlled_by = ["RJAA_APP"]
+
+[[stations]]
+id = "RJAA_S_APP"
+parent_id = "RJAA_APP"
+controlled_by = ["RJAA_S_APP"]
+
+[[stations]]
+id = "RJAA_R_APP"
+parent_id = "RJAA_S_APP"
+controlled_by = ["RJAA_R_APP"]
+
+[[stations]]
+id = "RJAA_B_APP"
+parent_id = "RJAA_R_APP"
+controlled_by = ["RJAA_B_APP"]
+
+[[stations]]
+id = "RJAA_E_APP"
+parent_id = "RJAA_APP"
+controlled_by = ["RJAA_E_APP"]
+
+[[stations]]
+id = "RJAA_A_APP"
+parent_id = "RJAA_R_APP"
+controlled_by = ["RJAA_A_APP"]
+
+[[stations]]
+id = "RJAA_DEP"
+parent_id = "RJAA_APP"
+controlled_by = ["RJAA_DEP"]
+
+[[stations]]
+id = "RJAA_A_DEP"
+parent_id = "RJAA_DEP"
+controlled_by = ["RJAA_A_DEP"]
+
+[[stations]]
+id = "RJAA_B_DEP"
+parent_id = "RJAA_DEP"
+controlled_by = ["RJAA_B_DEP"]
+
+[[stations]]
+id = "RJAA_R_DEP"
+parent_id = "RJAA_DEP"
+controlled_by = ["RJAA_R_DEP"]
+
+[[stations]]
+id = "RJAA_S_DEP"
+parent_id = "RJAA_DEP"
+controlled_by = ["RJAA_S_DEP"]
+
+[[stations]]
+id = "RJAA_N_DEP"
+parent_id = "RJAA_DEP"
+controlled_by = ["RJAA_N_DEP"]
+
+[[stations]]
+id = "RJAA_W_DEP"
+parent_id = "RJAA_DEP"
+controlled_by = ["RJAA_W_DEP"]
+
+[[stations]]
+id = "RJAA_V_APP"
+parent_id = "RJAA_DEP"
+controlled_by = ["RJAA_V_APP"]
+
+[[stations]]
+id = "RJTT_TWR"
+parent_id = "RJTT_S_DEP"
+controlled_by = ["RJTT_N_TWR", "RJTT_E_TWR", "RJTT_S_TWR", "RJTT_W_TWR"]


### PR DESCRIPTION
### Description

<!-- What does this PR change and why? -->
The purpose of this PR is to add stations under the RJJJ FIR (VATJPN) to vacs.

I (kentoasty/VATJPN15), am a part of the Operations Section (Team) for VATJPN. (https://vatjpn.org/document/public/staff)

Another user I would like to add as a data maintainer is https://github.com/yuniyuni33 our division director.

We request the team name to be @vacs-project/dataset-maintainers-rjjj, although in this PR there's files only for "RJ" we will be adding "RO" to cover the southern section of our FIR. 


### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [x] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
