### PR TITLE
convert NAT from CTP to normal ops

### DIFF
--- a/dataset/NAT/positions.toml
+++ b/dataset/NAT/positions.toml
@@ -19,7 +19,7 @@ id = "CZQO_A_CTR"
 prefixes = ["CZQO"]
 frequency = "131.575"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Gander_A"]
 
 [[positions]]
@@ -27,7 +27,7 @@ id = "CZQO_A_DEL"
 prefixes = ["CZQO"]
 frequency = "119.425"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Gander_DEL_A"]
 
 [[positions]]
@@ -35,7 +35,7 @@ id = "CZQO_B_CTR"
 prefixes = ["CZQO"]
 frequency = "131.675"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Gander_B"]
 
 [[positions]]
@@ -43,7 +43,7 @@ id = "CZQO_B_DEL"
 prefixes = ["CZQO"]
 frequency = "135.050"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Gander_DEL_B"]
 
 [[positions]]
@@ -51,7 +51,7 @@ id = "CZQO_C_CTR"
 prefixes = ["CZQO"]
 frequency = "131.775"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Gander_C"]
 
 [[positions]]
@@ -59,7 +59,7 @@ id = "CZQO_C_DEL"
 prefixes = ["CZQO"]
 frequency = "128.450"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Gander_DEL_C"]
 
 [[positions]]
@@ -67,7 +67,7 @@ id = "CZQO_D_CTR"
 prefixes = ["CZQO"]
 frequency = "131.875"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Gander_D"]
 
 [[positions]]
@@ -75,7 +75,7 @@ id = "CZQO_D_DEL"
 prefixes = ["CZQO"]
 frequency = "135.450"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Gander_DEL_D"]
 
 [[positions]]
@@ -83,7 +83,7 @@ id = "CZQO_F_CTR"
 prefixes = ["CZQO"]
 frequency = "131.975"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Gander_F"]
 
 [[positions]]
@@ -91,7 +91,7 @@ id = "CZQO_F_DEL"
 prefixes = ["CZQO"]
 frequency = "134.200"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Gander_DEL_F"]
 
 [[positions]]
@@ -99,7 +99,7 @@ id = "CZQO_G_CTR"
 prefixes = ["CZQO"]
 frequency = "131.475"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Gander_G"]
 
 [[positions]]
@@ -123,7 +123,7 @@ id = "EGGX_A_CTR"
 prefixes = ["EGGX"]
 frequency = "131.450"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_A"]
 
 [[positions]]
@@ -131,7 +131,7 @@ id = "EGGX_1_CTR"
 prefixes = ["EGGX"]
 frequency = "131.450"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_A"]
 
 [[positions]]
@@ -139,7 +139,7 @@ id = "EGGX_A_DEL"
 prefixes = ["EGGX"]
 frequency = "127.900"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_DEL_A"]
 
 [[positions]]
@@ -147,7 +147,7 @@ id = "EGGX_1_DEL"
 prefixes = ["EGGX"]
 frequency = "127.900"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_DEL_A"]
 
 [[positions]]
@@ -155,7 +155,7 @@ id = "EGGX_B_CTR"
 prefixes = ["EGGX"]
 frequency = "131.550"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_B"]
 
 [[positions]]
@@ -163,7 +163,7 @@ id = "EGGX_2_CTR"
 prefixes = ["EGGX"]
 frequency = "131.550"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_B"]
 
 [[positions]]
@@ -171,7 +171,7 @@ id = "EGGX_B_DEL"
 prefixes = ["EGGX"]
 frequency = "123.950"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_DEL_B"]
 
 [[positions]]
@@ -179,7 +179,7 @@ id = "EGGX_2_DEL"
 prefixes = ["EGGX"]
 frequency = "123.950"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_DEL_B"]
 
 [[positions]]
@@ -187,7 +187,7 @@ id = "EGGX_C_CTR"
 prefixes = ["EGGX"]
 frequency = "131.650"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_C"]
 
 [[positions]]
@@ -195,7 +195,7 @@ id = "EGGX_3_CTR"
 prefixes = ["EGGX"]
 frequency = "131.650"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_C"]
 
 [[positions]]
@@ -203,7 +203,7 @@ id = "EGGX_C_DEL"
 prefixes = ["EGGX"]
 frequency = "124.175"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_DEL_C"]
 
 [[positions]]
@@ -211,7 +211,7 @@ id = "EGGX_3_DEL"
 prefixes = ["EGGX"]
 frequency = "124.175"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_DEL_C"]
 
 [[positions]]
@@ -219,7 +219,7 @@ id = "EGGX_D_CTR"
 prefixes = ["EGGX"]
 frequency = "131.750"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_D"]
 
 [[positions]]
@@ -227,7 +227,7 @@ id = "EGGX_4_CTR"
 prefixes = ["EGGX"]
 frequency = "131.750"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_D"]
 
 [[positions]]
@@ -235,7 +235,7 @@ id = "EGGX_D_DEL"
 prefixes = ["EGGX"]
 frequency = "126.375"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_DEL_D"]
 
 [[positions]]
@@ -243,7 +243,7 @@ id = "EGGX_4_DEL"
 prefixes = ["EGGX"]
 frequency = "126.375"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_DEL_D"]
 
 [[positions]]
@@ -251,7 +251,7 @@ id = "EGGX_F_CTR"
 prefixes = ["EGGX"]
 frequency = "131.850"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_F"]
 
 [[positions]]
@@ -259,7 +259,7 @@ id = "EGGX_5_CTR"
 prefixes = ["EGGX"]
 frequency = "131.850"
 facility_type = "CTR"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_F"]
 
 [[positions]]
@@ -267,7 +267,7 @@ id = "EGGX_F_DEL"
 prefixes = ["EGGX"]
 frequency = "128.375"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_DEL_F"]
 
 [[positions]]
@@ -275,7 +275,7 @@ id = "EGGX_5_DEL"
 prefixes = ["EGGX"]
 frequency = "128.375"
 facility_type = "DEL"
-profile_id = "NAT"
+profile_id = "NAT-EVENT"
 default_call_sources = ["Shanwick_DEL_F"]
 
 [[positions]]

