### PR TITLE
Modified radar fallback stations for RJTT

### DIFF
--- a/dataset/RJ/positions.toml
+++ b/dataset/RJ/positions.toml
@@ -135,6 +135,14 @@ profile_id = "RJ"
 default_call_sources = ["RJTT_K_GND"]
 
 [[positions]]
+id = "RJTT_GND"
+prefixes = ["RJTT"]
+frequency = "121.700"
+facility_type = "GND"
+profile_id = "RJ"
+default_call_sources = ["RJTT_GND"]
+
+[[positions]]
 id = "RJTT_W_GND"
 prefixes = ["RJTT"]
 frequency = "121.700"

--- a/dataset/RJ/stations.toml
+++ b/dataset/RJ/stations.toml
@@ -1,6 +1,19 @@
 [[stations]]
 id = "RJTT_APP"
-controlled_by = ["RJTT_APP", "RJTT_N_APP", "RJTT_S_APP"]
+controlled_by = [
+  "RJTT_APP",
+  "RJTT_DEP",
+  "RJTT_N_APP",
+  "RJTT_S_APP",
+  "RJTT_K_APP",
+  "RJTT_F_APP",
+  "RJTT_R_APP",
+  "RJTT_H_APP",
+  "RJTT_Z_APP",
+  "RJTT_V_APP",
+  "RJTT_N_DEP",
+  "RJTT_S_DEP"
+]
 
 [[stations]]
 id = "RJTT_N_APP"
@@ -19,13 +32,13 @@ controlled_by = ["RJTT_S_APP"]
 
 [[stations]]
 id = "RJTT_F_APP"
-parent_id = "RJTT_S_APP"
-controlled_by = ["RJTT_F_APP"]
+parent_id = "RJTT_APP"
+controlled_by = ["RJTT_F_APP", "RJTT_S_APP"]
 
 [[stations]]
 id = "RJTT_R_APP"
-parent_id = "RJTT_F_APP"
-controlled_by = ["RJTT_R_APP"]
+parent_id = "RJTT_APP"
+controlled_by = ["RJTT_R_APP", "RJTT_F_APP", "RJTT_S_APP"]
 
 [[stations]]
 id = "RJTT_H_APP"
@@ -34,8 +47,8 @@ controlled_by = ["RJTT_H_APP"]
 
 [[stations]]
 id = "RJTT_Z_APP"
-parent_id = "RJTT_S_APP"
-controlled_by = ["RJTT_Z_APP"]
+parent_id = "RJTT_APP"
+controlled_by = ["RJTT_Z_APP", "RJTT_S_APP"]
 
 [[stations]]
 id = "RJTT_DEP"
