### PR TITLE
feat (EDGG): Rename and add DA keys

### DIFF
--- a/dataset/EDGG/profiles/EDGG_EBG6.json
+++ b/dataset/EDGG/profiles/EDGG_EBG6.json
@@ -48,7 +48,7 @@
           {
             "label": ["EDLP", "TWR"],
             "color": "azure",
-            "station_id": "EDGG-PADL"
+            "station_id": "EDGG-LPT"
           },
           {
             "label": ["EDLP", "GND"],

--- a/dataset/EDGG/profiles/EDGG_EBG7.json
+++ b/dataset/EDGG/profiles/EDGG_EBG7.json
@@ -132,7 +132,9 @@
             "station_id": "EDGG-BOT"
           },
           {
-            "label": [""]
+            "label": ["PADL"],
+            "color": "clay",
+            "station_id": "EDGG-PADL"
           },
           {
             "label": [""]

--- a/dataset/EDGG/profiles/EDGG_KLA.json
+++ b/dataset/EDGG/profiles/EDGG_KLA.json
@@ -71,14 +71,18 @@
             "station_id": "EDGG-PAH"
           },
           {
-            "label": [""]
+            "label": ["PADL"],
+            "color": "clay",
+            "station_id": "EDGG-PADL"
+          },
+          {
+            "label": ["HMM"],
+            "color": "clay",
+            "station_id": "EDGG-HMM"
           },
           {
             "label": ["EHAA", "ACE"],
             "color": "mint"
-          },
-          {
-            "label": [""]
           },
           {
             "label": ["EDGG", "RUD"],

--- a/dataset/EDGG/profiles/EDGG_TWR.json
+++ b/dataset/EDGG/profiles/EDGG_TWR.json
@@ -263,12 +263,14 @@
             "station_id": "EDGG-DSAT"
           },
           {
-            "label": [""]
-          },
-          {
             "label": ["EDDS", "TWR"],
             "color": "azure",
             "station_id": "EDGG-DST"
+          },       
+          {
+            "label": ["EDDS", "VFR", "TWR"],
+            "color": "azure",
+            "station_id": "EDGG-DSTV"
           },
           {
             "label": ["EDDS", "GND"],
@@ -444,7 +446,7 @@
             "station_id": "EDGG-BOT"
           },
           {
-            "label": ["PAL"],
+            "label": ["PADL"],
             "color": "umber",
             "station_id": "EDGG-PADL"
           },

--- a/dataset/EDGG/profiles/EDGG_TWR.json
+++ b/dataset/EDGG/profiles/EDGG_TWR.json
@@ -266,7 +266,7 @@
             "label": ["EDDS", "TWR"],
             "color": "azure",
             "station_id": "EDGG-DST"
