### PR TITLE
Operationalise Santa Maria (NAT)

### DIFF
--- a/dataset/NAT/profiles/NAT-EVENT.json
+++ b/dataset/NAT/profiles/NAT-EVENT.json
@@ -412,37 +412,25 @@
           "justify_content": "center",
           "children": [
             {
-              "label": ["Santa", "Maria", "(INOP)"],
+              "label": ["Santa", "Maria"],
               "size": 7,
               "page": {
-                "rows": 3,
+                "rows": 2,
                 "keys": [
                   {
-                    "label": ["Oceanic", "clearance"]
-                  },
-                  {
-                    "label": ["Oceanic", "clearance", "2"]
-                  },
-                  {
-                    "label": []
-                  },
-                  {
-                    "label": ["Radio", "1"]
-                  },
-                  {
-                    "label": ["Radio", "2"]
-                  },
-                  {
-                    "label": ["Radio", "3"]
+                    "label": ["Clearance"],
+                    "station_id": "LPPO_OC_DEL"
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": ["Radio"]
+                    "label": ["Oceanic"],
+                    "station_id": "LPPO_FSS"
                   },
                   {
-                    "label": []
+                    "label": ["Oceanic", "285+"],
+                    "station_id": "LPPO_OC_CTR"
                   }
                 ]
               }

--- a/dataset/NAT/profiles/NAT.json
+++ b/dataset/NAT/profiles/NAT.json
@@ -445,37 +445,25 @@
           "justify_content": "center",
           "children": [
             {
-              "label": ["Santa", "Maria", "(INOP)"],
+              "label": ["Santa", "Maria"],
               "size": 7,
               "page": {
-                "rows": 3,
+                "rows": 2,
                 "keys": [
                   {
-                    "label": ["Oceanic", "clearance"]
-                  },
-                  {
-                    "label": ["Oceanic", "clearance", "2"]
-                  },
-                  {
-                    "label": []
-                  },
-                  {
-                    "label": ["Radio", "1"]
-                  },
-                  {
-                    "label": ["Radio", "2"]
-                  },
-                  {
-                    "label": ["Radio", "3"]
+                    "label": ["Clearance"],
+                    "station_id": "LPPO_OC_DEL"
                   },
                   {
                     "label": []
                   },
                   {
-                    "label": ["Radio"]
+                    "label": ["Oceanic"],
+                    "station_id": "LPPO_FSS"
                   },
                   {
-                    "label": []
+                    "label": ["Oceanic", "285+"],
+                    "station_id": "LPPO_OC_CTR"
                   }
                 ]
               }


### PR DESCRIPTION
# Changes

Updates the Santa Maria page of the NAT & NAT Event profile for the addition of LPPO to the dataset.

# Screenshots

<img width="1734" height="1219" alt="image" src="https://github.com/user-attachments/assets/9e1a49bb-d113-46f3-bfb8-1b0dd15224f5" />

<img width="1737" height="1226" alt="image" src="https://github.com/user-attachments/assets/a5ae7ceb-5375-44ad-9478-659edef75d7f" />
