### PR TITLE
2605 LIRR update

### DIFF
--- a/dataset/LI/positions.json
+++ b/dataset/LI/positions.json
@@ -1214,7 +1214,7 @@
     {
       "id": "LIRJ_I_TWR",
       "prefixes": ["LIRJ"],
-      "frequency": "123.700",
+      "frequency": "123.705",
       "facility_type": "TWR",
       "profile_id": "LIRR-NORTH"
     },

--- a/dataset/LI/positions.json
+++ b/dataset/LI/positions.json
@@ -848,6 +848,13 @@
       "profile_id": "LIRR-NORTH"
     },
     {
+      "id": "LIRR_CTR",
+      "prefixes": ["LIRR"],
+      "frequency": "135.615",
+      "facility_type": "CTR",
+      "profile_id": "LIRR-NORTH"
+    },
+    {
       "id": "LICA_ES0_APP",
       "prefixes": ["LICA"],
       "frequency": "118.800",

--- a/dataset/LI/stations.json
+++ b/dataset/LI/stations.json
@@ -658,19 +658,19 @@
     },
     {
       "id": "LIRR-ES1",
-      "controlled_by": ["LIRR_ES1_CTR", "LIRR_SU1_CTR"]
+      "controlled_by": ["LIRR_ES1_CTR", "LIRR_SU1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-SU1",
-      "controlled_by": ["LIRR_SU1_CTR"]
+      "controlled_by": ["LIRR_SU1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-EW1",
-      "controlled_by": ["LIRR_EW1_CTR", "LIRR_SU1_CTR"]
+      "controlled_by": ["LIRR_EW1_CTR", "LIRR_SU1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-EE3",
-      "controlled_by": ["LIRR_EE3_CTR", "LIRR_EW1_CTR", "LIRR_SU1_CTR"]
+      "controlled_by": ["LIRR_EE3_CTR", "LIRR_EW1_CTR", "LIRR_SU1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-NE1",
@@ -698,7 +698,7 @@
     },
     {
       "id": "LIRR-SU7",
-      "controlled_by": ["LIRR_SU7_CTR", "LIRR_NE7_CTR", "LIRR_SU1_CTR"]
+      "controlled_by": ["LIRR_SU7_CTR", "LIRR_NE7_CTR", "LIRR_SU1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-EW7",

--- a/dataset/LI/stations.json
+++ b/dataset/LI/stations.json
@@ -653,7 +653,8 @@
         "LIRR_ND1_CTR",
         "LIRR_US2_CTR",
         "LIRR_TS1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {
@@ -670,7 +671,12 @@
     },
     {
       "id": "LIRR-EE3",
-      "controlled_by": ["LIRR_EE3_CTR", "LIRR_EW1_CTR", "LIRR_SU1_CTR", "LIRR_CTR"]
+      "controlled_by": [
+        "LIRR_EE3_CTR",
+        "LIRR_EW1_CTR",
+        "LIRR_SU1_CTR",
+        "LIRR_CTR"
+      ]
     },
     {
       "id": "LIRR-NE1",
@@ -690,15 +696,30 @@
     },
     {
       "id": "LIRR-OV1",
-      "controlled_by": ["LIRR_OV1_CTR", "LIRR_NW1_CTR", "LIRR_NE1_CTR", "LIRR_CTR"]
+      "controlled_by": [
+        "LIRR_OV1_CTR",
+        "LIRR_NW1_CTR",
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
+      ]
     },
     {
       "id": "LIRR-US2",
-      "controlled_by": ["LIRR_US2_CTR", "LIRR_TS1_CTR", "LIRR_NE1_CTR", "LIRR_CTR"]
+      "controlled_by": [
+        "LIRR_US2_CTR",
+        "LIRR_TS1_CTR",
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
+      ]
     },
     {
       "id": "LIRR-SU7",
-      "controlled_by": ["LIRR_SU7_CTR", "LIRR_NE7_CTR", "LIRR_SU1_CTR", "LIRR_CTR"]
+      "controlled_by": [
+        "LIRR_SU7_CTR",
+        "LIRR_NE7_CTR",
+        "LIRR_SU1_CTR",
+        "LIRR_CTR"
+      ]
     },
     {
       "id": "LIRR-EW7",
@@ -719,7 +740,8 @@
         "LIRR_NW7_CTR",
         "LIRR_NE7_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {
@@ -803,7 +825,8 @@
         "LIRR_TW1_APP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {
@@ -816,7 +839,8 @@
         "LIRR_PN1_DEP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {
@@ -834,7 +858,8 @@
         "LIRR_PN1_DEP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {
@@ -850,7 +875,8 @@
         "LIRR_TW1_APP",
         "LIRR_PN1_DEP",
         "LIRR_NN1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {
@@ -865,7 +891,8 @@
         "LIRR_OV1_CTR",
         "LIRR_TW1_APP",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {
@@ -876,7 +903,8 @@
         "LIRR_OV1_CTR",
         "LIRR_TW1_APP",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {
@@ -977,7 +1005,8 @@
         "LIRR_PN1_DEP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {
@@ -990,7 +1019,8 @@
         "LIRR_OV1_CTR",
         "LIRR_TW1_APP",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {
@@ -1006,7 +1036,8 @@
         "LIRR_AET_APP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {
@@ -1022,7 +1053,8 @@
         "LIRR_AET_APP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR", "LIRR_CTR"
+        "LIRR_NE1_CTR",
+        "LIRR_CTR"
       ]
     },
     {

--- a/dataset/LI/stations.json
+++ b/dataset/LI/stations.json
@@ -653,7 +653,7 @@
         "LIRR_ND1_CTR",
         "LIRR_US2_CTR",
         "LIRR_TS1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {
@@ -674,27 +674,27 @@
     },
     {
       "id": "LIRR-NE1",
-      "controlled_by": ["LIRR_NE1_CTR"]
+      "controlled_by": ["LIRR_NE1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-NW1",
-      "controlled_by": ["LIRR_NW1_CTR", "LIRR_NE1_CTR"]
+      "controlled_by": ["LIRR_NW1_CTR", "LIRR_NE1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-TS1",
-      "controlled_by": ["LIRR_TS1_CTR", "LIRR_NE1_CTR"]
+      "controlled_by": ["LIRR_TS1_CTR", "LIRR_NE1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-NN1",
-      "controlled_by": ["LIRR_NN1_CTR", "LIRR_NE1_CTR"]
+      "controlled_by": ["LIRR_NN1_CTR", "LIRR_NE1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-OV1",
-      "controlled_by": ["LIRR_OV1_CTR", "LIRR_NW1_CTR", "LIRR_NE1_CTR"]
+      "controlled_by": ["LIRR_OV1_CTR", "LIRR_NW1_CTR", "LIRR_NE1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-US2",
-      "controlled_by": ["LIRR_US2_CTR", "LIRR_TS1_CTR", "LIRR_NE1_CTR"]
+      "controlled_by": ["LIRR_US2_CTR", "LIRR_TS1_CTR", "LIRR_NE1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-SU7",
@@ -711,7 +711,7 @@
     },
     {
       "id": "LIRR-NE7",
-      "controlled_by": ["LIRR_NE7_CTR", "LIRR_NE1_CTR"]
+      "controlled_by": ["LIRR_NE7_CTR", "LIRR_NE1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-NW7",
@@ -719,7 +719,7 @@
         "LIRR_NW7_CTR",
         "LIRR_NE7_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {
@@ -803,7 +803,7 @@
         "LIRR_TW1_APP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {
@@ -816,7 +816,7 @@
         "LIRR_PN1_DEP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {
@@ -834,7 +834,7 @@
         "LIRR_PN1_DEP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {
@@ -850,12 +850,12 @@
         "LIRR_TW1_APP",
         "LIRR_PN1_DEP",
         "LIRR_NN1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {
       "id": "LIRZ-APP",
-      "controlled_by": ["LIRZ_APP", "LIRR_NE1_CTR"]
+      "controlled_by": ["LIRZ_APP", "LIRR_NE1_CTR", "LIRR_CTR"]
     },
     {
       "id": "LIRR-PN1",
@@ -865,7 +865,7 @@
         "LIRR_OV1_CTR",
         "LIRR_TW1_APP",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {
@@ -876,7 +876,7 @@
         "LIRR_OV1_CTR",
         "LIRR_TW1_APP",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {
@@ -977,7 +977,7 @@
         "LIRR_PN1_DEP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {
@@ -990,7 +990,7 @@
         "LIRR_OV1_CTR",
         "LIRR_TW1_APP",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {
@@ -1006,7 +1006,7 @@
         "LIRR_AET_APP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {
@@ -1022,7 +1022,7 @@
         "LIRR_AET_APP",
         "LIRR_OV1_CTR",
         "LIRR_NW1_CTR",
-        "LIRR_NE1_CTR"
+        "LIRR_NE1_CTR", "LIRR_CTR"
       ]
     },
     {


### PR DESCRIPTION
### Description

Added LIRR_CTR position and updated LIRJ_I_TWR frequency

### AIRAC dependency

- [x] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
