### PR TITLE
Update stations.toml

### DIFF
--- a/dataset/EP/stations.toml
+++ b/dataset/EP/stations.toml
@@ -479,7 +479,6 @@ controlled_by = ["EPGD_GND"]
 [[stations]]
 id = "EPGD_TWR"
 controlled_by = [
-  "EPGD_GND",
   "EPGD_TWR",
   "EPGD_L_APP",
   "EPGD_APP",
@@ -553,8 +552,6 @@ controlled_by = ["EPKK_GND"]
 [[stations]]
 id = "EPKK_TWR"
 controlled_by = [
-  "EPKK_DEL",
-  "EPKK_GND",
   "EPKK_TWR",
   "EPKK_KK_APP",
   "EPKK_APP",
@@ -665,8 +662,6 @@ controlled_by = ["EPKT_GND"]
 [[stations]]
 id = "EPKT_TWR"
 controlled_by = [
-  "EPKT_DEL",
-  "EPKT_GND",
   "EPKT_TWR",
   "EPKK_APP",
   "EPWW_J_CTR",
@@ -708,7 +703,6 @@ controlled_by = ["EPLL_DEL"]
 [[stations]]
 id = "EPLL_TWR"
 controlled_by = [
-  "EPLL_DEL",
   "EPLL_TWR",
   "EPWA_S_APP",
   "EPWA_N_APP",
@@ -764,7 +758,6 @@ controlled_by = ["EPMO_DEL"]
 [[stations]]
 id = "EPMO_TWR"
 controlled_by = [
-  "EPMO_DEL",
   "EPMO_TWR",
   "EPWA_N_APP",
   "EPWA_S_APP",
@@ -801,7 +794,6 @@ controlled_by = ["EPPO_GND"]
 [[stations]]
 id = "EPPO_TWR"
 controlled_by = [
-  "EPPO_GND",
   "EPPO_TWR",
   "EPPO_N_APP",
   "EPWW_D_CTR",
@@ -983,8 +975,6 @@ controlled_by = ["EPWA_GND"]
 [[stations]]
 id = "EPWA_TWR"
 controlled_by = [
-  "EPWA_DEL",
-  "EPWA_GND",
   "EPWA_TWR",
   "EPWA_F_APP",
   "EPWA_APP",


### PR DESCRIPTION
Update stations to remove invalid correlation with GND and DEL positions claiming to be controlling TWR position.


### Description

<!-- What does this PR change and why? -->

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [X ] Dataset files are in the correct `dataset/{FIR}/` directory.
- [X ] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ X] If contributing from a fork: "Allow edits by maintainers" is enabled.
