### PR TITLE
fix (EDGG): Wrong profile assignment and DA call receiver

### DIFF
--- a/dataset/EDGG/positions.json
+++ b/dataset/EDGG/positions.json
@@ -52,7 +52,7 @@
       "prefixes": ["EDUU"],
       "frequency": "136.560",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB",
+      "profile_id": "EDGG_UPR",
       "default_call_sources": ["EDUU-UW"]
     },
     {
@@ -60,7 +60,7 @@
       "prefixes": ["EDUU"],
       "frequency": "130.260",
       "facility_type": "CTR",
-      "profile_id": "EDGG_MBB",
+      "profile_id": "EDGG_UPR",
       "default_call_sources": ["EDUU-UC"]
     },
     {
@@ -117,7 +117,7 @@
       "frequency": "136.480",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_sources": ["EDGG-PAD"]
+      "default_call_sources": ["EDGG-PAH"]
     },
     {
       "id": "EDGG_N_CTR",
@@ -125,7 +125,7 @@
       "frequency": "118.215",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_sources": ["EDGG-PAD"]
+      "default_call_sources": ["EDGG-PAH"]
     },
     {
       "id": "EDGG_PAH_CTR",
@@ -133,7 +133,7 @@
       "frequency": "136.625",
       "facility_type": "CTR",
       "profile_id": "EDGG_MBB",
-      "default_call_sources": ["EDGG-PAD"]
+      "default_call_sources": ["EDGG-PAH"]
     },
     {
       "id": "EDGG_PAD_CTR",

--- a/dataset/EDGG/profiles/EDGG_MBB.json
+++ b/dataset/EDGG/profiles/EDGG_MBB.json
@@ -63,9 +63,9 @@
             }
           },
           {
-            "label": ["PAD"],
+            "label": ["PADH"],
             "color": "lagoon",
-            "station_id": "EDGG-PAD"
+            "station_id": "EDGG-PAH"
           },
           {
             "label": ["DLA"],
@@ -78,7 +78,7 @@
             "station_id": "EDGG-DLT"
           },
           {
-            "label": ["EDDL", "more..."],
+            "label": ["EDDL"],
             "page": {
               "rows": 3,
               "keys": [
@@ -148,7 +148,7 @@
             "station_id": "EDGG-DKT"
           },
           {
-            "label": ["EDDK", "more..."],
+            "label": ["EDDK"],
             "page": {
               "rows": 3,
               "keys": [
@@ -369,7 +369,7 @@
             "station_id": "EDGG-DFTC"
           },
           {
-            "label": ["EDDF", "more..."],
+            "label": ["EDDF"],
             "page": {
               "rows": 4,
               "keys": [
@@ -536,6 +536,16 @@
             "station_id": "EDGG-SIG"
           },
           {
+            "label": ["EDGG", "PADL"],
+            "color": "clay",
+            "station_id": "EDGG-PADL"
+          },
+          {
+            "label": ["ETOU", "TWR"],
+            "color": "steel",
+            "station_id": "EDGG-TOUT"
+          },
+          {
             "label": ["EDDL", "EDDK"],
             "page": {
               "rows": 2,
@@ -562,14 +572,6 @@
             }
           },
           {
-            "label": ["ETOU", "TWR"],
-            "color": "steel",
-            "station_id": "EDGG-TOUT"
-          },
-          {
-            "label": [""]
-          },
-          {
             "label": ["EDUU", "ERL"],
             "color": "lavender",
             "station_id": "EDUU-ERL"
@@ -585,9 +587,9 @@
             "station_id": "EDGG-GIN"
           },
           {
-            "label": ["EDGG", "PAD"],
+            "label": ["EDGG", "PADH"],
             "color": "mint",
-            "station_id": "EDGG-PAD"
+            "station_id": "EDGG-PAH"
           },
           {
             "label": ["EDWW", "HRZ"],
@@ -770,7 +772,7 @@
             "station_id": "EDGG-DST"
           },
           {
-            "label": ["EDDS", "more..."],
+            "label": ["EDDS"],
             "page": {
               "rows": 2,
               "keys": [
@@ -922,7 +924,7 @@
             "station_id": "EDGG-PFA"
           },
           {
-            "label": ["DFAS"],
+            "label": ["EDGG", "DFAS"],
             "color": "clay",
             "station_id": "EDGG-DFAS"
           },
@@ -932,7 +934,7 @@
             "station_id": "EDGG-DFTC"
           },
           {
-            "label": ["EDDF", "more..."],
+            "label": ["EDDF"],
             "page": {
               "rows": 4,
               "keys": [
@@ -1138,9 +1140,9 @@
             "station_id": "EDYY-RL"
           },
           {
-            "label": ["PAD"],
+            "label": ["PADH"],
             "color": "lagoon",
-            "station_id": "EDGG-PAD"
+            "station_id": "EDGG-PAH"
           },
           {
             "label": [""]


### PR DESCRIPTION
### Description

* Fix wrong profile assignment for C and W CTR (UPR)
* Fix DA keys calling PAD to call PAH now
* Add PADL to C/CH profile
* Remove more... text for folders in MBB profile

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

### Checklist

- [X] Dataset files are in the correct `dataset/{FIR}/` directory.
- [X] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
