### PR TITLE
add ADRIA stations to LRBB profile

### DIFF
--- a/dataset/LR/profiles/LRBB.json
+++ b/dataset/LR/profiles/LRBB.json
@@ -8,19 +8,11 @@
         "rows": 7,
         "keys": [
           {
-            "label": [
-              "ADRIA",
-              "EAST",
-              "F335-660"
-            ],
+            "label": ["ADRIA", "EAST", "F335-660"],
             "station_id": "ADRIA-EAST-UPPER"
           },
           {
-            "label": [
-              "ADRIA",
-              "EAST",
-              "GND-F335"
-            ],
+            "label": ["ADRIA", "EAST", "GND-F335"],
             "station_id": "ADRIA-EAST"
           },
           {
@@ -56,11 +48,7 @@
             "station_id": "LYBA-UPPER-EAST"
           },
           {
-            "label": [
-              "BEO_N",
-              "MID",
-              "F125-F335"
-            ],
+            "label": ["BEO_N", "MID", "F125-F335"],
             "station_id": "LYBA-NORTH"
           },
           {
@@ -118,11 +106,7 @@
             "label": ["BPS_EN", "MID", ""]
           },
           {
-            "label": [
-              "BPS_EN",
-              "LOW",
-              "F095-345"
-            ],
+            "label": ["BPS_EN", "LOW", "F095-345"],
             "station_id": "LHCC_CTR"
           },
           {
@@ -143,11 +127,7 @@
             "station_id": "LHCC_NU"
           },
           {
-            "label": [
-              "BPS_EN",
-              "FIC",
-              "GND-9500"
-            ],
+            "label": ["BPS_EN", "FIC", "GND-9500"],
             "station_id": "LHCC_EFIC"
           },
           {

--- a/dataset/LR/profiles/LRBB.json
+++ b/dataset/LR/profiles/LRBB.json
@@ -8,22 +8,68 @@
         "rows": 7,
         "keys": [
           {
-            "label": ["BEO", "STP", "F385-660"]
+            "label": [
+              "ADRIA",
+              "EAST",
+              "F335-660"
+            ],
+            "station_id": "ADRIA-EAST-UPPER"
           },
           {
-            "label": ["BEO", "TOP", "F365-385"]
+            "label": [
+              "ADRIA",
+              "EAST",
+              "GND-F335"
+            ],
+            "station_id": "ADRIA-EAST"
           },
           {
-            "label": ["BEO", "UPP", "F345-365"]
+            "label": ["ADRIA", "ALL", "F335-660"],
+            "station_id": "ADRIA-UPPER"
           },
           {
-            "label": ["BEO", "MID", "F325-345"]
+            "label": ["ADRIA", "ALL", "GND-F335"],
+            "station_id": "ADRIA"
           },
           {
-            "label": ["BEO", "LOW", "F205-325"]
+            "label": ["BEO", "APP", "GND-205"],
+            "station_id": "LYBE_APP"
           },
           {
-            "label": ["BEO", "APP", "GNF-205"]
+            "label": ["MIL", "APP", "GND-F125"],
+            "station_id": "LYBT_APP"
+          },
+          {
+            "label": ["VRSAC", "APP", "GND-F075"],
+            "station_id": "LYVR_APP"
+          },
+          {
+            "label": ["BEO_N", "UPP", "F335-660"],
+            "station_id": "LYBA-UPPER-NORTH"
+          },
+          {
+            "label": ["BEO", "UPP", "F335-660"],
+            "station_id": "LYBA-UPPER"
+          },
+          {
+            "label": ["BEO_E", "UPP", "F335-660"],
+            "station_id": "LYBA-UPPER-EAST"
+          },
+          {
+            "label": [
+              "BEO_N",
+              "MID",
+              "F125-F335"
+            ],
+            "station_id": "LYBA-NORTH"
+          },
+          {
+            "label": ["BEO", "MID", "GND-F335"],
+            "station_id": "LYBA"
+          },
+          {
+            "label": ["BEO_E", "MID", "F125-335"],
+            "station_id": "LYBA-EAST"
           },
           {
             "label": ["BELGRAD", "FDA"]
@@ -72,7 +118,11 @@
             "label": ["BPS_EN", "MID", ""]
           },
           {
-            "label": ["BPS_EN", "LOW", "F095-345"],
+            "label": [
+              "BPS_EN",
+              "LOW",
+              "F095-345"
+            ],
             "station_id": "LHCC_CTR"
           },
           {
@@ -93,7 +143,11 @@
             "station_id": "LHCC_NU"
           },
           {
-            "label": ["BPS_EN", "FIC", "GND-9500"],
+            "label": [
+              "BPS_EN",
+              "FIC",
+              "GND-9500"
+            ],
             "station_id": "LHCC_EFIC"
           },
           {
@@ -339,7 +393,24 @@
             "station_id": "LRCL_S_APP"
           },
           {
-            "label": ["SUP", "SALA"]
+            "label": ["SUP", "SALA"],
+            "page": {
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["ACC", "X1"]
+                },
+                {
+                  "label": ["ACC", "X2"]
+                },
+                {
+                  "label": ["APP", "X"]
+                },
+                {
+                  "label": ["TWR", "X"]
+                }
+              ]
+            }
           },
           {
             "label": ["SUP", "INF"]


### PR DESCRIPTION
### Description

- add callable buttons from ADRIA
- add a subpage on SUP SALA button

<!-- What does this PR change and why? -->

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
