### PR TITLE
Add missing "EDMM" upper stations to EBG2

### DIFF
--- a/dataset/EDGG/profiles/EDGG_EBG2.json
+++ b/dataset/EDGG/profiles/EDGG_EBG2.json
@@ -151,7 +151,9 @@
             "color": "mint"
           },
           {
-            "label": [""]
+            "label": ["EDUU", "AMM"],
+            "color": "lavender",
+            "station_id": "EDUU-AMM"
           },
           {
             "label": ["EDGG", "KIR"],
@@ -173,7 +175,9 @@
             "color": "mint"
           },
           {
-            "label": [""]
+            "label": ["EDUU", "ALP"],
+            "color": "lavender",
+            "station_id": "EDUU-ALP"
           },
           {
             "label": ["EDGG", "GIN"],


### PR DESCRIPTION
### Description

Add two missing neighbouring stations (AMM / ALP) for EBG2 profile

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

### Checklist

- [X] Dataset files are in the correct `dataset/{FIR}/` directory.
- [X] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
