### PR TITLE
Remove RCAA definitions from VHHK dataset

### DIFF
--- a/dataset/VH/positions.json
+++ b/dataset/VH/positions.json
@@ -321,41 +321,6 @@
       "default_call_sources": ["VHHK_FMP"]
     },
     {
-      "id": "RCAA_W_CTR",
-      "prefixes": ["TPE"],
-      "frequency": "126.700",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "RCAA_L_CTR",
-      "prefixes": ["TPE"],
-      "frequency": "125.500",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "RCAA_N_CTR",
-      "prefixes": ["TPE"],
-      "frequency": "123.600",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "RCAA_E_CTR",
-      "prefixes": ["TPE"],
-      "frequency": "127.900",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "RCAA_S_CTR",
-      "prefixes": ["TPE"],
-      "frequency": "129.100",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
       "id": "ASEA_FSS",
       "prefixes": ["ASEA"],
       "frequency": "135.350",

--- a/dataset/VH/profiles/VHHK.json
+++ b/dataset/VH/profiles/VHHK.json
@@ -193,23 +193,23 @@
         "keys": [
           {
             "label": ["PEW"],
-            "station_id": "TPE_W_CTR"
+            "station_id": "AWR"
           },
           {
             "label": ["PEL"],
-            "station_id": "TPE_L_CTR"
+            "station_id": "ALR"
           },
           {
             "label": ["PEE"],
-            "station_id": "TPE_E_CTR"
+            "station_id": "AER"
           },
           {
             "label": ["PEN"],
-            "station_id": "TPE_N_CTR"
+            "station_id": "ANR"
           },
           {
             "label": ["PES"],
-            "station_id": "TPE_S_CTR"
+            "station_id": "ASR"
           },
           {
             "label": ["SEA"],

--- a/dataset/VH/profiles/VHHK.json
+++ b/dataset/VH/profiles/VHHK.json
@@ -193,23 +193,23 @@
         "keys": [
           {
             "label": ["PEW"],
-            "station_id": "RCAA_W_CTR"
+            "station_id": "TPE_W_CTR"
           },
           {
             "label": ["PEL"],
-            "station_id": "RCAA_L_CTR"
+            "station_id": "TPE_L_CTR"
           },
           {
             "label": ["PEE"],
-            "station_id": "RCAA_E_CTR"
+            "station_id": "TPE_E_CTR"
           },
           {
             "label": ["PEN"],
-            "station_id": "RCAA_N_CTR"
+            "station_id": "TPE_N_CTR"
           },
           {
             "label": ["PES"],
-            "station_id": "RCAA_S_CTR"
+            "station_id": "TPE_S_CTR"
           },
           {
             "label": ["SEA"],

--- a/dataset/VH/stations.json
+++ b/dataset/VH/stations.json
@@ -200,28 +200,6 @@
       "controlled_by": ["VHHK_FMP"]
     },
     {
-      "id": "RCAA_W_CTR",
-      "controlled_by": ["RCAA_W_CTR"]
-    },
-    {
-      "id": "RCAA_E_CTR",
-      "parent_id": "RCAA_W_CTR",
-      "controlled_by": ["RCAA_E_CTR"]
-    },
-    {
-      "id": "RCAA_S_CTR",
-      "parent_id": "RCAA_E_CTR",
-      "controlled_by": ["RCAA_S_CTR"]
-    },
-    {
-      "id": "RCAA_L_CTR",
-      "controlled_by": ["RCAA_L_CTR", "RCAA_W_CTR"]
-    },
-    {
-      "id": "RCAA_N_CTR",
-      "controlled_by": ["RCAA_N_CTR", "RCAA_L_CTR", "RCAA_W_CTR"]
-    },
-    {
       "id": "ASEA_FSS",
       "controlled_by": ["ASEA_FSS"]
     },


### PR DESCRIPTION
### Description

<!-- What does this PR change and why? -->

Removed RCAA definitions from VHHK dataset as per #363. **Not to be merged until #363 has been merged.**

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [x] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