--- a/dataset/NAT/profiles/NAT-EVENT.json
+++ b/dataset/NAT/profiles/NAT-EVENT.json
@@ -1,5 +1,5 @@
 {
-  "id": "NAT",
+  "id": "NAT-EVENT",
   "type": "Geo",
   "direction": "row",
   "padding": 0.5,
@@ -324,7 +324,6 @@
       "direction": "col",
       "height": "100%",
       "justify_content": "space-between",
-      "align_items": "center",
       "gap": 0.75,
       "children": [
         {
@@ -430,216 +429,214 @@
           ]
         },
         {
-          "direction": "col",
-          "gap": 0.5,
-          "align_items": "center",
+          "direction": "row",
+          "gap": 3,
           "children": [
             {
-              "direction": "row",
-              "gap": 2,
-              "align_items": "center",
-              "children": [
-                {
-                  "label": [
-                    "Gander",
-                    "Radio"
-                  ],
-                  "size": 11,
-                  "station_id": "Gander"
-                },
-                {
-                  "label": [
-                    "Shanwick",
-                    "Radio"
-                  ],
-                  "size": 11,
-                  "station_id": "Shanwick"
-                }
-              ]
+              "label": [
+                "Gander"
+              ],
+              "size": 12,
+              "page": {
+                "rows": 6,
+                "keys": [
+                  {
+                    "label": [
+                      "DEL",
+                      "A"
+                    ],
+                    "station_id": "Gander_DEL_A"
+                  },
+                  {
+                    "label": [
+                      "DEL",
+                      "B"
+                    ],
+                    "station_id": "Gander_DEL_B"
+                  },
+                  {
+                    "label": [
+                      "DEL",
+                      "C"
+                    ],
+                    "station_id": "Gander_DEL_C"
+                  },
+                  {
+                    "label": [
+                      "DEL",
+                      "D"
+                    ],
+                    "station_id": "Gander_DEL_D"
+                  },
+                  {
+                    "label": [
+                      "DEL",
+                      "F"
+                    ],
+                    "station_id": "Gander_DEL_F"
+                  },
+                  {
+                    "label": []
+                  },
+                  {
+                    "label": [
+                      "A"
+                    ],
+                    "station_id": "Gander_A"
+                  },
+                  {
+                    "label": [
+                      "B"
+                    ],
+                    "station_id": "Gander_B"
+                  },
+                  {
+                    "label": [
+                      "C"
+                    ],
+                    "station_id": "Gander_C"
+                  },
+                  {
+                    "label": [
+                      "D"
+                    ],
+                    "station_id": "Gander_D"
+                  },
+                  {
+                    "label": [
+                      "F"
+                    ],
+                    "station_id": "Gander_F"
+                  },
+                  {
+                    "label": [
+                      "G"
+                    ],
+                    "station_id": "Gander_G"
+                  },
+                  {
+                    "label": []
+                  },
+                  {
+                    "label": []
+                  },
+                  {
+                    "label": [
+                      "Gander"
+                    ],
+                    "station_id": "Gander"
+                  },
+                  {
+                    "label": [
+                      "DEL"
+                    ],
+                    "station_id": "Gander_DEL"
+                  },
+                  {
+                    "label": []
+                  },
+                  {
+                    "label": []
+                  }
+                ]
+              }
             },
             {
-              "direction": "row",
-              "gap": 1,
-              "align_items": "center",
-              "children": [
-                {
-                  "label": [
-                    "CZQO",
-                    "Splits"
-                  ],
-                  "size": 5,
-                  "page": {
-                    "rows": 6,
-                    "keys": [
-                      {
-                        "label": [
-                          "CZQO",
-                          "DEL"
-                        ],
-                        "station_id": "Gander_DEL"
-                      },
-                      {
-                        "label": [
-                          "DEL",
-                          "A"
-                        ],
-                        "station_id": "Gander_DEL_A"
-                      },
-                      {
-                        "label": [
-                          "DEL",
-                          "B"
-                        ],
-                        "station_id": "Gander_DEL_B"
-                      },
-                      {
-                        "label": [
-                          "DEL",
-                          "C"
-                        ],
-                        "station_id": "Gander_DEL_C"
-                      },
-                      {
-                        "label": [
-                          "DEL",
-                          "D"
-                        ],
-                        "station_id": "Gander_DEL_D"
-                      },
-                      {
-                        "label": [
-                          "DEL",
-                          "F"
-                        ],
-                        "station_id": "Gander_DEL_F"
-                      },
-                      {
-                        "label": [
-                          "A"
-                        ],
-                        "station_id": "Gander_A"
-                      },
-                      {
-                        "label": [
-                          "B"
-                        ],
-                        "station_id": "Gander_B"
-                      },
-                      {
-                        "label": [
-                          "C"
-                        ],
-                        "station_id": "Gander_C"
-                      },
-                      {
-                        "label": [
-                          "D"
-                        ],
-                        "station_id": "Gander_D"
-                      },
-                      {
-                        "label": [
-                          "F"
-                        ],
-                        "station_id": "Gander_F"
-                      },
-                      {
-                        "label": [
-                          "G"
-                        ],
-                        "station_id": "Gander_G"
-                      }
-                    ]
+              "label": [
+                "Shanwick"
+              ],
+              "size": 12,
+              "page": {
+                "rows": 5,
+                "keys": [
+                  {
+                    "label": [
+                      "DEL",
+                      "A"
+                    ],
+                    "station_id": "Shanwick_DEL_A"
+                  },
+                  {
+                    "label": [
+                      "DEL",
+                      "B"
+                    ],
+                    "station_id": "Shanwick_DEL_B"
+                  },
+                  {
+                    "label": [
+                      "DEL",
+                      "C"
+                    ],
+                    "station_id": "Shanwick_DEL_C"
+                  },
+                  {
+                    "label": [
+                      "DEL",
+                      "D"
+                    ],
+                    "station_id": "Shanwick_DEL_D"
+                  },
+                  {
+                    "label": [
+                      "DEL",
+                      "F"
+                    ],
+                    "station_id": "Shanwick_DEL_F"
+                  },
+                  {
+                    "label": [
+                      "A"
+                    ],
+                    "station_id": "Shanwick_A"
+                  },
+                  {
+                    "label": [
+                      "B"
+                    ],
+                    "station_id": "Shanwick_B"
+                  },
+                  {
+                    "label": [
+                      "C"
+                    ],
+                    "station_id": "Shanwick_C"
+                  },
+                  {
+                    "label": [
+                      "D"
+                    ],
+                    "station_id": "Shanwick_D"
+                  },
+                  {
+                    "label": [
+                      "F"
+                    ],
+                    "station_id": "Shanwick_F"
+                  },
+                  {
+                    "label": []
+                  },
+                  {
+                    "label": []
+                  },
+                  {
+                    "label": [
+                      "Shanwick"
+                    ],
+                    "station_id": "Shanwick"
+                  },
+                  {
+                    "label": [
+                      "DEL"
+                    ],
+                    "station_id": "Shanwick_DEL"
+                  },
+                  {
+                    "label": []
                   }
-                },
-                {
-                  "label": [
-                    "EGGX",
-                    "Splits"
-                  ],
-                  "size": 5,
-                  "page": {
-                    "rows": 6,
-                    "keys": [
-                      {
-                        "label": [
-                          "EGGX",
-                          "DEL"
-                        ],
-                        "station_id": "Shanwick_DEL"
-                      },
-                      {
-                        "label": [
-                          "DEL",
-                          "A"
-                        ],
-                        "station_id": "Shanwick_DEL_A"
-                      },
-                      {
-                        "label": [
-                          "DEL",
-                          "B"
-                        ],
-                        "station_id": "Shanwick_DEL_B"
-                      },
-                      {
-                        "label": [
-                          "DEL",
-                          "C"
-                        ],
-                        "station_id": "Shanwick_DEL_C"
-                      },
-                      {
-                        "label": [
-                          "DEL",
-                          "D"
-                        ],
-                        "station_id": "Shanwick_DEL_D"
-                      },
-                      {
-                        "label": [
-                          "DEL",
-                          "F"
-                        ],
-                        "station_id": "Shanwick_DEL_F"
-                      },
-                      {
-                        "label": [
-                          "A"
-                        ],
-                        "station_id": "Shanwick_A"
-                      },
-                      {
-                        "label": [
-                          "B"
-                        ],
-                        "station_id": "Shanwick_B"
-                      },
-                      {
-                        "label": [
-                          "C"
-                        ],
-                        "station_id": "Shanwick_C"
-                      },
-                      {
-                        "label": [
-                          "D"
-                        ],
-                        "station_id": "Shanwick_D"
-                      },
-                      {
-                        "label": [
-                          "F"
-                        ],
-                        "station_id": "Shanwick_F"
-                      },
-                      {
-                        "label": []
-                      }
-                    ]
-                  }
-                }
-              ]
+                ]
+              }
             }
           ]
         },

--- a/dataset/NAT/profiles/NAT-EVENT.json
+++ b/dataset/NAT/profiles/NAT-EVENT.json
@@ -13,69 +13,45 @@
       "gap": 0.75,
       "children": [
         {
-          "label": [
-            "Edmonton",
-            "(INOP)"
-          ],
+          "label": ["Edmonton", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "INOP"
-                ]
+                "label": ["INOP"]
               }
             ]
           }
         },
         {
-          "label": [
-            "Montreal",
-            "(INOP)"
-          ],
+          "label": ["Montreal", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "INOP"
-                ]
+                "label": ["INOP"]
               }
             ]
           }
         },
         {
-          "label": [
-            "Gander",
-            "Domestic"
-          ],
+          "label": ["Gander", "Domestic"],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "Gander",
-                  "Domestic"
-                ],
+                "label": ["Gander", "Domestic"],
                 "station_id": "CZQX-CTR"
               },
               {
-                "label": [
-                  "GOTA",
-                  "North",
-                  "QX 7"
-                ],
+                "label": ["GOTA", "North", "QX 7"],
                 "station_id": "CZQX-7-CTR"
               },
               {
-                "label": [
-                  "GOTA",
-                  "South",
-                  "QX 6"
-                ],
+                "label": ["GOTA", "South", "QX 6"],
                 "station_id": "CZQX-6-CTR"
               },
               {
@@ -100,219 +76,125 @@
                 "label": []
               },
               {
-                "label": [
-                  "QX",
-                  "5"
-                ],
+                "label": ["QX", "5"],
                 "station_id": "CZQX-5-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "4"
-                ],
+                "label": ["QX", "4"],
                 "station_id": "CZQX-4-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "3"
-                ],
+                "label": ["QX", "3"],
                 "station_id": "CZQX-3-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "2"
-                ],
+                "label": ["QX", "2"],
                 "station_id": "CZQX-2-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "1"
-                ],
+                "label": ["QX", "1"],
                 "station_id": "CZQX-1-CTR"
               }
             ]
           }
         },
         {
-          "label": [
-            "New York"
-          ],
+          "label": ["New York"],
           "size": 7,
           "page": {
             "rows": 6,
             "keys": [
               {
-                "label": [
-                  "JOBOC",
-                  "65"
-                ],
+                "label": ["JOBOC", "65"],
                 "station_id": "JOBOC"
               },
               {
-                "label": [
-                  "OHRYN",
-                  "85"
-                ],
+                "label": ["OHRYN", "85"],
                 "station_id": "OHRYN"
               },
               {
-                "label": [
-                  "ATLANTIC",
-                  "86"
-                ],
+                "label": ["ATLANTIC", "86"],
                 "station_id": "ATLANTIC"
               },
               {
-                "label": [
-                  "PAEPR",
-                  "82"
-                ],
+                "label": ["PAEPR", "82"],
                 "station_id": "PAEPR"
               },
               {
-                "label": [
-                  "HANRI",
-                  "83"
-                ],
+                "label": ["HANRI", "83"],
                 "station_id": "HANRI"
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "CHAMP",
-                  "87",
-                  "High"
-                ],
+                "label": ["CHAMP", "87", "High"],
                 "station_id": "CHAMP_H"
               },
               {
-                "label": [
-                  "CHAMP",
-                  "87",
-                  "Low"
-                ],
+                "label": ["CHAMP", "87", "Low"],
                 "station_id": "CHAMP_L"
               },
               {
-                "label": [
-                  "BACUS",
-                  "88",
-                  "High"
-                ],
+                "label": ["BACUS", "88", "High"],
                 "station_id": "BACUS_H"
               },
               {
-                "label": [
-                  "BACUS",
-                  "88",
-                  "Low"
-                ],
+                "label": ["BACUS", "88", "Low"],
                 "station_id": "BACUS_L"
               },
               {
-                "label": [
-                  "GRATX",
-                  "90",
-                  "High"
-                ],
+                "label": ["GRATX", "90", "High"],
                 "station_id": "GRATX_H"
               },
               {
-                "label": [
-                  "GRATX",
-                  "90",
-                  "Low"
-                ],
+                "label": ["GRATX", "90", "Low"],
                 "station_id": "GRATX_L"
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "COCOA",
-                  "80"
-                ],
+                "label": ["COCOA", "80"],
                 "station_id": "COCOA"
               },
               {
-                "label": [
-                  "HILDY",
-                  "81"
-                ],
+                "label": ["HILDY", "81"],
                 "station_id": "HILDY"
               },
               {
-                "label": [
-                  "KRAFT",
-                  "89",
-                  "High"
-                ],
+                "label": ["KRAFT", "89", "High"],
                 "station_id": "KRAFT_H"
               },
               {
-                "label": [
-                  "KRAFT",
-                  "89",
-                  "Low"
-                ],
+                "label": ["KRAFT", "89", "Low"],
                 "station_id": "KRAFT_L"
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "MERCURY",
-                  "21-24",
-                  "High"
-                ],
+                "label": ["MERCURY", "21-24", "High"],
                 "station_id": "MERCURY_H"
               },
               {
-                "label": [
-                  "MERCURY",
-                  "21-24",
-                  "Low"
-                ],
+                "label": ["MERCURY", "21-24", "Low"],
                 "station_id": "MERCURY_L"
               },
               {
-                "label": [
-                  "GEMINI",
-                  "18-20",
-                  "High"
-                ],
+                "label": ["GEMINI", "18-20", "High"],
                 "station_id": "GEMINI_H"
               },
               {
-                "label": [
-                  "GEMINI",
-                  "18-20",
-                  "Low"
-                ],
+                "label": ["GEMINI", "18-20", "Low"],
                 "station_id": "GEMINI_L"
               },
               {
-                "label": [
-                  "APOLLO",
-                  "16-17",
-                  "High"
-                ],
+                "label": ["APOLLO", "16-17", "High"],
                 "station_id": "APOLLO_H"
               },
               {
-                "label": [
-                  "APOLLO",
-                  "16-17",
-                  "Low"
-                ],
+                "label": ["APOLLO", "16-17", "Low"],
                 "station_id": "APOLLO_L"
               }
             ]
