### PR TITLE
Modified inheritance for RJTT/RJAA

### DIFF
--- a/dataset/RJ/positions.toml
+++ b/dataset/RJ/positions.toml
@@ -135,6 +135,14 @@ profile_id = "RJ"
 default_call_sources = ["RJTT_K_GND"]
 
 [[positions]]
+id = "RJTT_GND"
+prefixes = ["RJTT"]
+frequency = "121.700"
+facility_type = "GND"
+profile_id = "RJ"
+default_call_sources = ["RJTT_GND"]
+
+[[positions]]
 id = "RJTT_W_GND"
 prefixes = ["RJTT"]
 frequency = "121.700"

--- a/dataset/RJ/stations.toml
+++ b/dataset/RJ/stations.toml
@@ -1,6 +1,6 @@
 [[stations]]
 id = "RJTT_APP"
-controlled_by = ["RJTT_APP"]
+controlled_by = ["RJTT_APP", "RJTT_N_APP", "RJTT_S_APP"]
 
 [[stations]]
 id = "RJTT_N_APP"
@@ -40,7 +40,11 @@ controlled_by = ["RJTT_Z_APP"]
 [[stations]]
 id = "RJTT_DEP"
 parent_id = "RJTT_APP"
-controlled_by = ["RJTT_DEP"]
+controlled_by = [
+    "RJTT_DEP", 
+    "RJTT_N_DEP", 
+    "RJTT_S_DEP"
+    ]
 
 [[stations]]
 id = "RJTT_N_DEP"
@@ -78,28 +82,40 @@ parent_id = "RJTT_TWR"
 controlled_by = ["RJTT_W_TWR"]
 
 [[stations]]
+id = "RJTT_GND"
+parent_id = "RJTT_TWR"
+controlled_by = [
+    "RJTT_N_GND", 
+    "RJTT_E_GND", 
+    "RJTT_W_GND", 
+    "RJTT_S_GND", 
+    "RJTT_K_GND", 
+    "RJTT_GND"
+    ]
+
+[[stations]]
 id = "RJTT_K_GND"
-parent_id = "RJTT_W_TWR"
+parent_id = "RJTT_GND"
 controlled_by = ["RJTT_K_GND"]
 
 [[stations]]
 id = "RJTT_W_GND"
-parent_id = "RJTT_W_TWR"
+parent_id = "RJTT_GND"
 controlled_by = ["RJTT_W_GND"]
 
 [[stations]]
 id = "RJTT_N_GND"
-parent_id = "RJTT_N_TWR"
+parent_id = "RJTT_GND"
 controlled_by = ["RJTT_N_GND"]
 
 [[stations]]
 id = "RJTT_E_GND"
-parent_id = "RJTT_E_TWR"
+parent_id = "RJTT_GND"
 controlled_by = ["RJTT_E_GND"]
 
 [[stations]]
 id = "RJTT_S_GND"
-parent_id = "RJTT_S_TWR"
+parent_id = "RJTT_GND"
 controlled_by = ["RJTT_S_GND"]
 
 [[stations]]
@@ -109,7 +125,14 @@ controlled_by = ["RJTT_DEL"]
 
 [[stations]]
 id = "RJAA_APP"
-controlled_by = ["RJAA_APP"]
+controlled_by = [
+  "RJAA_APP", 
+  "RJAA_S_APP", 
+  "RJAA_R_APP", 
+  "RJAA_B_APP", 
+  "RJAA_E_APP", 
+  "RJAA_A_APP"
+]
 
 [[stations]]
 id = "RJAA_S_APP"
@@ -139,7 +162,15 @@ controlled_by = ["RJAA_A_APP"]
 [[stations]]
 id = "RJAA_DEP"
 parent_id = "RJAA_APP"
-controlled_by = ["RJAA_DEP"]
+controlled_by = [
+  "RJAA_DEP", 
+  "RJAA_A_DEP", 
+  "RJAA_B_DEP", 
+  "RJAA_R_DEP", 
+  "RJAA_S_DEP", 
+  "RJAA_N_DEP", 
+  "RJAA_W_DEP"
+]
 
 [[stations]]
 id = "RJAA_A_DEP"

--- a/dataset/RJ/stations.toml
+++ b/dataset/RJ/stations.toml
@@ -40,11 +40,7 @@ controlled_by = ["RJTT_Z_APP"]
 [[stations]]
 id = "RJTT_DEP"
 parent_id = "RJTT_APP"
-controlled_by = [
-    "RJTT_DEP", 
-    "RJTT_N_DEP", 
-    "RJTT_S_DEP"
-    ]
+controlled_by = ["RJTT_DEP", "RJTT_N_DEP", "RJTT_S_DEP"]
 
 [[stations]]
 id = "RJTT_N_DEP"
@@ -85,13 +81,13 @@ controlled_by = ["RJTT_W_TWR"]
 id = "RJTT_GND"
 parent_id = "RJTT_TWR"
 controlled_by = [
-    "RJTT_N_GND", 
-    "RJTT_E_GND", 
-    "RJTT_W_GND", 
-    "RJTT_S_GND", 
-    "RJTT_K_GND", 
-    "RJTT_GND"
-    ]
+  "RJTT_N_GND",
+  "RJTT_E_GND",
+  "RJTT_W_GND",
+  "RJTT_S_GND",
+  "RJTT_K_GND",
+  "RJTT_GND",
+]
 
 [[stations]]
 id = "RJTT_K_GND"
@@ -126,12 +122,12 @@ controlled_by = ["RJTT_DEL"]
 [[stations]]
 id = "RJAA_APP"
 controlled_by = [
-  "RJAA_APP", 
-  "RJAA_S_APP", 
-  "RJAA_R_APP", 
-  "RJAA_B_APP", 
-  "RJAA_E_APP", 
-  "RJAA_A_APP"
+  "RJAA_APP",
+  "RJAA_S_APP",
+  "RJAA_R_APP",
+  "RJAA_B_APP",
+  "RJAA_E_APP",
+  "RJAA_A_APP",
 ]
 
 [[stations]]
@@ -163,13 +159,13 @@ controlled_by = ["RJAA_A_APP"]
 id = "RJAA_DEP"
 parent_id = "RJAA_APP"
 controlled_by = [
-  "RJAA_DEP", 
-  "RJAA_A_DEP", 
-  "RJAA_B_DEP", 
-  "RJAA_R_DEP", 
-  "RJAA_S_DEP", 
-  "RJAA_N_DEP", 
-  "RJAA_W_DEP"
+  "RJAA_DEP",
+  "RJAA_A_DEP",
+  "RJAA_B_DEP",
+  "RJAA_R_DEP",
+  "RJAA_S_DEP",
+  "RJAA_N_DEP",
+  "RJAA_W_DEP",
 ]
 
 [[stations]]


### PR DESCRIPTION
### Description

<!-- What does this PR change and why? -->
Modified inheritance for RJTT/RJAA

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
