### PR TITLE
Remove RPHI definitions from VHHK dataset

### DIFF
--- a/dataset/RCAA/profiles/RCAA.json
+++ b/dataset/RCAA/profiles/RCAA.json
@@ -364,15 +364,15 @@
           },
           {
             "label": ["MNL", "CTR"],
-            "station_id": "RPHI_CTR"
+            "station_id": "MNL_CTR"
           },
           {
-            "label": ["MNL", "1_CTR"],
-            "station_id": "RPHI_1_CTR"
+            "label": ["MNL", "NW_CTR"],
+            "station_id": "MNL_NW_CTR"
           },
           {
             "label": ["MNL", "N_CTR"],
-            "station_id": "RPHI_N_CTR"
+            "station_id": "MNL_N_CTR"
           },
           {
             "label": ["ZSHA", "CTR"],

--- a/dataset/VH/positions.json
+++ b/dataset/VH/positions.json
@@ -328,27 +328,6 @@
       "profile_id": "VHHK"
     },
     {
-      "id": "RPHI_1_CTR",
-      "prefixes": ["MNL"],
-      "frequency": "127.500",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "RPHI_N_CTR",
-      "prefixes": ["MNL"],
-      "frequency": "126.575",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "RPHI_CTR",
-      "prefixes": ["MNL"],
-      "frequency": "119.300",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
       "id": "ZBBB_FSS",
       "prefixes": ["PRC"],
       "frequency": "133.075",

--- a/dataset/VH/profiles/VHHK.json
+++ b/dataset/VH/profiles/VHHK.json
@@ -216,16 +216,16 @@
             "station_id": "ASEA_FSS"
           },
           {
-            "label": ["MN1"],
-            "station_id": "RPHI_1_CTR"
+            "label": ["MNW"],
+            "station_id": "MNL_NW_CTR"
           },
           {
             "label": ["MNN"],
-            "station_id": "RPHI_N_CTR"
+            "station_id": "MNL_N_CTR"
           },
           {
             "label": ["MNL"],
-            "station_id": "RPHI_CTR"
+            "station_id": "MNL_CTR"
           },
           {
             "label": ["PRC"],

--- a/dataset/VH/stations.json
+++ b/dataset/VH/stations.json
@@ -204,20 +204,6 @@
       "controlled_by": ["ASEA_FSS"]
     },
     {
-      "id": "RPHI_1_CTR",
-      "parent_id": "RPHI_N_CTR",
-      "controlled_by": ["RPHI_1_CTR"]
-    },
-    {
-      "id": "RPHI_N_CTR",
-      "parent_id": "RPHI_CTR",
-      "controlled_by": ["RPHI_N_CTR"]
-    },
-    {
-      "id": "RPHI_CTR",
-      "controlled_by": ["RPHI_CTR"]
-    },
-    {
       "id": "ZBBB_FSS",
       "controlled_by": ["ZBBB_FSS"]
     },


### PR DESCRIPTION
### Description

Removed RPHI definitions from VHHK dataset

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [x] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
