### PR TITLE
Amend EG station_ids used in LFFF profile

### DIFF
--- a/dataset/LFFF/profiles/LFFF.json
+++ b/dataset/LFFF/profiles/LFFF.json
@@ -299,7 +299,7 @@
           {
             "label": ["LON", "S18"],
             "color": "clay",
-            "station_id": "LON_SF_CTR"
+            "station_id": "EG-Sector-18"
           },
           {
             "label": []
@@ -316,7 +316,7 @@
           {
             "label": ["LON", "S01"],
             "color": "blush",
-            "station_id": "LON_SU_CTR"
+            "station_id": "EG-Sector-01"
           },
           {
             "label": ["LON", "S16/S17"],
@@ -344,7 +344,7 @@
           {
             "label": ["LON", "S15"],
             "color": "clay",
-            "station_id": "LON_DK_CTR"
+            "station_id": "EG-Sector-15"
           },
           {
             "label": ["BBU", "WLS"],


### PR DESCRIPTION
# Summary of changes

Amends LFFF profile to correctly reference EG stations.

## Discussion

@vacs-project/dataset-maintainers-lf if you can, when referencing EG sectors please use the sectors rather than the positions defined in our stations.toml file.
The main reason why is so that our sometimes complex sectorisation is properly reflected, for example when referring to LAC Sector 01, you should use `EG-Sector-01`, rather than `LON_SU_CTR`, as if `LON_H_CTR` (or anything covering it top-down) is open without `LON_SU_CTR`/`LON_SN_CTR`, then it will not be routed to `LON_H_CTR`/its top-down owner (hence the bug label).
Additionally, it lets us make dataset amendments without necessarily having to amend the profiles of our neighbours.
The reason why I haven't amended `LON_DL_CTR` is that LAC Sectors 16 & 17 are permanently bandboxed on VATSIM, and therefore aren't notified [as separate] in the LoA, so it is fine as an exception, but generally the sector station id is preferable to the position station id.
Thanks!