### PR TITLE
Add OO stations and positions. Update OEJD profiles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,7 @@ CONTRIBUTING.md @vacs-project/maintainers
 /dataset/NAT/ @vacs-project/dataset-maintainers-nat
 /dataset/OE/ @vacs-project/dataset-maintainers-oe
 /dataset/OM/ @vacs-project/dataset-maintainers-arb
+/dataset/OO/ @vacs-project/dataset-maintainers-arb
 /dataset/OP/ @vacs-project/dataset-maintainers-pak
 /dataset/OT/ @vacs-project/dataset-maintainers-arb
 /dataset/RCAA/ @vacs-project/dataset-maintainers-rcaa

--- a/dataset/OE/positions.json
+++ b/dataset/OE/positions.json
@@ -40,7 +40,6 @@
       "profile_id": "OERD",
       "default_call_sources": ["OERD_1_CTR"]
     },
-
     {
       "id": "OEJD_1_CTR",
       "prefixes": ["OEJD"],
@@ -48,6 +47,14 @@
       "facility_type": "CTR",
       "profile_id": "OEJD",
       "default_call_sources": ["OEJD_1_CTR"]
+    },
+    {
+      "id": "OEJD_2_CTR",
+      "prefixes": ["OEJD"],
+      "frequency": "133.900",
+      "facility_type": "CTR",
+      "profile_id": "OEJD-2",
+      "default_call_sources": ["OEJD_2_CTR"]
     },
     {
       "id": "OEJD_N_CTR",
@@ -86,7 +93,7 @@
       "prefixes": ["OEJD"],
       "frequency": "134.500",
       "facility_type": "CTR",
-      "profile_id": "OEJD",
+      "profile_id": "OEJD-SE",
       "default_call_sources": ["OEJD_SE_CTR"]
     },
     {
@@ -230,7 +237,6 @@
       "profile_id": "OERK",
       "default_call_sources": ["OERK_F_APP"]
     },
