### PR TITLE
Update GMMN APC positions profile id

### DIFF
--- a/dataset/GM/positions.json
+++ b/dataset/GM/positions.json
@@ -286,6 +286,7 @@
       "prefixes": ["GMMN"],
       "frequency": "119.900",
       "facility_type": "APP",
+      "profile_id": "GMMN",
       "default_call_sources": ["GMMN_APP"]
     },
     {
@@ -293,6 +294,7 @@
       "prefixes": ["GMMN"],
       "frequency": "121.300",
       "facility_type": "APP",
+      "profile_id": "GMMN",
       "default_call_sources": ["GMMN_F_APP"]
     },
     {


### PR DESCRIPTION
### Description

Updated GMMN_APP and GMMN_F_APP profile ID

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