-          },       
+          },
           {
             "label": ["EDDS", "VFR", "TWR"],
             "color": "azure",

--- a/dataset/EDGG/profiles/EDGG_UPR.json
+++ b/dataset/EDGG/profiles/EDGG_UPR.json
@@ -5,7 +5,7 @@
     {
       "label": "RL",
       "page": {
-        "rows": 6,
+        "rows": 5,
         "keys": [
           {
             "label": ["RH"],
@@ -18,9 +18,9 @@
             "station_id": "EDYY-RL"
           },
           {
-            "label": ["PAD"],
+            "label": ["PADH"],
             "color": "lagoon",
-            "station_id": "EDGG-PAD"
+            "station_id": "EDGG-PAH"
           },
           {
             "label": ["EDUU", "NTM"],
@@ -31,9 +31,6 @@
             "label": ["EDGG", "RUD"],
             "color": "mint",
             "station_id": "EDGG-RUD"
-          },
-          {
-            "label": [""]
           },
           {
             "label": ["MH"],
@@ -61,9 +58,6 @@
             "station_id": "EDGG-TAU"
           },
           {
-            "label": [""]
-          },
-          {
             "label": ["EDYY", "JH"],
             "color": "lavender",
             "station_id": "EDYY-JH"
@@ -89,9 +83,6 @@
             "station_id": "EDGG-SIG"
           },
           {
-            "label": [""]
-          },
-          {
             "label": ["EDYY", "HH"],
             "color": "lavender",
             "station_id": "EDYY-HH"
@@ -113,9 +104,6 @@
             "label": ["EDGG", "GIN"],
             "color": "mint",
             "station_id": "EDGG-GIN"
-          },
-          {
-            "label": [""]
           },
           {
             "label": ["EDYY", "CH"],
@@ -141,9 +129,6 @@
             "station_id": "EDWW-EID"
           },
           {
-            "label": [""]
-          },
-          {
             "label": ["EDYY", "SH"],
             "color": "lavender",
             "station_id": "EDYY-SH"
@@ -163,9 +148,6 @@
             "label": ["EDWW", "ALR"],
             "color": "mint",
             "station_id": "EDWW-ALR"
-          },
-          {
-            "label": [""]
           },
           {
             "label": ["EDYY", "YYD"],
@@ -190,9 +172,6 @@
             "station_id": "EDWW-EMS"
           },
           {
-            "label": [""]
-          },
-          {
             "label": ["EDYY", "LNH"],
             "color": "lavender",
             "station_id": "EDYY-LNH"
@@ -212,9 +191,6 @@
             "label": ["EDWW", "HRZ"],
             "color": "mint",
             "station_id": "EDWW-HRZ"
-          },
-          {
-            "label": [""]
           }
         ]
       }
@@ -222,7 +198,7 @@
     {
       "label": "FUL",
       "page": {
-        "rows": 6,
+        "rows": 5,
         "keys": [
           {
             "label": ["NTM"],
@@ -250,9 +226,6 @@
             "station_id": "EDGG-NKRH"
           },
           {
-            "label": [""]
-          },
-          {
             "label": ["FFM"],
             "color": "lilac",
             "station_id": "EDUU-FFM"
@@ -276,9 +249,6 @@
             "label": ["EDGG", "MAN"],
             "color": "mint",
             "station_id": "EDGG-MAN"
-          },
-          {
-            "label": [""]
           },
           {
             "label": ["FUL"],
@@ -306,9 +276,6 @@
             "station_id": "EDGG-HAB"
           },
           {
-            "label": [""]
-          },
-          {
             "label": ["EDYY", "LXH"],
             "color": "lavender",
             "station_id": "EDYY-LXH"
@@ -324,15 +291,14 @@
             "station_id": "EDGG-GED"
           },
           {
-            "label": [""]
+            "label": ["NOR"],
+            "color": "clay",
+            "station_id": "EDGG-NOR"
           },
           {
-            "label": ["EDGG", "PAD"],
-            "color": "mint",
-            "station_id": "EDGG-PAD"
-          },
-          {
-            "label": [""]
+            "label": ["DLA"],
+            "color": "clay",
+            "station_id": "EDGG-DLA"
           },
           {
             "label": ["EDYY", "SH"],
@@ -355,12 +321,9 @@
             "station_id": "EDYY-LXH"
           },
           {
-            "label": ["EBBU", "EHS"],
+            "label": ["EDGG", "PADH"],
             "color": "mint",
-            "station_id": "EBBU-EHS"
-          },
-          {
-            "label": [""]
+            "station_id": "EDGG-PAH"
           },
           {
             "label": ["EDYY", "MH"],
@@ -383,12 +346,9 @@
             "station_id": "EDMM-BBG"
           },
           {
-            "label": ["EBBU", "LUS"],
+            "label": ["EBBU", "EHS"],
             "color": "mint",
-            "station_id": "EBBU-LUS"
-          },
-          {
-            "label": [""]
+            "station_id": "EBBU-EHS"
           },
           {
             "label": ["EDYY", "RH"],
@@ -411,10 +371,9 @@
             "station_id": "EDMM-GER"
           },
           {
-            "label": [""]
-          },
-          {
-            "label": [""]
+            "label": ["EBBU", "LUS"],
+            "color": "mint",
+            "station_id": "EBBU-LUS"
           },
           {
             "label": ["EDUU", "SAL"],
@@ -437,9 +396,6 @@
           {
             "label": ["LFEE", "UE"],
             "color": "mint"
-          },
-          {
-            "label": [""]
           }
         ]
       }

--- a/dataset/EDGG/profiles/EDGG_UPR.json
+++ b/dataset/EDGG/profiles/EDGG_UPR.json
@@ -291,12 +291,12 @@
             "station_id": "EDGG-GED"
           },
           {
-            "label": ["NOR"],
+            "label": ["EDGG", "NOR"],
             "color": "clay",
             "station_id": "EDGG-NOR"
           },
           {
-            "label": ["DLA"],
+            "label": ["EDGG", "DLA"],
             "color": "clay",
             "station_id": "EDGG-DLA"
           },


### PR DESCRIPTION
### Description

* Fix EDLP TWR DA keys station_id
* Rename PAD to PADH and PAL to PADL
* Add NOR / DLA to FUL profile
* Add EDDS VFR TWR DA key
* Remove (empty) rows in UPR (RL / FUL) profile

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

### Checklist

- [X] Dataset files are in the correct `dataset/{FIR}/` directory.
- [X] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