@@ -49,22 +62,22 @@ controlled_by = [
 [[stations]]
 id = "RJTT_N_DEP"
 parent_id = "RJTT_DEP"
-controlled_by = ["RJTT_N_DEP"]
+controlled_by = ["RJTT_N_DEP", "RJTT_S_DEP", "RJTT_N_APP"]
 
 [[stations]]
 id = "RJTT_S_DEP"
 parent_id = "RJTT_DEP"
-controlled_by = ["RJTT_S_DEP"]
+controlled_by = ["RJTT_S_DEP", "RJTT_N_DEP", "RJTT_S_APP"]
 
 [[stations]]
 id = "RJTT_V_APP"
 parent_id = "RJTT_APP"
-controlled_by = ["RJTT_V_APP"]
+controlled_by = ["RJTT_V_APP", "RJTT_S_APP"]
 
 [[stations]]
 id = "RJTT_N_TWR"
 parent_id = "RJTT_TWR"
-controlled_by = ["RJTT_N_TWR"]
+controlled_by = ["RJTT_N_TWR", "RJTT_W_TWR"]
 
 [[stations]]
 id = "RJTT_E_TWR"
@@ -74,7 +87,7 @@ controlled_by = ["RJTT_E_TWR"]
 [[stations]]
 id = "RJTT_S_TWR"
 parent_id = "RJTT_TWR"
-controlled_by = ["RJTT_S_TWR"]
+controlled_by = ["RJTT_S_TWR", "RJTT_E_TWR"]
 
 [[stations]]
 id = "RJTT_W_TWR"
@@ -94,11 +107,6 @@ controlled_by = [
     ]
 
 [[stations]]
-id = "RJTT_K_GND"
-parent_id = "RJTT_GND"
-controlled_by = ["RJTT_K_GND"]
-
-[[stations]]
 id = "RJTT_W_GND"
 parent_id = "RJTT_GND"
 controlled_by = ["RJTT_W_GND"]
@@ -106,7 +114,7 @@ controlled_by = ["RJTT_W_GND"]
 [[stations]]
 id = "RJTT_N_GND"
 parent_id = "RJTT_GND"
-controlled_by = ["RJTT_N_GND"]
+controlled_by = ["RJTT_N_GND", "RJTT_W_GND"]
 
 [[stations]]
 id = "RJTT_E_GND"
@@ -116,11 +124,16 @@ controlled_by = ["RJTT_E_GND"]
 [[stations]]
 id = "RJTT_S_GND"
 parent_id = "RJTT_GND"
-controlled_by = ["RJTT_S_GND"]
+controlled_by = ["RJTT_S_GND", "RJTT_E_GND"]
+
+[[stations]]
+id = "RJTT_K_GND"
+parent_id = "RJTT_GND"
+controlled_by = ["RJTT_K_GND", "RJTT_W_GND"]
 
 [[stations]]
 id = "RJTT_DEL"
-parent_id = "RJTT_K_GND"
+parent_id = "RJTT_GND"
 controlled_by = ["RJTT_DEL"]
 
 [[stations]]

--- a/dataset/RJ/stations.toml
+++ b/dataset/RJ/stations.toml
@@ -12,7 +12,7 @@ controlled_by = [
   "RJTT_Z_APP",
   "RJTT_V_APP",
   "RJTT_N_DEP",
-  "RJTT_S_DEP"
+  "RJTT_S_DEP",
 ]
 
 [[stations]]
@@ -53,11 +53,7 @@ controlled_by = ["RJTT_Z_APP", "RJTT_S_APP"]
 [[stations]]
 id = "RJTT_DEP"
 parent_id = "RJTT_APP"
-controlled_by = [
-    "RJTT_DEP", 
-    "RJTT_N_DEP", 
-    "RJTT_S_DEP"
-    ]
+controlled_by = ["RJTT_DEP", "RJTT_N_DEP", "RJTT_S_DEP"]
 
 [[stations]]
 id = "RJTT_N_DEP"
@@ -110,13 +106,13 @@ controlled_by = [
 id = "RJTT_GND"
 parent_id = "RJTT_TWR"
 controlled_by = [
-    "RJTT_N_GND", 
-    "RJTT_E_GND", 
-    "RJTT_W_GND", 
-    "RJTT_S_GND", 
-    "RJTT_K_GND", 
-    "RJTT_GND"
-    ]
+  "RJTT_N_GND",
+  "RJTT_E_GND",
+  "RJTT_W_GND",
+  "RJTT_S_GND",
+  "RJTT_K_GND",
+  "RJTT_GND",
+]
 
 [[stations]]
 id = "RJTT_W_GND"
@@ -153,12 +149,12 @@ controlled_by = ["RJTT_DEL"]
 [[stations]]
 id = "RJAA_APP"
 controlled_by = [
-  "RJAA_APP", 
-  "RJAA_S_APP", 
-  "RJAA_R_APP", 
-  "RJAA_B_APP", 
-  "RJAA_E_APP", 
-  "RJAA_A_APP"
+  "RJAA_APP",
+  "RJAA_S_APP",
+  "RJAA_R_APP",
+  "RJAA_B_APP",
+  "RJAA_E_APP",
+  "RJAA_A_APP",
 ]
 
 [[stations]]
@@ -190,13 +186,13 @@ controlled_by = ["RJAA_A_APP"]
 id = "RJAA_DEP"
 parent_id = "RJAA_APP"
 controlled_by = [
-  "RJAA_DEP", 
-  "RJAA_A_DEP", 
-  "RJAA_B_DEP", 
-  "RJAA_R_DEP", 
-  "RJAA_S_DEP", 
-  "RJAA_N_DEP", 
-  "RJAA_W_DEP"
+  "RJAA_DEP",
+  "RJAA_A_DEP",
+  "RJAA_B_DEP",
+  "RJAA_R_DEP",
+  "RJAA_S_DEP",
+  "RJAA_N_DEP",
+  "RJAA_W_DEP",
 ]
 
 [[stations]]

--- a/dataset/RJ/stations.toml
+++ b/dataset/RJ/stations.toml
@@ -1,6 +1,6 @@
 [[stations]]
 id = "RJTT_APP"
-controlled_by = ["RJTT_APP"]
+controlled_by = ["RJTT_APP", "RJTT_N_APP", "RJTT_S_APP"]
 
 [[stations]]
 id = "RJTT_N_APP"
@@ -40,7 +40,11 @@ controlled_by = ["RJTT_Z_APP"]
 [[stations]]
 id = "RJTT_DEP"
 parent_id = "RJTT_APP"
-controlled_by = ["RJTT_DEP"]
+controlled_by = [
+    "RJTT_DEP", 
+    "RJTT_N_DEP", 
+    "RJTT_S_DEP"
+    ]
 
 [[stations]]
 id = "RJTT_N_DEP"
@@ -78,28 +82,40 @@ parent_id = "RJTT_TWR"
 controlled_by = ["RJTT_W_TWR"]
 
 [[stations]]
+id = "RJTT_GND"
+parent_id = "RJTT_TWR"
+controlled_by = [
+    "RJTT_N_GND", 
+    "RJTT_E_GND", 
+    "RJTT_W_GND", 
+    "RJTT_S_GND", 
+    "RJTT_K_GND", 
+    "RJTT_GND"
+    ]
+
+[[stations]]
 id = "RJTT_K_GND"
-parent_id = "RJTT_W_TWR"
+parent_id = "RJTT_GND"
 controlled_by = ["RJTT_K_GND"]
 
 [[stations]]
 id = "RJTT_W_GND"
-parent_id = "RJTT_W_TWR"
+parent_id = "RJTT_GND"
 controlled_by = ["RJTT_W_GND"]
 
 [[stations]]
 id = "RJTT_N_GND"
-parent_id = "RJTT_N_TWR"
+parent_id = "RJTT_GND"
 controlled_by = ["RJTT_N_GND"]
 
 [[stations]]
 id = "RJTT_E_GND"
-parent_id = "RJTT_E_TWR"
+parent_id = "RJTT_GND"
 controlled_by = ["RJTT_E_GND"]
 
 [[stations]]
 id = "RJTT_S_GND"
-parent_id = "RJTT_S_TWR"
+parent_id = "RJTT_GND"
 controlled_by = ["RJTT_S_GND"]
 
 [[stations]]
@@ -109,7 +125,14 @@ controlled_by = ["RJTT_DEL"]
 
 [[stations]]
 id = "RJAA_APP"
-controlled_by = ["RJAA_APP"]
+controlled_by = [
+  "RJAA_APP", 
+  "RJAA_S_APP", 
+  "RJAA_R_APP", 
+  "RJAA_B_APP", 
+  "RJAA_E_APP", 
+  "RJAA_A_APP"
+]
 
 [[stations]]
 id = "RJAA_S_APP"
@@ -139,7 +162,15 @@ controlled_by = ["RJAA_A_APP"]
 [[stations]]
 id = "RJAA_DEP"
 parent_id = "RJAA_APP"
-controlled_by = ["RJAA_DEP"]
+controlled_by = [
+  "RJAA_DEP", 
+  "RJAA_A_DEP", 
+  "RJAA_B_DEP", 
+  "RJAA_R_DEP", 
+  "RJAA_S_DEP", 
+  "RJAA_N_DEP", 
+  "RJAA_W_DEP"
+]
 
 [[stations]]
 id = "RJAA_A_DEP"

--- a/dataset/RJ/stations.toml
+++ b/dataset/RJ/stations.toml
@@ -103,20 +103,7 @@ controlled_by = [
 ]
 
 [[stations]]
-id = "RJTT_GND"
-parent_id = "RJTT_TWR"
-controlled_by = [
-  "RJTT_N_GND",
-  "RJTT_E_GND",
-  "RJTT_W_GND",
-  "RJTT_S_GND",
-  "RJTT_K_GND",
-  "RJTT_GND",
-]
-
-[[stations]]
 id = "RJTT_W_GND"
-parent_id = "RJTT_GND"
 parent_id = "RJTT_GND"
 controlled_by = ["RJTT_W_GND"]
 
@@ -127,7 +114,6 @@ controlled_by = ["RJTT_N_GND", "RJTT_W_GND"]
 
 [[stations]]
 id = "RJTT_E_GND"
-parent_id = "RJTT_GND"
 parent_id = "RJTT_GND"
 controlled_by = ["RJTT_E_GND"]
 


### PR DESCRIPTION
### Description

<!-- What does this PR change and why? -->
Adds a smarter fallback for offline positions

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