@@ -331,97 +213,46 @@
           "justify_content": "center",
           "children": [
             {
-              "label": [
-                "Reykjavík",
-                "(INOP)"
-              ],
+              "label": ["Reykjavík", "(INOP)"],
               "size": 7,
               "page": {
                 "rows": 4,
                 "keys": [
                   {
-                    "label": [
-                      "West",
-                      "Upper",
-                      "365-660"
-                    ]
+                    "label": ["West", "Upper", "365-660"]
                   },
                   {
-                    "label": [
-                      "West",
-                      "Middle",
-                      "355-365"
-                    ]
+                    "label": ["West", "Middle", "355-365"]
                   },
                   {
-                    "label": [
-                      "West",
-                      "Middle",
-                      "345-355"
-                    ]
+                    "label": ["West", "Middle", "345-355"]
                   },
                   {
-                    "label": [
-                      "West",
-                      "Lower",
-                      "55-345"
-                    ]
+                    "label": ["West", "Lower", "55-345"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Upper",
-                      "365-660"
-                    ]
+                    "label": ["South", "Upper", "365-660"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Middle",
-                      "355-365"
-                    ]
+                    "label": ["South", "Middle", "355-365"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Middle",
-                      "345-355"
-                    ]
+                    "label": ["South", "Middle", "345-355"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Lower",
-                      "55-345"
-                    ]
+                    "label": ["South", "Lower", "55-345"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Upper",
-                      "365-660"
-                    ]
+                    "label": ["East", "Upper", "365-660"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Middle",
-                      "355-365"
-                    ]
+                    "label": ["East", "Middle", "355-365"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Middle",
-                      "345-355"
-                    ]
+                    "label": ["East", "Middle", "345-355"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Lower",
-                      "55-345"
-                    ]
+                    "label": ["East", "Lower", "55-345"]
                   }
                 ]
               }
@@ -433,85 +264,56 @@
           "gap": 3,
           "children": [
             {
-              "label": [
-                "Gander"
-              ],
+              "label": ["Gander"],
               "size": 12,
               "page": {
                 "rows": 6,
                 "keys": [
                   {
-                    "label": [
-                      "DEL",
-                      "A"
-                    ],
+                    "label": ["DEL", "A"],
                     "station_id": "Gander_DEL_A"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "B"
-                    ],
+                    "label": ["DEL", "B"],
                     "station_id": "Gander_DEL_B"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "C"
-                    ],
+                    "label": ["DEL", "C"],
                     "station_id": "Gander_DEL_C"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "D"
-                    ],
+                    "label": ["DEL", "D"],
                     "station_id": "Gander_DEL_D"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "F"
-                    ],
+                    "label": ["DEL", "F"],
                     "station_id": "Gander_DEL_F"
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": [
-                      "A"
-                    ],
+                    "label": ["A"],
                     "station_id": "Gander_A"
                   },
                   {
-                    "label": [
-                      "B"
-                    ],
+                    "label": ["B"],
                     "station_id": "Gander_B"
                   },
                   {
-                    "label": [
-                      "C"
-                    ],
+                    "label": ["C"],
                     "station_id": "Gander_C"
                   },
                   {
-                    "label": [
-                      "D"
-                    ],
+                    "label": ["D"],
                     "station_id": "Gander_D"
                   },
                   {
-                    "label": [
-                      "F"
-                    ],
+                    "label": ["F"],
                     "station_id": "Gander_F"
                   },
                   {
-                    "label": [
-                      "G"
-                    ],
+                    "label": ["G"],
                     "station_id": "Gander_G"
                   },
                   {
@@ -521,15 +323,11 @@
                     "label": []
                   },
                   {
-                    "label": [
-                      "Gander"
-                    ],
+                    "label": ["Gander"],
                     "station_id": "Gander"
                   },
                   {
-                    "label": [
-                      "DEL"
-                    ],
+                    "label": ["DEL"],
                     "station_id": "Gander_DEL"
                   },
                   {
@@ -542,76 +340,49 @@
               }
             },
             {
-              "label": [
-                "Shanwick"
-              ],
+              "label": ["Shanwick"],
               "size": 12,
               "page": {
                 "rows": 5,
                 "keys": [
                   {
-                    "label": [
-                      "DEL",
-                      "A"
-                    ],
+                    "label": ["DEL", "A"],
                     "station_id": "Shanwick_DEL_A"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "B"
-                    ],
+                    "label": ["DEL", "B"],
                     "station_id": "Shanwick_DEL_B"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "C"
-                    ],
+                    "label": ["DEL", "C"],
                     "station_id": "Shanwick_DEL_C"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "D"
-                    ],
+                    "label": ["DEL", "D"],
                     "station_id": "Shanwick_DEL_D"
                   },
                   {
-                    "label": [
-                      "DEL",
-                      "F"
-                    ],
+                    "label": ["DEL", "F"],
                     "station_id": "Shanwick_DEL_F"
                   },
                   {
-                    "label": [
-                      "A"
-                    ],
+                    "label": ["A"],
                     "station_id": "Shanwick_A"
                   },
                   {
-                    "label": [
-                      "B"
-                    ],
+                    "label": ["B"],
                     "station_id": "Shanwick_B"
                   },
                   {
-                    "label": [
-                      "C"
-                    ],
+                    "label": ["C"],
                     "station_id": "Shanwick_C"
                   },
                   {
-                    "label": [
-                      "D"
-                    ],
+                    "label": ["D"],
                     "station_id": "Shanwick_D"
                   },
                   {
-                    "label": [
-                      "F"
-                    ],
+                    "label": ["F"],
                     "station_id": "Shanwick_F"
                   },
                   {
@@ -621,15 +392,11 @@
                     "label": []
                   },
                   {
-                    "label": [
-                      "Shanwick"
-                    ],
+                    "label": ["Shanwick"],
                     "station_id": "Shanwick"
                   },
                   {
-                    "label": [
-                      "DEL"
-                    ],
+                    "label": ["DEL"],
                     "station_id": "Shanwick_DEL"
                   },
                   {
@@ -645,56 +412,34 @@
           "justify_content": "center",
           "children": [
             {
-              "label": [
-                "Santa",
-                "Maria",
-                "(INOP)"
-              ],
+              "label": ["Santa", "Maria", "(INOP)"],
               "size": 7,
               "page": {
                 "rows": 3,
                 "keys": [
                   {
-                    "label": [
-                      "Oceanic",
-                      "clearance"
-                    ]
+                    "label": ["Oceanic", "clearance"]
                   },
                   {
-                    "label": [
-                      "Oceanic",
-                      "clearance",
-                      "2"
-                    ]
+                    "label": ["Oceanic", "clearance", "2"]
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": [
-                      "Radio",
-                      "1"
-                    ]
+                    "label": ["Radio", "1"]
                   },
                   {
-                    "label": [
-                      "Radio",
-                      "2"
-                    ]
+                    "label": ["Radio", "2"]
                   },
                   {
-                    "label": [
-                      "Radio",
-                      "3"
-                    ]
+                    "label": ["Radio", "3"]
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": [
-                      "Radio"
-                    ]
+                    "label": ["Radio"]
                   },
                   {
                     "label": []
@@ -713,42 +458,25 @@
       "gap": 0.75,
       "children": [
         {
-          "label": [
-            "Scottish/",
-            "EGLL"
-          ],
+          "label": ["Scottish/", "EGLL"],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": [
-                  "Hebrides",
-                  "High",
-                  "255-660"
-                ],
+                "label": ["Hebrides", "High", "255-660"],
                 "station_id": "EG-Hebrides-High"
               },
               {
-                "label": [
-                  "Central",
-                  "255-660"
-                ],
+                "label": ["Central", "255-660"],
                 "station_id": "EG-Central"
               },
               {
-                "label": [
-                  "Hebrides",
-                  "Low",
-                  "DB-255"
-                ],
+                "label": ["Hebrides", "Low", "DB-255"],
                 "station_id": "EG-Hebrides-Low"
               },
               {
-                "label": [
-                  "Central",
-                  "DB-255"
-                ],
+                "label": ["Central", "DB-255"],
                 "station_id": "EG-Westcoast-Central"
               },
               {
@@ -758,10 +486,7 @@
                 "label": []
               },
               {
-                "label": [
-                  "EGLL",
-                  "PLN"
-                ],
+                "label": ["EGLL", "PLN"],
                 "station_id": "EGLL_P_GND"
               },
               {
@@ -771,86 +496,48 @@
           }
         },
         {
-          "label": [
-            "Shannon"
-          ],
+          "label": ["Shannon"],
           "size": 7,
           "page": {
             "rows": 4,
             "keys": [
               {
-                "label": [
-                  "NOTA",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["NOTA", "Super", "355+"],
                 "station_id": "EISN_NS_CTR"
               },
               {
-                "label": [
-                  "West",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["West", "Super", "355+"],
                 "station_id": "EISN_WS_CTR"
               },
               {
-                "label": [
-                  "Ocean",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["Ocean", "Super", "355+"],
                 "station_id": "EISN_SS_CTR"
               },
               {
-                "label": [
-                  "SOTA",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["SOTA", "Super", "355+"],
                 "station_id": "EISN_SS_CTR"
               },
               {
-                "label": [
-                  "NOTA",
-                  "Upper",
-                  "245-355"
-                ],
+                "label": ["NOTA", "Upper", "245-355"],
                 "station_id": "EISN_N_CTR"
               },
               {
-                "label": [
-                  "West",
-                  "Upper",
-                  "245-355"
-                ],
+                "label": ["West", "Upper", "245-355"],
                 "station_id": "EISN_W_CTR"
               },
               {
-                "label": [
-                  "Ocean",
-                  "Upper",
-                  "245-355"
-                ],
+                "label": ["Ocean", "Upper", "245-355"],
                 "station_id": "EISN_O_CTR"
               },
               {
-                "label": [
-                  "SOTA",
-                  "Upper",
-                  "245-255"
-                ],
+                "label": ["SOTA", "Upper", "245-255"],
                 "station_id": "EISN_S_CTR"
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "Low",
-                  "Level",
-                  "245-"
-                ],
+                "label": ["Low", "Level", "245-"],
                 "station_id": "EISN_LS_CTR"
               },
               {
@@ -863,40 +550,25 @@
           }
         },
         {
-          "label": [
-            "Brest",
-            "(INOP)"
-          ],
+          "label": ["Brest", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": [
-                  "West",
-                  "255+"
-                ]
+                "label": ["West", "255+"]
               },
               {
-                "label": [
-                  "AU",
-                  "355-660"
-                ]
+                "label": ["AU", "355-660"]
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "AS",
-                  "255-355"
-                ]
+                "label": ["AS", "255-355"]
               },
               {
-                "label": [
-                  "Lower",
-                  "255-"
-                ]
+                "label": ["Lower", "255-"]
               },
               {
                 "label": []
@@ -905,25 +577,16 @@
           }
         },
         {
-          "label": [
-            "Madrid",
-            "(INOP)"
-          ],
+          "label": ["Madrid", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": [
-                  "Upper",
-                  "245-660"
-                ]
+                "label": ["Upper", "245-660"]
               },
               {
-                "label": [
-                  "Lower",
-                  "245-"
-                ]
+                "label": ["Lower", "245-"]
               }
             ]
           }

--- a/dataset/NAT/profiles/NAT.json
+++ b/dataset/NAT/profiles/NAT.json
@@ -13,45 +13,69 @@
       "gap": 0.75,
       "children": [
         {
-          "label": ["Edmonton", "(INOP)"],
+          "label": [
+            "Edmonton",
+            "(INOP)"
+          ],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": ["INOP"]
+                "label": [
+                  "INOP"
+                ]
               }
             ]
           }
         },
         {
-          "label": ["Montreal", "(INOP)"],
+          "label": [
+            "Montreal",
+            "(INOP)"
+          ],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": ["INOP"]
+                "label": [
+                  "INOP"
+                ]
               }
             ]
           }
         },
         {
-          "label": ["Gander", "Domestic"],
+          "label": [
+            "Gander",
+            "Domestic"
+          ],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": ["Gander", "Domestic"],
+                "label": [
+                  "Gander",
+                  "Domestic"
+                ],
                 "station_id": "CZQX-CTR"
               },
               {
-                "label": ["GOTA", "North", "QX 7"],
+                "label": [
+                  "GOTA",
+                  "North",
+                  "QX 7"
+                ],
                 "station_id": "CZQX-7-CTR"
               },
               {
-                "label": ["GOTA", "South", "QX 6"],
+                "label": [
+                  "GOTA",
+                  "South",
+                  "QX 6"
+                ],
                 "station_id": "CZQX-6-CTR"
               },
               {
@@ -76,70 +100,221 @@
                 "label": []
               },
               {
-                "label": ["QX", "5"],
+                "label": [
+                  "QX",
+                  "5"
+                ],
                 "station_id": "CZQX-5-CTR"
               },
               {
-                "label": ["QX", "4"],
+                "label": [
+                  "QX",
+                  "4"
+                ],
                 "station_id": "CZQX-4-CTR"
               },
               {
-                "label": ["QX", "3"],
+                "label": [
+                  "QX",
+                  "3"
+                ],
                 "station_id": "CZQX-3-CTR"
               },
               {
-                "label": ["QX", "2"],
+                "label": [
+                  "QX",
+                  "2"
+                ],
                 "station_id": "CZQX-2-CTR"
               },
               {
-                "label": ["QX", "1"],
+                "label": [
+                  "QX",
+                  "1"
+                ],
                 "station_id": "CZQX-1-CTR"
               }
             ]
           }
         },
         {
-          "label": ["New York"],
+          "label": [
+            "New York"
+          ],
           "size": 7,
           "page": {
             "rows": 6,
             "keys": [
-              { "label": ["JOBOC", "65"], "station_id": "JOBOC" },
-              { "label": ["OHRYN", "85"], "station_id": "OHRYN" },
-              { "label": ["ATLANTIC", "86"], "station_id": "ATLANTIC" },
-              { "label": ["PAEPR", "82"], "station_id": "PAEPR" },
-              { "label": ["HANRI", "83"], "station_id": "HANRI" },
-              { "label": [] },
-              { "label": ["CHAMP", "87", "High"], "station_id": "CHAMP_H" },
-              { "label": ["CHAMP", "87", "Low"], "station_id": "CHAMP_L" },
-              { "label": ["BACUS", "88", "High"], "station_id": "BACUS_H" },
-              { "label": ["BACUS", "88", "Low"], "station_id": "BACUS_L" },
-              { "label": ["GRATX", "90", "High"], "station_id": "GRATX_H" },
-              { "label": ["GRATX", "90", "Low"], "station_id": "GRATX_L" },
-              { "label": [] },
-              { "label": ["COCOA", "80"], "station_id": "COCOA" },
-              { "label": ["HILDY", "81"], "station_id": "HILDY" },
-              { "label": ["KRAFT", "89", "High"], "station_id": "KRAFT_H" },
-              { "label": ["KRAFT", "89", "Low"], "station_id": "KRAFT_L" },
-              { "label": [] },
               {
-                "label": ["MERCURY", "21-24", "High"],
+                "label": [
+                  "JOBOC",
+                  "65"
+                ],
+                "station_id": "JOBOC"
+              },
+              {
+                "label": [
+                  "OHRYN",
+                  "85"
+                ],
+                "station_id": "OHRYN"
+              },
+              {
+                "label": [
+                  "ATLANTIC",
+                  "86"
+                ],
+                "station_id": "ATLANTIC"
+              },
+              {
+                "label": [
+                  "PAEPR",
+                  "82"
+                ],
+                "station_id": "PAEPR"
+              },
+              {
+                "label": [
+                  "HANRI",
+                  "83"
+                ],
+                "station_id": "HANRI"
+              },
+              {
+                "label": []
+              },
+              {
+                "label": [
+                  "CHAMP",
+                  "87",
+                  "High"
+                ],
+                "station_id": "CHAMP_H"
+              },
+              {
+                "label": [
+                  "CHAMP",
+                  "87",
+                  "Low"
+                ],
+                "station_id": "CHAMP_L"
+              },
+              {
+                "label": [
+                  "BACUS",
+                  "88",
+                  "High"
+                ],
+                "station_id": "BACUS_H"
+              },
+              {
+                "label": [
+                  "BACUS",
+                  "88",
+                  "Low"
+                ],
+                "station_id": "BACUS_L"
+              },
+              {
+                "label": [
+                  "GRATX",
+                  "90",
+                  "High"
+                ],
+                "station_id": "GRATX_H"
+              },
+              {
+                "label": [
+                  "GRATX",
+                  "90",
+                  "Low"
+                ],
+                "station_id": "GRATX_L"
+              },
+              {
+                "label": []
+              },
+              {
+                "label": [
+                  "COCOA",
+                  "80"
+                ],
+                "station_id": "COCOA"
+              },
+              {
+                "label": [
+                  "HILDY",
+                  "81"
+                ],
+                "station_id": "HILDY"
+              },
+              {
+                "label": [
+                  "KRAFT",
+                  "89",
+                  "High"
+                ],
+                "station_id": "KRAFT_H"
+              },
+              {
+                "label": [
+                  "KRAFT",
+                  "89",
+                  "Low"
+                ],
+                "station_id": "KRAFT_L"
+              },
+              {
+                "label": []
+              },
+              {
+                "label": [
+                  "MERCURY",
+                  "21-24",
+                  "High"
+                ],
                 "station_id": "MERCURY_H"
               },
               {
-                "label": ["MERCURY", "21-24", "Low"],
+                "label": [
+                  "MERCURY",
+                  "21-24",
+                  "Low"
+                ],
                 "station_id": "MERCURY_L"
               },
               {
-                "label": ["GEMINI", "18-20", "High"],
+                "label": [
+                  "GEMINI",
+                  "18-20",
+                  "High"
+                ],
                 "station_id": "GEMINI_H"
               },
-              { "label": ["GEMINI", "18-20", "Low"], "station_id": "GEMINI_L" },
               {
-                "label": ["APOLLO", "16-17", "High"],
+                "label": [
+                  "GEMINI",
+                  "18-20",
+                  "Low"
+                ],
+                "station_id": "GEMINI_L"
+              },
+              {
+                "label": [
+                  "APOLLO",
+                  "16-17",
+                  "High"
+                ],
                 "station_id": "APOLLO_H"
               },
-              { "label": ["APOLLO", "16-17", "Low"], "station_id": "APOLLO_L" }
+              {
+                "label": [
+                  "APOLLO",
+                  "16-17",
+                  "Low"
+                ],
+                "station_id": "APOLLO_L"
+              }
             ]
           }
         }
