### PR TITLE
Update EGAC frequencies - 2606

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -29,14 +29,14 @@ profile_id = "EG-Scottish"
 [[positions]]
 id = "EGAC_APP"
 prefixes = ["EGAC"]
-frequency = "130.850"
+frequency = "130.855"
 facility_type = "APP"
 profile_id = "EG-Scottish"
 
 [[positions]]
 id = "EGAC_F_APP"
 prefixes = ["EGAC"]
-frequency = "134.800"
+frequency = "134.805"
 facility_type = "APP"
 profile_id = "EG-Scottish"
 


### PR DESCRIPTION
# Changes

Updates EGAC frequencies for 2606.

https://docs.vatsim.uk/Briefing/2026/06/10/pi-26-015---belfast-radar-egac-833-frequency-changes/