### PR TITLE
EG EHAA creation amendments

### DIFF
--- a/dataset/EG/profiles/EGPX.json
+++ b/dataset/EG/profiles/EGPX.json
@@ -648,7 +648,8 @@
                       },
                       {
                         "label": ["EHAA W", "245-"],
-                        "color": "azure"
+                        "color": "azure",
+                        "station_id": "EHAA_W"
                       }
                     ]
                   }

--- a/dataset/EH/profiles/EHAA.json
+++ b/dataset/EH/profiles/EHAA.json
@@ -15,32 +15,32 @@
           {
             "label": ["LON", "EN"],
             "color": "taupe",
-            "station_id": "LON_EN_CTR"
+            "station_id": "EG-Sector-12"
           },
           {
             "label": ["LON", "ES"],
             "color": "taupe",
-            "station_id": "LON_ES_CTR"
+            "station_id": "EG-Sector-13"
           },
           {
             "label": ["LON", "E"],
             "color": "taupe",
-            "station_id": "LON_E_CTR"
+            "station_id": "EG-Sector-14"
           },
           {
             "label": ["LTC", "JACKO"],
             "color": "cadet",
-            "station_id": "LTC_EJ_CTR"
+            "station_id": "EG-TC-JACKO"
           },
           {
             "label": ["LTC", "REDFA"],
             "color": "cadet",
-            "station_id": "LTC_ER_CTR"
+            "station_id": "EG-TC-REDFA"
           },
           {
             "label": ["SCO", "HUM"],
             "color": "steel",
-            "station_id": "SCO_HUM_CTR"
+            "station_id": "EG-Humber"
           },
           {
             "label": [],

--- a/dataset/EH/profiles/EHAA.json
+++ b/dataset/EH/profiles/EHAA.json
@@ -13,17 +13,17 @@
             "station_id": "LON_NE_CTR"
           },
           {
-            "label": ["LON", "EN"],
+            "label": ["LON", "12"],
             "color": "taupe",
             "station_id": "EG-Sector-12"
           },
           {
-            "label": ["LON", "ES"],
+            "label": ["LON", "13"],
             "color": "taupe",
             "station_id": "EG-Sector-13"
           },
           {
-            "label": ["LON", "E"],
+            "label": ["LON", "14"],
             "color": "taupe",
             "station_id": "EG-Sector-14"
           },


### PR DESCRIPTION
# Changes

- Amends EHAA profile to correctly reference EG stations.
- Amends EGPX profile to reference EHAA (W) station.

## Discussion

@vacs-project/dataset-maintainers-eh @OIleJanssen if you can, when referencing EG sectors please use the sectors rather than the positions defined in our `stations.toml` file.
The main reason why is so that our sometimes complex sectorisation is properly reflected, for example when referring to AC Sector 14, you should use `EG-Sector-14`, rather than `LON_E_CTR`, as if `LON_ES_CTR` is open with `LON_C_CTR`, then it will be incorrectly routed (hence the bug label). Additionally, it lets us make dataset amendments without necessarily having to amend the profiles of our neighbours. The reason why I haven't amended LAC North Sea is that LAC Sectors 10 & 11 are permanently bandboxed on VATSIM, and therefore aren't notified [as seperate] in the LoA, so it is fine as an exception.

I've also taken the time to amend the labelling to match, but if that isn't something which is taught, or preferred otherwise, then it can be amended to suit what would be best for Dutch VACC controllers.