@@ -149,6 +324,7 @@
       "direction": "col",
       "height": "100%",
       "justify_content": "space-between",
+      "align_items": "center",
       "gap": 0.75,
       "children": [
         {
@@ -156,46 +332,97 @@
           "justify_content": "center",
           "children": [
             {
-              "label": ["Reykjavík", "(INOP)"],
+              "label": [
+                "Reykjavík",
+                "(INOP)"
+              ],
               "size": 7,
               "page": {
                 "rows": 4,
                 "keys": [
                   {
-                    "label": ["West", "Upper", "365-660"]
+                    "label": [
+                      "West",
+                      "Upper",
+                      "365-660"
+                    ]
                   },
                   {
-                    "label": ["West", "Middle", "355-365"]
+                    "label": [
+                      "West",
+                      "Middle",
+                      "355-365"
+                    ]
                   },
                   {
-                    "label": ["West", "Middle", "345-355"]
+                    "label": [
+                      "West",
+                      "Middle",
+                      "345-355"
+                    ]
                   },
                   {
-                    "label": ["West", "Lower", "55-345"]
+                    "label": [
+                      "West",
+                      "Lower",
+                      "55-345"
+                    ]
                   },
                   {
-                    "label": ["South", "Upper", "365-660"]
+                    "label": [
+                      "South",
+                      "Upper",
+                      "365-660"
+                    ]
                   },
                   {
-                    "label": ["South", "Middle", "355-365"]
+                    "label": [
+                      "South",
+                      "Middle",
+                      "355-365"
+                    ]
                   },
                   {
-                    "label": ["South", "Middle", "345-355"]
+                    "label": [
+                      "South",
+                      "Middle",
+                      "345-355"
+                    ]
                   },
                   {
-                    "label": ["South", "Lower", "55-345"]
+                    "label": [
+                      "South",
+                      "Lower",
+                      "55-345"
+                    ]
                   },
                   {
-                    "label": ["East", "Upper", "365-660"]
+                    "label": [
+                      "East",
+                      "Upper",
+                      "365-660"
+                    ]
                   },
                   {
-                    "label": ["East", "Middle", "355-365"]
+                    "label": [
+                      "East",
+                      "Middle",
+                      "355-365"
+                    ]
                   },
                   {
-                    "label": ["East", "Middle", "345-355"]
+                    "label": [
+                      "East",
+                      "Middle",
+                      "345-355"
+                    ]
                   },
                   {
-                    "label": ["East", "Lower", "55-345"]
+                    "label": [
+                      "East",
+                      "Lower",
+                      "55-345"
+                    ]
                   }
                 ]
               }
@@ -203,150 +430,216 @@
           ]
         },
         {
-          "direction": "row",
-          "gap": 3,
+          "direction": "col",
+          "gap": 0.5,
+          "align_items": "center",
           "children": [
             {
-              "label": ["Gander"],
-              "size": 12,
-              "page": {
-                "rows": 6,
-                "keys": [
-                  {
-                    "label": ["DEL", "A"],
-                    "station_id": "Gander_DEL_A"
-                  },
-                  {
-                    "label": ["DEL", "B"],
-                    "station_id": "Gander_DEL_B"
-                  },
-                  {
-                    "label": ["DEL", "C"],
-                    "station_id": "Gander_DEL_C"
-                  },
-                  {
-                    "label": ["DEL", "D"],
-                    "station_id": "Gander_DEL_D"
-                  },
-                  {
-                    "label": ["DEL", "F"],
-                    "station_id": "Gander_DEL_F"
-                  },
-                  {
-                    "label": []
-                  },
-                  {
-                    "label": ["A"],
-                    "station_id": "Gander_A"
-                  },
-                  {
-                    "label": ["B"],
-                    "station_id": "Gander_B"
-                  },
-                  {
-                    "label": ["C"],
-                    "station_id": "Gander_C"
-                  },
-                  {
-                    "label": ["D"],
-                    "station_id": "Gander_D"
-                  },
-                  {
-                    "label": ["F"],
-                    "station_id": "Gander_F"
-                  },
-                  {
-                    "label": ["G"],
-                    "station_id": "Gander_G"
-                  },
-                  {
-                    "label": []
-                  },
-                  {
-                    "label": []
-                  },
-                  {
-                    "label": ["Gander"],
-                    "station_id": "Gander"
-                  },
-                  {
-                    "label": ["DEL"],
-                    "station_id": "Gander_DEL"
-                  },
-                  {
-                    "label": []
-                  },
-                  {
-                    "label": []
-                  }
-                ]
-              }
+              "direction": "row",
+              "gap": 2,
+              "align_items": "center",
+              "children": [
+                {
+                  "label": [
+                    "Gander",
+                    "Radio"
+                  ],
+                  "size": 11,
+                  "station_id": "Gander"
+                },
+                {
+                  "label": [
+                    "Shanwick",
+                    "Radio"
+                  ],
+                  "size": 11,
+                  "station_id": "Shanwick"
+                }
+              ]
             },
             {
-              "label": ["Shanwick"],
-              "size": 12,
-              "page": {
-                "rows": 5,
-                "keys": [
-                  {
-                    "label": ["DEL", "A"],
-                    "station_id": "Shanwick_DEL_A"
-                  },
-                  {
-                    "label": ["DEL", "B"],
-                    "station_id": "Shanwick_DEL_B"
-                  },
-                  {
-                    "label": ["DEL", "C"],
-                    "station_id": "Shanwick_DEL_C"
-                  },
-                  {
-                    "label": ["DEL", "D"],
-                    "station_id": "Shanwick_DEL_D"
-                  },
-                  {
-                    "label": ["DEL", "F"],
-                    "station_id": "Shanwick_DEL_F"
-                  },
-                  {
-                    "label": ["A"],
-                    "station_id": "Shanwick_A"
-                  },
-                  {
-                    "label": ["B"],
-                    "station_id": "Shanwick_B"
-                  },
-                  {
-                    "label": ["C"],
-                    "station_id": "Shanwick_C"
-                  },
-                  {
-                    "label": ["D"],
-                    "station_id": "Shanwick_D"
-                  },
-                  {
-                    "label": ["F"],
-                    "station_id": "Shanwick_F"
-                  },
-                  {
-                    "label": []
-                  },
-                  {
-                    "label": []
-                  },
-                  {
-                    "label": ["Shanwick"],
-                    "station_id": "Shanwick"
-                  },
-                  {
-                    "label": ["DEL"],
-                    "station_id": "Shanwick_DEL"
-                  },
-                  {
-                    "label": []
+              "direction": "row",
+              "gap": 1,
+              "align_items": "center",
+              "children": [
+                {
+                  "label": [
+                    "CZQO",
+                    "Splits"
+                  ],
+                  "size": 5,
+                  "page": {
+                    "rows": 6,
+                    "keys": [
+                      {
+                        "label": [
+                          "CZQO",
+                          "DEL"
+                        ],
+                        "station_id": "Gander_DEL"
+                      },
+                      {
+                        "label": [
+                          "DEL",
+                          "A"
+                        ],
+                        "station_id": "Gander_DEL_A"
+                      },
+                      {
+                        "label": [
+                          "DEL",
+                          "B"
+                        ],
+                        "station_id": "Gander_DEL_B"
+                      },
+                      {
+                        "label": [
+                          "DEL",
+                          "C"
+                        ],
+                        "station_id": "Gander_DEL_C"
+                      },
+                      {
+                        "label": [
+                          "DEL",
+                          "D"
+                        ],
+                        "station_id": "Gander_DEL_D"
+                      },
+                      {
+                        "label": [
+                          "DEL",
+                          "F"
+                        ],
+                        "station_id": "Gander_DEL_F"
+                      },
+                      {
+                        "label": [
+                          "A"
+                        ],
+                        "station_id": "Gander_A"
+                      },
+                      {
+                        "label": [
+                          "B"
+                        ],
+                        "station_id": "Gander_B"
+                      },
+                      {
+                        "label": [
+                          "C"
+                        ],
+                        "station_id": "Gander_C"
+                      },
+                      {
+                        "label": [
+                          "D"
+                        ],
+                        "station_id": "Gander_D"
+                      },
+                      {
+                        "label": [
+                          "F"
+                        ],
+                        "station_id": "Gander_F"
+                      },
+                      {
+                        "label": [
+                          "G"
+                        ],
+                        "station_id": "Gander_G"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "label": [
+                    "EGGX",
+                    "Splits"
+                  ],
+                  "size": 5,
+                  "page": {
+                    "rows": 6,
+                    "keys": [
+                      {
+                        "label": [
+                          "EGGX",
+                          "DEL"
+                        ],
+                        "station_id": "Shanwick_DEL"
+                      },
+                      {
+                        "label": [
+                          "DEL",
+                          "A"
+                        ],
+                        "station_id": "Shanwick_DEL_A"
+                      },
+                      {
+                        "label": [
+                          "DEL",
+                          "B"
+                        ],
+                        "station_id": "Shanwick_DEL_B"
+                      },
+                      {
+                        "label": [
+                          "DEL",
+                          "C"
+                        ],
+                        "station_id": "Shanwick_DEL_C"
+                      },
+                      {
+                        "label": [
+                          "DEL",
+                          "D"
+                        ],
+                        "station_id": "Shanwick_DEL_D"
+                      },
+                      {
+                        "label": [
+                          "DEL",
+                          "F"
+                        ],
+                        "station_id": "Shanwick_DEL_F"
+                      },
+                      {
+                        "label": [
+                          "A"
+                        ],
+                        "station_id": "Shanwick_A"
+                      },
+                      {
+                        "label": [
+                          "B"
+                        ],
+                        "station_id": "Shanwick_B"
+                      },
+                      {
+                        "label": [
+                          "C"
+                        ],
+                        "station_id": "Shanwick_C"
+                      },
+                      {
+                        "label": [
+                          "D"
+                        ],
+                        "station_id": "Shanwick_D"
+                      },
+                      {
+                        "label": [
+                          "F"
+                        ],
+                        "station_id": "Shanwick_F"
+                      },
+                      {
+                        "label": []
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         },
@@ -355,34 +648,56 @@
           "justify_content": "center",
           "children": [
             {
-              "label": ["Santa", "Maria", "(INOP)"],
+              "label": [
+                "Santa",
+                "Maria",
+                "(INOP)"
+              ],
               "size": 7,
               "page": {
                 "rows": 3,
                 "keys": [
                   {
-                    "label": ["Oceanic", "clearance"]
+                    "label": [
+                      "Oceanic",
+                      "clearance"
+                    ]
                   },
                   {
-                    "label": ["Oceanic", "clearance", "2"]
-                  },
-                  {
-                    "label": []
-                  },
-                  {
-                    "label": ["Radio", "1"]
-                  },
-                  {
-                    "label": ["Radio", "2"]
-                  },
-                  {
-                    "label": ["Radio", "3"]
+                    "label": [
+                      "Oceanic",
+                      "clearance",
+                      "2"
+                    ]
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": ["Radio"]
+                    "label": [
+                      "Radio",
+                      "1"
+                    ]
+                  },
+                  {
+                    "label": [
+                      "Radio",
+                      "2"
+                    ]
+                  },
+                  {
+                    "label": [
+                      "Radio",
+                      "3"
+                    ]
+                  },
+                  {
+                    "label": []
+                  },
+                  {
+                    "label": [
+                      "Radio"
+                    ]
                   },
                   {
                     "label": []
@@ -401,25 +716,42 @@
       "gap": 0.75,
       "children": [
         {
-          "label": ["Scottish/", "EGLL"],
+          "label": [
+            "Scottish/",
+            "EGLL"
+          ],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": ["Hebrides", "High", "255-660"],
+                "label": [
+                  "Hebrides",
+                  "High",
+                  "255-660"
+                ],
                 "station_id": "EG-Hebrides-High"
               },
               {
-                "label": ["Central", "255-660"],
+                "label": [
+                  "Central",
+                  "255-660"
+                ],
                 "station_id": "EG-Central"
               },
               {
-                "label": ["Hebrides", "Low", "DB-255"],
+                "label": [
+                  "Hebrides",
+                  "Low",
+                  "DB-255"
+                ],
                 "station_id": "EG-Hebrides-Low"
               },
               {
-                "label": ["Central", "DB-255"],
+                "label": [
+                  "Central",
+                  "DB-255"
+                ],
                 "station_id": "EG-Westcoast-Central"
               },
               {
@@ -429,7 +761,10 @@
                 "label": []
               },
               {
-                "label": ["EGLL", "PLN"],
+                "label": [
+                  "EGLL",
+                  "PLN"
+                ],
                 "station_id": "EGLL_P_GND"
               },
               {
@@ -439,48 +774,86 @@
           }
         },
         {
-          "label": ["Shannon"],
+          "label": [
+            "Shannon"
+          ],
           "size": 7,
           "page": {
             "rows": 4,
             "keys": [
               {
-                "label": ["NOTA", "Super", "355+"],
+                "label": [
+                  "NOTA",
+                  "Super",
+                  "355+"
+                ],
                 "station_id": "EISN_NS_CTR"
               },
               {
-                "label": ["West", "Super", "355+"],
+                "label": [
+                  "West",
+                  "Super",
+                  "355+"
+                ],
                 "station_id": "EISN_WS_CTR"
               },
               {
-                "label": ["Ocean", "Super", "355+"],
+                "label": [
+                  "Ocean",
+                  "Super",
+                  "355+"
+                ],
                 "station_id": "EISN_SS_CTR"
               },
               {
-                "label": ["SOTA", "Super", "355+"],
+                "label": [
+                  "SOTA",
+                  "Super",
+                  "355+"
+                ],
                 "station_id": "EISN_SS_CTR"
               },
               {
-                "label": ["NOTA", "Upper", "245-355"],
+                "label": [
+                  "NOTA",
+                  "Upper",
+                  "245-355"
+                ],
                 "station_id": "EISN_N_CTR"
               },
               {
-                "label": ["West", "Upper", "245-355"],
+                "label": [
+                  "West",
+                  "Upper",
+                  "245-355"
+                ],
                 "station_id": "EISN_W_CTR"
               },
               {
-                "label": ["Ocean", "Upper", "245-355"],
+                "label": [
+                  "Ocean",
+                  "Upper",
+                  "245-355"
+                ],
                 "station_id": "EISN_O_CTR"
               },
               {
-                "label": ["SOTA", "Upper", "245-255"],
+                "label": [
+                  "SOTA",
+                  "Upper",
+                  "245-255"
+                ],
                 "station_id": "EISN_S_CTR"
               },
               {
                 "label": []
               },
               {
-                "label": ["Low", "Level", "245-"],
+                "label": [
+                  "Low",
+                  "Level",
+                  "245-"
+                ],
                 "station_id": "EISN_LS_CTR"
               },
               {
@@ -493,25 +866,40 @@
           }
         },
         {
-          "label": ["Brest", "(INOP)"],
+          "label": [
+            "Brest",
+            "(INOP)"
+          ],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": ["West", "255+"]
+                "label": [
+                  "West",
+                  "255+"
+                ]
               },
               {
-                "label": ["AU", "355-660"]
+                "label": [
+                  "AU",
+                  "355-660"
+                ]
               },
               {
                 "label": []
               },
               {
-                "label": ["AS", "255-355"]
+                "label": [
+                  "AS",
+                  "255-355"
+                ]
               },
               {
-                "label": ["Lower", "255-"]
+                "label": [
+                  "Lower",
+                  "255-"
+                ]
               },
               {
                 "label": []
@@ -520,16 +908,25 @@
           }
         },
         {
-          "label": ["Madrid", "(INOP)"],
+          "label": [
+            "Madrid",
+            "(INOP)"
+          ],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": ["Upper", "245-660"]
+                "label": [
+                  "Upper",
+                  "245-660"
+                ]
               },
               {
-                "label": ["Lower", "245-"]
+                "label": [
+                  "Lower",
+                  "245-"
+                ]
               }
             ]
           }

--- a/dataset/NAT/profiles/NAT.json
+++ b/dataset/NAT/profiles/NAT.json
@@ -294,10 +294,6 @@
                     "rows": 6,
                     "keys": [
                       {
-                        "label": ["CZQO", "DEL"],
-                        "station_id": "Gander_DEL"
-                      },
-                      {
                         "label": ["DEL", "A"],
                         "station_id": "Gander_DEL_A"
                       },
@@ -316,6 +312,9 @@
                       {
                         "label": ["DEL", "F"],
                         "station_id": "Gander_DEL_F"
+                      },
+                      {
+                        "label": []
                       },
                       {
                         "label": ["A"],
@@ -340,6 +339,25 @@
                       {
                         "label": ["G"],
                         "station_id": "Gander_G"
+                      },
+                      {
+                        "label": []
+                      },
+                      {
+                        "label": []
+                      },
+                      {
+                        "label": ["CZQO", "DEL"],
+                        "station_id": "Gander_DEL"
+                      },
+                      {
+                        "label": []
+                      },
+                      {
+                        "label": []
+                      },
+                      {
+                        "label": []
                       }
                     ]
                   }
@@ -350,10 +368,6 @@
                   "page": {
                     "rows": 6,
                     "keys": [
-                      {
-                        "label": ["EGGX", "DEL"],
-                        "station_id": "Shanwick_DEL"
-                      },
                       {
                         "label": ["DEL", "A"],
                         "station_id": "Shanwick_DEL_A"
@@ -375,6 +389,9 @@
                         "station_id": "Shanwick_DEL_F"
                       },
                       {
+                        "label": []
+                      },
+                      {
                         "label": ["A"],
                         "station_id": "Shanwick_A"
                       },
@@ -393,6 +410,25 @@
                       {
                         "label": ["F"],
                         "station_id": "Shanwick_F"
+                      },
+                      {
+                        "label": []
+                      },
+                      {
+                        "label": []
+                      },
+                      {
+                        "label": []
+                      },
+                      {
+                        "label": ["EGGX", "DEL"],
+                        "station_id": "Shanwick_DEL"
+                      },
+                      {
+                        "label": []
+                      },
+                      {
+                        "label": []
                       },
                       {
                         "label": []

--- a/dataset/NAT/profiles/NAT.json
+++ b/dataset/NAT/profiles/NAT.json
@@ -13,69 +13,45 @@
       "gap": 0.75,
       "children": [
         {
-          "label": [
-            "Edmonton",
-            "(INOP)"
-          ],
+          "label": ["Edmonton", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "INOP"
-                ]
+                "label": ["INOP"]
               }
             ]
           }
         },
         {
-          "label": [
-            "Montreal",
-            "(INOP)"
-          ],
+          "label": ["Montreal", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "INOP"
-                ]
+                "label": ["INOP"]
               }
             ]
           }
         },
         {
-          "label": [
-            "Gander",
-            "Domestic"
-          ],
+          "label": ["Gander", "Domestic"],
           "size": 7,
           "page": {
             "rows": 5,
             "keys": [
               {
-                "label": [
-                  "Gander",
-                  "Domestic"
-                ],
+                "label": ["Gander", "Domestic"],
                 "station_id": "CZQX-CTR"
               },
               {
-                "label": [
-                  "GOTA",
-                  "North",
-                  "QX 7"
-                ],
+                "label": ["GOTA", "North", "QX 7"],
                 "station_id": "CZQX-7-CTR"
               },
               {
-                "label": [
-                  "GOTA",
-                  "South",
-                  "QX 6"
-                ],
+                "label": ["GOTA", "South", "QX 6"],
                 "station_id": "CZQX-6-CTR"
               },
               {
@@ -100,219 +76,125 @@
                 "label": []
               },
               {
-                "label": [
-                  "QX",
-                  "5"
-                ],
+                "label": ["QX", "5"],
                 "station_id": "CZQX-5-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "4"
-                ],
+                "label": ["QX", "4"],
                 "station_id": "CZQX-4-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "3"
-                ],
+                "label": ["QX", "3"],
                 "station_id": "CZQX-3-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "2"
-                ],
+                "label": ["QX", "2"],
                 "station_id": "CZQX-2-CTR"
               },
               {
-                "label": [
-                  "QX",
-                  "1"
-                ],
+                "label": ["QX", "1"],
                 "station_id": "CZQX-1-CTR"
               }
             ]
           }
         },
         {
-          "label": [
-            "New York"
-          ],
+          "label": ["New York"],
           "size": 7,
           "page": {
             "rows": 6,
             "keys": [
               {
-                "label": [
-                  "JOBOC",
-                  "65"
-                ],
+                "label": ["JOBOC", "65"],
                 "station_id": "JOBOC"
               },
               {
-                "label": [
-                  "OHRYN",
-                  "85"
-                ],
+                "label": ["OHRYN", "85"],
                 "station_id": "OHRYN"
               },
               {
-                "label": [
-                  "ATLANTIC",
-                  "86"
-                ],
+                "label": ["ATLANTIC", "86"],
                 "station_id": "ATLANTIC"
               },
               {
-                "label": [
-                  "PAEPR",
-                  "82"
-                ],
+                "label": ["PAEPR", "82"],
                 "station_id": "PAEPR"
               },
               {
-                "label": [
-                  "HANRI",
-                  "83"
-                ],
+                "label": ["HANRI", "83"],
                 "station_id": "HANRI"
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "CHAMP",
-                  "87",
-                  "High"
-                ],
+                "label": ["CHAMP", "87", "High"],
                 "station_id": "CHAMP_H"
               },
               {
-                "label": [
-                  "CHAMP",
-                  "87",
-                  "Low"
-                ],
+                "label": ["CHAMP", "87", "Low"],
                 "station_id": "CHAMP_L"
               },
               {
-                "label": [
-                  "BACUS",
-                  "88",
-                  "High"
-                ],
+                "label": ["BACUS", "88", "High"],
                 "station_id": "BACUS_H"
               },
               {
-                "label": [
-                  "BACUS",
-                  "88",
-                  "Low"
-                ],
+                "label": ["BACUS", "88", "Low"],
                 "station_id": "BACUS_L"
               },
               {
-                "label": [
-                  "GRATX",
-                  "90",
-                  "High"
-                ],
+                "label": ["GRATX", "90", "High"],
                 "station_id": "GRATX_H"
               },
               {
-                "label": [
-                  "GRATX",
-                  "90",
-                  "Low"
-                ],
+                "label": ["GRATX", "90", "Low"],
                 "station_id": "GRATX_L"
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "COCOA",
-                  "80"
-                ],
+                "label": ["COCOA", "80"],
                 "station_id": "COCOA"
               },
               {
-                "label": [
-                  "HILDY",
-                  "81"
-                ],
+                "label": ["HILDY", "81"],
                 "station_id": "HILDY"
               },
               {
-                "label": [
-                  "KRAFT",
-                  "89",
-                  "High"
-                ],
+                "label": ["KRAFT", "89", "High"],
                 "station_id": "KRAFT_H"
               },
               {
-                "label": [
-                  "KRAFT",
-                  "89",
-                  "Low"
-                ],
+                "label": ["KRAFT", "89", "Low"],
                 "station_id": "KRAFT_L"
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "MERCURY",
-                  "21-24",
-                  "High"
-                ],
+                "label": ["MERCURY", "21-24", "High"],
                 "station_id": "MERCURY_H"
               },
               {
-                "label": [
-                  "MERCURY",
-                  "21-24",
-                  "Low"
-                ],
+                "label": ["MERCURY", "21-24", "Low"],
                 "station_id": "MERCURY_L"
               },
               {
-                "label": [
-                  "GEMINI",
-                  "18-20",
-                  "High"
-                ],
+                "label": ["GEMINI", "18-20", "High"],
                 "station_id": "GEMINI_H"
               },
               {
-                "label": [
-                  "GEMINI",
-                  "18-20",
-                  "Low"
-                ],
+                "label": ["GEMINI", "18-20", "Low"],
                 "station_id": "GEMINI_L"
               },
               {
-                "label": [
-                  "APOLLO",
-                  "16-17",
-                  "High"
-                ],
+                "label": ["APOLLO", "16-17", "High"],
                 "station_id": "APOLLO_H"
               },
               {
-                "label": [
-                  "APOLLO",
-                  "16-17",
-                  "Low"
-                ],
+                "label": ["APOLLO", "16-17", "Low"],
                 "station_id": "APOLLO_L"
               }
             ]
@@ -332,97 +214,46 @@
           "justify_content": "center",
           "children": [
             {
-              "label": [
-                "Reykjavík",
-                "(INOP)"
-              ],
+              "label": ["Reykjavík", "(INOP)"],
               "size": 7,
               "page": {
                 "rows": 4,
                 "keys": [
                   {
-                    "label": [
-                      "West",
-                      "Upper",
-                      "365-660"
-                    ]
+                    "label": ["West", "Upper", "365-660"]
                   },
                   {
-                    "label": [
-                      "West",
-                      "Middle",
-                      "355-365"
-                    ]
+                    "label": ["West", "Middle", "355-365"]
                   },
                   {
-                    "label": [
-                      "West",
-                      "Middle",
-                      "345-355"
-                    ]
+                    "label": ["West", "Middle", "345-355"]
                   },
                   {
-                    "label": [
-                      "West",
-                      "Lower",
-                      "55-345"
-                    ]
+                    "label": ["West", "Lower", "55-345"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Upper",
-                      "365-660"
-                    ]
+                    "label": ["South", "Upper", "365-660"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Middle",
-                      "355-365"
-                    ]
+                    "label": ["South", "Middle", "355-365"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Middle",
-                      "345-355"
-                    ]
+                    "label": ["South", "Middle", "345-355"]
                   },
                   {
-                    "label": [
-                      "South",
-                      "Lower",
-                      "55-345"
-                    ]
+                    "label": ["South", "Lower", "55-345"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Upper",
-                      "365-660"
-                    ]
+                    "label": ["East", "Upper", "365-660"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Middle",
-                      "355-365"
-                    ]
+                    "label": ["East", "Middle", "355-365"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Middle",
-                      "345-355"
-                    ]
+                    "label": ["East", "Middle", "345-355"]
                   },
                   {
-                    "label": [
-                      "East",
-                      "Lower",
-                      "55-345"
-                    ]
+                    "label": ["East", "Lower", "55-345"]
                   }
                 ]
               }
@@ -440,18 +271,12 @@
               "align_items": "center",
               "children": [
                 {
-                  "label": [
-                    "Gander",
-                    "Radio"
-                  ],
+                  "label": ["Gander", "Radio"],
                   "size": 11,
                   "station_id": "Gander"
                 },
                 {
-                  "label": [
-                    "Shanwick",
-                    "Radio"
-                  ],
+                  "label": ["Shanwick", "Radio"],
                   "size": 11,
                   "station_id": "Shanwick"
                 }
@@ -463,174 +288,110 @@
               "align_items": "center",
               "children": [
                 {
-                  "label": [
-                    "CZQO",
-                    "Splits"
-                  ],
+                  "label": ["CZQO", "Splits"],
                   "size": 5,
                   "page": {
                     "rows": 6,
                     "keys": [
                       {
-                        "label": [
-                          "CZQO",
-                          "DEL"
-                        ],
+                        "label": ["CZQO", "DEL"],
                         "station_id": "Gander_DEL"
                       },
                       {
-                        "label": [
-                          "DEL",
-                          "A"
-                        ],
+                        "label": ["DEL", "A"],
                         "station_id": "Gander_DEL_A"
                       },
                       {
-                        "label": [
-                          "DEL",
-                          "B"
-                        ],
+                        "label": ["DEL", "B"],
                         "station_id": "Gander_DEL_B"
                       },
                       {
-                        "label": [
-                          "DEL",
-                          "C"
-                        ],
+                        "label": ["DEL", "C"],
                         "station_id": "Gander_DEL_C"
                       },
                       {
-                        "label": [
-                          "DEL",
-                          "D"
-                        ],
+                        "label": ["DEL", "D"],
                         "station_id": "Gander_DEL_D"
                       },
                       {
-                        "label": [
-                          "DEL",
-                          "F"
-                        ],
+                        "label": ["DEL", "F"],
                         "station_id": "Gander_DEL_F"
                       },
                       {
-                        "label": [
-                          "A"
-                        ],
+                        "label": ["A"],
                         "station_id": "Gander_A"
                       },
                       {
-                        "label": [
-                          "B"
-                        ],
+                        "label": ["B"],
                         "station_id": "Gander_B"
                       },
                       {
-                        "label": [
-                          "C"
-                        ],
+                        "label": ["C"],
                         "station_id": "Gander_C"
                       },
                       {
-                        "label": [
-                          "D"
-                        ],
+                        "label": ["D"],
                         "station_id": "Gander_D"
                       },
                       {
-                        "label": [
-                          "F"
-                        ],
+                        "label": ["F"],
                         "station_id": "Gander_F"
                       },
                       {
-                        "label": [
-                          "G"
-                        ],
+                        "label": ["G"],
                         "station_id": "Gander_G"
                       }
                     ]
                   }
                 },
                 {
-                  "label": [
-                    "EGGX",
-                    "Splits"
-                  ],
+                  "label": ["EGGX", "Splits"],
                   "size": 5,
                   "page": {
                     "rows": 6,
                     "keys": [
                       {
-                        "label": [
-                          "EGGX",
-                          "DEL"
-                        ],
+                        "label": ["EGGX", "DEL"],
                         "station_id": "Shanwick_DEL"
                       },
                       {
-                        "label": [
-                          "DEL",
-                          "A"
-                        ],
+                        "label": ["DEL", "A"],
                         "station_id": "Shanwick_DEL_A"
                       },
                       {
-                        "label": [
-                          "DEL",
-                          "B"
-                        ],
+                        "label": ["DEL", "B"],
                         "station_id": "Shanwick_DEL_B"
                       },
                       {
-                        "label": [
-                          "DEL",
-                          "C"
-                        ],
+                        "label": ["DEL", "C"],
                         "station_id": "Shanwick_DEL_C"
                       },
                       {
-                        "label": [
-                          "DEL",
-                          "D"
-                        ],
+                        "label": ["DEL", "D"],
                         "station_id": "Shanwick_DEL_D"
                       },
                       {
-                        "label": [
-                          "DEL",
-                          "F"
-                        ],
+                        "label": ["DEL", "F"],
                         "station_id": "Shanwick_DEL_F"
                       },
                       {
-                        "label": [
-                          "A"
-                        ],
+                        "label": ["A"],
                         "station_id": "Shanwick_A"
                       },
                       {
-                        "label": [
-                          "B"
-                        ],
+                        "label": ["B"],
                         "station_id": "Shanwick_B"
                       },
                       {
-                        "label": [
-                          "C"
-                        ],
+                        "label": ["C"],
                         "station_id": "Shanwick_C"
                       },
                       {
-                        "label": [
-                          "D"
-                        ],
+                        "label": ["D"],
                         "station_id": "Shanwick_D"
                       },
                       {
-                        "label": [
-                          "F"
-                        ],
+                        "label": ["F"],
                         "station_id": "Shanwick_F"
                       },
                       {
@@ -648,56 +409,34 @@
           "justify_content": "center",
           "children": [
             {
-              "label": [
-                "Santa",
-                "Maria",
-                "(INOP)"
-              ],
+              "label": ["Santa", "Maria", "(INOP)"],
               "size": 7,
               "page": {
                 "rows": 3,
                 "keys": [
                   {
-                    "label": [
-                      "Oceanic",
-                      "clearance"
-                    ]
+                    "label": ["Oceanic", "clearance"]
                   },
                   {
-                    "label": [
-                      "Oceanic",
-                      "clearance",
-                      "2"
-                    ]
+                    "label": ["Oceanic", "clearance", "2"]
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": [
-                      "Radio",
-                      "1"
-                    ]
+                    "label": ["Radio", "1"]
                   },
                   {
-                    "label": [
-                      "Radio",
-                      "2"
-                    ]
+                    "label": ["Radio", "2"]
                   },
                   {
-                    "label": [
-                      "Radio",
-                      "3"
-                    ]
+                    "label": ["Radio", "3"]
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": [
-                      "Radio"
-                    ]
+                    "label": ["Radio"]
                   },
                   {
                     "label": []
@@ -716,42 +455,25 @@
       "gap": 0.75,
       "children": [
         {
-          "label": [
-            "Scottish/",
-            "EGLL"
-          ],
+          "label": ["Scottish/", "EGLL"],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": [
-                  "Hebrides",
-                  "High",
-                  "255-660"
-                ],
+                "label": ["Hebrides", "High", "255-660"],
                 "station_id": "EG-Hebrides-High"
               },
               {
-                "label": [
-                  "Central",
-                  "255-660"
-                ],
+                "label": ["Central", "255-660"],
                 "station_id": "EG-Central"
               },
               {
-                "label": [
-                  "Hebrides",
-                  "Low",
-                  "DB-255"
-                ],
+                "label": ["Hebrides", "Low", "DB-255"],
                 "station_id": "EG-Hebrides-Low"
               },
               {
-                "label": [
-                  "Central",
-                  "DB-255"
-                ],
+                "label": ["Central", "DB-255"],
                 "station_id": "EG-Westcoast-Central"
               },
               {
@@ -761,10 +483,7 @@
                 "label": []
               },
               {
-                "label": [
-                  "EGLL",
-                  "PLN"
-                ],
+                "label": ["EGLL", "PLN"],
                 "station_id": "EGLL_P_GND"
               },
               {
@@ -774,86 +493,48 @@
           }
         },
         {
-          "label": [
-            "Shannon"
-          ],
+          "label": ["Shannon"],
           "size": 7,
           "page": {
             "rows": 4,
             "keys": [
               {
-                "label": [
-                  "NOTA",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["NOTA", "Super", "355+"],
                 "station_id": "EISN_NS_CTR"
               },
               {
-                "label": [
-                  "West",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["West", "Super", "355+"],
                 "station_id": "EISN_WS_CTR"
               },
               {
-                "label": [
-                  "Ocean",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["Ocean", "Super", "355+"],
                 "station_id": "EISN_SS_CTR"
               },
               {
-                "label": [
-                  "SOTA",
-                  "Super",
-                  "355+"
-                ],
+                "label": ["SOTA", "Super", "355+"],
                 "station_id": "EISN_SS_CTR"
               },
               {
-                "label": [
-                  "NOTA",
-                  "Upper",
-                  "245-355"
-                ],
+                "label": ["NOTA", "Upper", "245-355"],
                 "station_id": "EISN_N_CTR"
               },
               {
-                "label": [
-                  "West",
-                  "Upper",
-                  "245-355"
-                ],
+                "label": ["West", "Upper", "245-355"],
                 "station_id": "EISN_W_CTR"
               },
               {
-                "label": [
-                  "Ocean",
-                  "Upper",
-                  "245-355"
-                ],
+                "label": ["Ocean", "Upper", "245-355"],
                 "station_id": "EISN_O_CTR"
               },
               {
-                "label": [
-                  "SOTA",
-                  "Upper",
-                  "245-255"
-                ],
+                "label": ["SOTA", "Upper", "245-255"],
                 "station_id": "EISN_S_CTR"
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "Low",
-                  "Level",
-                  "245-"
-                ],
+                "label": ["Low", "Level", "245-"],
                 "station_id": "EISN_LS_CTR"
               },
               {
@@ -866,40 +547,25 @@
           }
         },
         {
-          "label": [
-            "Brest",
-            "(INOP)"
-          ],
+          "label": ["Brest", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": [
-                  "West",
-                  "255+"
-                ]
+                "label": ["West", "255+"]
               },
               {
-                "label": [
-                  "AU",
-                  "355-660"
-                ]
+                "label": ["AU", "355-660"]
               },
               {
                 "label": []
               },
               {
-                "label": [
-                  "AS",
-                  "255-355"
-                ]
+                "label": ["AS", "255-355"]
               },
               {
-                "label": [
-                  "Lower",
-                  "255-"
-                ]
+                "label": ["Lower", "255-"]
               },
               {
                 "label": []
@@ -908,25 +574,16 @@
           }
         },
         {
-          "label": [
-            "Madrid",
-            "(INOP)"
-          ],
+          "label": ["Madrid", "(INOP)"],
           "size": 7,
           "page": {
             "rows": 2,
             "keys": [
               {
-                "label": [
-                  "Upper",
-                  "245-660"
-                ]
+                "label": ["Upper", "245-660"]
               },
               {
-                "label": [
-                  "Lower",
-                  "245-"
-                ]
+                "label": ["Lower", "245-"]
               }
             ]
           }


### PR DESCRIPTION
The NAT is currently setup for a configuration which focuses on the splits of the NAT positions which is not something that is used in everyday practice. This PR moves the split positions to be hidden within subpages while leaving the primary positions (CZQO and EGGX) exposed on the primary page for easy access.

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