-
     {
       "id": "OERK_E_TWR",
       "prefixes": ["OERK"],

--- a/dataset/OE/profiles/OEJD-2.json
+++ b/dataset/OE/profiles/OEJD-2.json
@@ -1,0 +1,60 @@
+{
+  "id": "OEJD-2",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["ACC 2"],
+      "page": {
+        "rows": 2,
+        "keys": [
+          {
+            "label": ["RD", "CTA"],
+            "station_id": "OERD_E_CTR"
+          },
+          {
+            "label": ["JD", "ACC", "SOUTH"],
+            "station_id": "OEJD_S_CTR"
+          },
+          {
+            "label": ["RD", "NE", "345+"],
+            "station_id": "OERD_NE_CTR"
+          },
+          {
+            "label": ["JD", "NE", "245-345"],
+            "station_id": "OERD_NE_CTR"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["DOH", "R2", "245-"],
+            "station_id": "DOH_R2_APP"
+          },
+          {
+            "label": ["OTDF", "ACC 2", "245+"],
+            "station_id": "OTDF_2_CTR"
+          },
+          {
+            "label": ["UAE", "SOUTH"],
+            "station_id": "OMAE_S_CTR"
+          },
+          {
+            "label": ["OOMM", "ACC S"],
+            "station_id": "OOMM_5_CTR"
+          },
+          {
+            "label": ["OOMM", "ACC C"],
+            "station_id": "OOMM_6_CTR"
+          },
+          {
+            "label": ["OOMM", "ACC M"],
+            "station_id": "OOMM_4_CTR"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dataset/OE/profiles/OEJD-SE.json
+++ b/dataset/OE/profiles/OEJD-SE.json
@@ -1,0 +1,60 @@
+{
+  "id": "OEJD-SE",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["ACC", "SE"],
+      "page": {
+        "rows": 2,
+        "keys": [
+          {
+            "label": ["RD", "CTA"],
+            "station_id": "OERD_E_CTR"
+          },
+          {
+            "label": ["JD", "ACC", "SOUTH"],
+            "station_id": "OEJD_S_CTR"
+          },
+          {
+            "label": ["RD", "NE", "345+"],
+            "station_id": "OERD_NE_CTR"
+          },
+          {
+            "label": ["JD", "NE", "245-345"],
+            "station_id": "OERD_NE_CTR"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["DOH", "R2", "245-"],
+            "station_id": "DOH_R2_APP"
+          },
+          {
+            "label": ["OTDF", "ACC 2", "245+"],
+            "station_id": "OTDF_2_CTR"
+          },
+          {
+            "label": ["UAE", "SOUTH"],
+            "station_id": "OMAE_S_CTR"
+          },
+          {
+            "label": ["OOMM", "ACC S"],
+            "station_id": "OOMM_5_CTR"
+          },
+          {
+            "label": ["OOMM", "ACC C"],
+            "station_id": "OOMM_6_CTR"
+          },
+          {
+            "label": ["OOMM", "ACC M"],
+            "station_id": "OOMM_4_CTR"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dataset/OE/stations.json
+++ b/dataset/OE/stations.json
@@ -26,8 +26,15 @@
       "parent_id": "OERD_1_CTR",
       "controlled_by": ["OERK_N_CTR"]
     },
-
-    { "id": "OEJD_1_CTR", "controlled_by": ["OEJD_1_CTR"] },
+    {
+      "id": "OEJD_1_CTR",
+      "controlled_by": ["OEJD_1_CTR"]
+    },
+    {
+      "id": "OEJD_2_CTR",
+      "parent_id": "OEJD_1_CTR",
+      "controlled_by": ["OEJD_2_CTR"]
+    },
     {
       "id": "OEJD_N_CTR",
       "parent_id": "OEJD_1_CTR",
@@ -35,12 +42,12 @@
     },
     {
       "id": "OEJD_S_CTR",
-      "parent_id": "OEJD_1_CTR",
+      "parent_id": "OEJD_2_CTR",
       "controlled_by": ["OEJD_S_CTR"]
     },
     {
       "id": "OEJD_W_CTR",
-      "parent_id": "OEJD_1_CTR",
+      "parent_id": "OEJD_2_CTR",
       "controlled_by": ["OEJD_W_CTR"]
     },
     {
@@ -55,7 +62,7 @@
     },
     {
       "id": "OEJD_C_CTR",
-      "parent_id": "OEJD_1_CTR",
+      "parent_id": "OEJD_2_CTR",
       "controlled_by": ["OEJD_C_CTR"]
     },
 

--- a/dataset/OO/positions.json
+++ b/dataset/OO/positions.json
@@ -1,0 +1,179 @@
+{
+  "positions": [
+    {
+      "id": "OOMM_FMP",
+      "prefixes": ["OOMM"],
+      "frequency": "199.998",
+      "facility_type": "FMP",
+      "default_call_sources": ["OOMM_FMP"]
+    },
+    {
+      "id": "OOMM_1_CTR",
+      "prefixes": ["OOMM"],
+      "frequency": "128.150",
+      "facility_type": "CTR",
+      "default_call_sources": ["OOMM_1_CTR"]
+    },
+    {
+      "id": "OOMM_2_CTR",
+      "prefixes": ["OOMM"],
+      "frequency": "135.600",
+      "facility_type": "CTR",
+      "default_call_sources": ["OOMM_2_CTR"]
+    },
+    {
+      "id": "OOMM_3_CTR",
+      "prefixes": ["OOMM"],
+      "frequency": "126.550",
+      "facility_type": "CTR",
+      "default_call_sources": ["OOMM_3_CTR"]
+    },
+    {
+      "id": "OOMM_4_CTR",
+      "prefixes": ["OOMM"],
+      "frequency": "118.325",
+      "facility_type": "CTR",
+      "default_call_sources": ["OOMM_4_CTR"]
+    },
+    {
+      "id": "OOMM_5_CTR",
+      "prefixes": ["OOMM"],
+      "frequency": "123.950",
+      "facility_type": "CTR",
+      "default_call_sources": ["OOMM_5_CTR"]
+    },
+    {
+      "id": "OOMM_6_CTR",
+      "prefixes": ["OOMM"],
+      "frequency": "124.700",
+      "facility_type": "CTR",
+      "default_call_sources": ["OOMM_6_CTR"]
+    },
+    {
+      "id": "OOMM_7_CTR",
+      "prefixes": ["OOMM"],
+      "frequency": "119.800",
+      "facility_type": "CTR",
+      "default_call_sources": ["OOMM_7_CTR"]
+    },
+    {
+      "id": "OODQ_I_TWR",
+      "prefixes": ["OODQ"],
+      "frequency": "118.000",
+      "facility_type": "TWR",
+      "default_call_sources": ["OODQ_I_TWR"]
+    },
+    {
+      "id": "OOFD_I_TWR",
+      "prefixes": ["OOFD"],
+      "frequency": "122.750",
+      "facility_type": "TWR",
+      "default_call_sources": ["OOFD_I_TWR"]
+    },
+    {
+      "id": "OOJA_R_TWR",
+      "prefixes": ["OOJA"],
+      "frequency": "122.750",
+      "facility_type": "TWR",
+      "default_call_sources": ["OOJA_R_TWR"]
+    },
+    {
+      "id": "OOKB_APP",
+      "prefixes": ["OOKB"],
+      "frequency": "125.000",
+      "facility_type": "APP",
+      "default_call_sources": ["OOKB_APP"]
+    },
+    {
+      "id": "OOKB_TWR",
+      "prefixes": ["OOKB"],
+      "frequency": "124.350",
+      "facility_type": "TWR",
+      "default_call_sources": ["OOKB_TWR"]
+    },
+    {
+      "id": "OOMK_I_TWR",
+      "prefixes": ["OOMK"],
+      "frequency": "130.000",
+      "facility_type": "TWR",
+      "default_call_sources": ["OOMK_I_TWR"]
+    },
+    {
+      "id": "OOMS_APP",
+      "prefixes": ["OOMS"],
+      "frequency": "121.200",
+      "facility_type": "APP",
+      "default_call_sources": ["OOMS_APP"]
+    },
+    {
+      "id": "OOMS_1_TWR",
+      "prefixes": ["OOMS"],
+      "frequency": "118.825",
+      "facility_type": "TWR",
+      "default_call_sources": ["OOMS_1_TWR"]
+    },
+    {
+      "id": "OOMS_2_TWR",
+      "prefixes": ["OOMS"],
+      "frequency": "118.400",
+      "facility_type": "TWR",
+      "default_call_sources": ["OOMS_2_TWR"]
+    },
+    {
+      "id": "OOMS_1_GND",
+      "prefixes": ["OOMS"],
+      "frequency": "127.875",
+      "facility_type": "GND",
+      "default_call_sources": ["OOMS_1_GND"]
+    },
+    {
+      "id": "OOMS_2_GND",
+      "prefixes": ["OOMS"],
+      "frequency": "121.800",
+      "facility_type": "GND",
+      "default_call_sources": ["OOMS_2_GND"]
+    },
+    {
+      "id": "OOMS_DEL",
+      "prefixes": ["OOMS"],
+      "frequency": "125.575",
+      "facility_type": "DEL",
+      "default_call_sources": ["OOMS_DEL"]
+    },
+    {
+      "id": "OOMX_I_TWR",
+      "prefixes": ["OOMX"],
+      "frequency": "122.750",
+      "facility_type": "TWR",
+      "default_call_sources": ["OOMX_I_TWR"]
+    },
+    {
+      "id": "OOSA_APP",
+      "prefixes": ["OOSA"],
+      "frequency": "119.100",
+      "facility_type": "APP",
+      "default_call_sources": ["OOSA_APP"]
+    },
+    {
+      "id": "OOSA_TWR",
+      "prefixes": ["OOSA"],
+      "frequency": "118.200",
+      "facility_type": "TWR",
+      "default_call_sources": ["OOSA_TWR"]
+    },
+    {
+      "id": "OOSA_GND",
+      "prefixes": ["OOSA"],
+      "frequency": "124.025",
+      "facility_type": "GND",
+      "default_call_sources": ["OOSA_GND"]
+    },
+    {
+      "id": "OOSH_I_TWR",
+      "prefixes": ["OOSH"],
+      "frequency": "118.725",
+      "facility_type": "TWR",
+      "default_call_sources": ["OOSH_I_TWR"]
+    }
+  ]
+}

--- a/dataset/OO/stations.json
+++ b/dataset/OO/stations.json
@@ -1,0 +1,126 @@
+{
+  "stations": [
+    {
+      "id": "OOMM_FMP",
+      "parent_id": "OOMM_1_CTR",
+      "controlled_by": ["OOMM_FMP"]
+    },
+    {
+      "id": "OOMM_1_CTR",
+      "controlled_by": ["OOMM_1_CTR"]
+    },
+    {
+      "id": "OOMM_2_CTR",
+      "parent_id": "OOMM_1_CTR",
+      "controlled_by": ["OOMM_2_CTR"]
+    },
+    {
+      "id": "OOMM_3_CTR",
+      "parent_id": "OOMM_1_CTR",
+      "controlled_by": ["OOMM_3_CTR"]
+    },
+    {
+      "id": "OOMM_4_CTR",
+      "parent_id": "OOMM_1_CTR",
+      "controlled_by": ["OOMM_4_CTR"]
+    },
+    {
+      "id": "OOMM_5_CTR",
+      "parent_id": "OOMM_1_CTR",
+      "controlled_by": ["OOMM_5_CTR"]
+    },
+    {
+      "id": "OOMM_6_CTR",
+      "parent_id": "OOMM_1_CTR",
+      "controlled_by": ["OOMM_6_CTR"]
+    },
+    {
+      "id": "OOMM_7_CTR",
+      "parent_id": "OOMM_1_CTR",
+      "controlled_by": ["OOMM_7_CTR"]
+    },
+    {
+      "id": "OODQ_I_TWR",
+      "parent_id": "OOMM_4_CTR",
+      "controlled_by": ["OODQ_I_TWR"]
+    },
+    {
+      "id": "OOFD_I_TWR",
+      "parent_id": "OOMM_4_CTR",
+      "controlled_by": ["OOFD_I_TWR"]
+    },
+    {
+      "id": "OOJA_R_TWR",
+      "parent_id": "OOMM_5_CTR",
+      "controlled_by": ["OOJA_R_TWR"]
+    },
+    {
+      "id": "OOKB_APP",
+      "controlled_by": ["OOKB_APP"]
+    },
+    {
+      "id": "OOKB_TWR",
+      "parent_id": "OOKB_APP",
+      "controlled_by": ["OOKB_TWR"]
+    },
+    {
+      "id": "OOMK_I_TWR",
+      "controlled_by": ["OOMK_I_TWR"]
+    },
+    {
+      "id": "OOMS_APP",
+      "parent_id": "OOMM_1_CTR",
+      "controlled_by": ["OOMS_APP"]
+    },
+    {
+      "id": "OOMS_1_TWR",
+      "parent_id": "OOMS_APP",
+      "controlled_by": ["OOMS_1_TWR"]
+    },
+    {
+      "id": "OOMS_2_TWR",
+      "parent_id": "OOMS_APP",
+      "controlled_by": ["OOMS_2_TWR"]
+    },
+    {
+      "id": "OOMS_1_GND",
+      "parent_id": "OOMS_1_TWR",
+      "controlled_by": ["OOMS_1_GND"]
+    },
+    {
+      "id": "OOMS_2_GND",
+      "parent_id": "OOMS_2_TWR",
+      "controlled_by": ["OOMS_2_GND"]
+    },
+    {
+      "id": "OOMS_DEL",
+      "parent_id": "OOMS_1_GND",
+      "controlled_by": ["OOMS_DEL"]
+    },
+    {
+      "id": "OOMX_I_TWR",
+      "parent_id": "OOMM_5_CTR",
+      "controlled_by": ["OOMX_I_TWR"]
+    },
+    {
+      "id": "OOSA_APP",
+      "parent_id": "OOMM_5_CTR",
+      "controlled_by": ["OOSA_APP"]
+    },
+    {
+      "id": "OOSA_TWR",
+      "parent_id": "OOSA_APP",
+      "controlled_by": ["OOSA_TWR"]
+    },
+    {
+      "id": "OOSA_GND",
+      "parent_id": "OOSA_TWR",
+      "controlled_by": ["OOSA_GND"]
+    },
+    {
+      "id": "OOSH_I_TWR",
+      "parent_id": "OOMM_7_CTR",
+      "controlled_by": ["OOSH_I_TWR"]
+    }
+  ]
+}


### PR DESCRIPTION
### Description

- Add OEJD-SE profile for Hajj OPS: 2026
- Adds OO positions and stations for Hajj OPS: 2026

### OEJD-SE Profile
<img width="1493" height="1136" alt="image" src="https://github.com/user-attachments/assets/b4a020cd-3df3-4323-9749-6785e143cc91" />


### AIRAC dependency

- [x] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [x] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
