### PR TITLE
LSAS: init

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,7 @@ CONTRIBUTING.md @vacs-project/maintainers
 /dataset/LPPO/ @vacs-project/dataset-maintainers-lppo
 /dataset/LQ/ @vacs-project/dataset-maintainers-adr
 /dataset/LR/ @vacs-project/dataset-maintainers-lr
+/dataset/LS/ @vacs-project/dataset-maintainers-ls
 /dataset/LU/ @vacs-project/dataset-maintainers-lr
 /dataset/LW/ @vacs-project/dataset-maintainers-adr
 /dataset/LY/ @vacs-project/dataset-maintainers-adr

--- a/dataset/EDMM/positions.toml
+++ b/dataset/EDMM/positions.toml
@@ -472,10 +472,3 @@ prefixes = ["EDNY"]
 frequency = "120.080"
 facility_type = "TWR"
 profile_id = "EDMM-WEST-SOUTH"
-
-[[positions]]
-id = "LSZR_TWR"
-prefixes = ["LSZR"]
-frequency = "135.430"
-facility_type = "TWR"
-profile_id = "EDMM-WEST-SOUTH"

--- a/dataset/EDMM/profiles/EDMM-WEST-SOUTH.json
+++ b/dataset/EDMM/profiles/EDMM-WEST-SOUTH.json
@@ -26,7 +26,7 @@
           },
           {
             "label": ["ARFA"],
-            "station_id": "LSFA-ARFA"
+            "station_id": "LSFA_APP"
           },
           {
             "label": ["LSZH", "APP"]

--- a/dataset/EDMM/stations.toml
+++ b/dataset/EDMM/stations.toml
@@ -380,14 +380,6 @@ controlled_by = [
   "EDMM_RDG_CTR",
 ]
 
-[[stations]]
-id = "LSFA-ARFA"
-controlled_by = [
-  # LSZH_APP, LSAS_CTR sadly not on vacs
-  "EDMM_ZUG_CTR",
-  "EDMM_RDG_CTR",
-]
-
 # TWR/GND EDDM
 [[stations]]
 id = "EDDM-TWR-N"
@@ -531,9 +523,4 @@ parent_id = "EDMM-FRK"
 [[stations]]
 id = "EDNY-TWR"
 controlled_by = ["EDNY_TWR"]
-parent_id = "LSFA-ARFA"
-
-[[stations]]
-id = "LSZR-TWR"
-controlled_by = ["LSZR_TWR"]
-parent_id = "LSFA-ARFA"
+parent_id = "LSFA_APP"

--- a/dataset/LFEE/stations.toml
+++ b/dataset/LFEE/stations.toml
@@ -88,7 +88,15 @@ controlled_by = ["LFEE_YR_CTR"]
 
 [[stations]]
 id = "LFSB_APP"
-controlled_by = ["LFSB_APP", "LFSB_C_APP", "LFEE_CTR"]
+controlled_by = [
+  "LFSB_APP",
+  "LFSB_C_APP",
+  "LFEE_CTR",
+  "LSAZ_W_CTR",
+  "LSAZ_S_CTR",
+  "LSAZ_CTR",
+  "LSAS_CTR",
+]
 
 [[stations]]
 id = "LFSB_C_APP"

--- a/dataset/LI/positions.json
+++ b/dataset/LI/positions.json
@@ -1385,13 +1385,6 @@
       "frequency": "131.675",
       "facility_type": "DEL",
       "profile_id": "LIRR-NORTH"
-    },
-    {
-      "id": "LSZA_TWR",
-      "prefixes": ["LSZA"],
-      "frequency": "120.250",
-      "facility_type": "TWR",
-      "profile_id": "LIMM"
     }
   ]
 }

--- a/dataset/LI/profiles/LIMM.json
+++ b/dataset/LI/profiles/LIMM.json
@@ -111,7 +111,7 @@
             {
               "label": ["LUGANO", "TWR"],
               "size": 5,
-              "station_id": "LSZA-TWR"
+              "station_id": "LSZA_TWR"
             }
           ]
         },

--- a/dataset/LI/stations.json
+++ b/dataset/LI/stations.json
@@ -1194,16 +1194,6 @@
       "id": "LIRN-P-DEL",
       "controlled_by": ["LIRN_P_DEL"],
       "parent_id": "LIRN-GND"
-    },
-    {
-      "id": "LSZA-TWR",
-      "controlled_by": [
-        "LSZA_TWR",
-        "LIMM_ANW_APP",
-        "LIMM_ANE_APP",
-        "LIMM_EN2_CTR",
-        "LIMM_WS2_CTR"
-      ]
     }
   ]
 }

--- a/dataset/LO/profiles/LOVV.json
+++ b/dataset/LO/profiles/LOVV.json
@@ -161,7 +161,7 @@
               },
               {
                 "label": ["ZUR", "ARFA"],
-                "station_id": "LSFA-ARFA"
+                "station_id": "LSFA_APP"
               }
             ],
             "rows": 6

--- a/dataset/LS/positions.toml
+++ b/dataset/LS/positions.toml
@@ -1,0 +1,461 @@
+#####
+### Radar positions
+#####
+
+[[positions]]
+id = "LSAS_CTR"
+prefixes = ["LSAS"]
+frequency = "135.015"
+facility_type = "CTR"
+
+[[positions]]
+id = "LSAS_I_CTR"
+prefixes = ["LSAS"]
+frequency = "124.700"
+facility_type = "CTR"
+
+# LSAG
+
+[[positions]]
+id = "LSAG_CTR"
+prefixes = ["LSAG"]
+frequency = "134.850"
+facility_type = "CTR"
+
+[[positions]]
+id = "LSAG_E_CTR"
+prefixes = ["LSAG"]
+frequency = "128.905"
+facility_type = "CTR"
+
+[[positions]]
+id = "LSAG_S_CTR"
+prefixes = ["LSAG"]
+frequency = "124.225"
+facility_type = "CTR"
+
+[[positions]]
+id = "LSAG_N_CTR"
+prefixes = ["LSAG"]
+frequency = "134.030"
+facility_type = "CTR"
+
+# LSAZ
+
+[[positions]]
+id = "LSAZ_CTR"
+prefixes = ["LSAZ"]
+frequency = "133.050"
+facility_type = "CTR"
+
+[[positions]]
+id = "LSAZ_S_CTR"
+prefixes = ["LSAZ"]
+frequency = "128.050"
+facility_type = "CTR"
+
+[[positions]]
+id = "LSAZ_W_CTR"
+prefixes = ["LSAZ"]
+frequency = "135.680"
+facility_type = "CTR"
+
+[[positions]]
+id = "LSAZ_E_CTR"
+prefixes = ["LSAZ"]
+frequency = "133.905"
+facility_type = "CTR"
+
+[[positions]]
+id = "LSAZ_N_CTR"
+prefixes = ["LSAZ"]
+frequency = "136.155"
+facility_type = "CTR"
+
+#####
+### Majors
+#####
+
+# LSZH
+
+[[positions]]
+id = "LSZH_APP"
+prefixes = ["LSZH"]
+frequency = "135.230"
+facility_type = "APP"
+
+[[positions]]
+id = "LSZH_W_APP"
+prefixes = ["LSZH"]
+frequency = "130.560"
+facility_type = "APP"
+
+[[positions]]
+id = "LSZH_F_APP"
+prefixes = ["LSZH"]
+frequency = "125.330"
+facility_type = "APP"
+
+[[positions]]
+id = "LSZH_DEP"
+prefixes = ["LSZH"]
+frequency = "125.955"
+facility_type = "DEP"
+
+[[positions]]
+id = "LSZH_TWR"
+prefixes = ["LSZH"]
+frequency = "118.100"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZH_2_TWR"
+prefixes = ["LSZH"]
+frequency = "120.230"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZH_S_GND"
+prefixes = ["LSZH"]
+frequency = "121.755"
+facility_type = "GND"
+
+[[positions]]
+id = "LSZH_N_GND"
+prefixes = ["LSZH"]
+frequency = "121.855"
+facility_type = "GND"
+
+[[positions]]
+id = "LSZH_GND"
+prefixes = ["LSZH"]
+frequency = "121.905"
+facility_type = "GND"
+
+[[positions]]
+id = "LSZH_DEL"
+prefixes = ["LSZH"]
+frequency = "121.930"
+facility_type = "DEL"
+
+# LSGG
+
+[[positions]]
+id = "LSGG_APP"
+prefixes = ["LSGG"]
+frequency = "136.255"
+facility_type = "APP"
+
+[[positions]]
+id = "LSGG_F_APP"
+prefixes = ["LSGG"]
+frequency = "120.305"
+facility_type = "APP"
+
+[[positions]]
+id = "LSGG_DEP"
+prefixes = ["LSGG"]
+frequency = "119.530"
+facility_type = "DEP"
+
+[[positions]]
+id = "LSGG_TWR"
+prefixes = ["LSGG"]
+frequency = "118.705"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSGG_A_GND"
+prefixes = ["LSGG"]
+frequency = "121.855"
+facility_type = "GND"
+
+[[positions]]
+id = "LSGG_GND"
+prefixes = ["LSGG"]
+frequency = "121.680"
+facility_type = "GND"
+
+#####
+### Minors
+#####
+
+# ARFA & LSZR
+
+[[positions]]
+id = "LSFA_APP"
+prefixes = ["LSFA"]
+frequency = "119.925"
+facility_type = "APP"
+
+[[positions]]
+id = "LSZR_TWR"
+prefixes = ["LSZR"]
+frequency = "135.430"
+facility_type = "TWR"
+
+# LSGC
+
+[[positions]]
+id = "LSGC_TWR"
+prefixes = ["LSGC"]
+frequency = "118.130"
+facility_type = "TWR"
+
+# LSGS
+
+[[positions]]
+id = "LSGS_APP"
+prefixes = ["LSGS"]
+frequency = "126.830"
+facility_type = "APP"
+
+[[positions]]
+id = "LSGS_TWR"
+prefixes = ["LSGS"]
+frequency = "118.275"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSGS_GND"
+prefixes = ["LSGS"]
+frequency = "121.705"
+facility_type = "GND"
+
+# LSMA
+
+[[positions]]
+id = "LSMA_TWR"
+prefixes = ["LSMA"]
+frequency = "128.475"
+facility_type = "TWR"
+
+# LSMD
+
+[[positions]]
+id = "LSMD_APP"
+prefixes = ["LSMD"]
+frequency = "134.950"
+facility_type = "APP"
+
+[[positions]]
+id = "LSMD_TWR"
+prefixes = ["LSMD"]
+frequency = "118.975"
+facility_type = "TWR"
+
+# LSME
+
+[[positions]]
+id = "LSME_APP"
+prefixes = ["LSME"]
+frequency = "119.505"
+facility_type = "APP"
+
+[[positions]]
+id = "LSME_TWR"
+prefixes = ["LSME"]
+frequency = "118.005"
+facility_type = "TWR"
+
+# LSMM
+
+[[positions]]
+id = "LSMM_TWR"
+prefixes = ["LSMM"]
+frequency = "130.150"
+facility_type = "TWR"
+
+# LSMP
+
+[[positions]]
+id = "LSMP_APP"
+prefixes = ["LSMP"]
+frequency = "136.355"
+facility_type = "APP"
+
+[[positions]]
+id = "LSMP_TWR"
+prefixes = ["LSMP"]
+frequency = "128.680"
+facility_type = "TWR"
+
+# LSZA
+
+[[positions]]
+id = "LSZA_TWR"
+prefixes = ["LSZA"]
+frequency = "120.250"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZA_DEL"
+prefixes = ["LSZA"]
+frequency = "121.780"
+facility_type = "DEL"
+
+# LSZB & LSZG
+
+[[positions]]
+id = "LSZB_APP"
+prefixes = ["LSZB"]
+frequency = "127.325"
+facility_type = "APP"
+
+[[positions]]
+id = "LSZB_TWR"
+prefixes = ["LSZB"]
+frequency = "121.030"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZB_DEL"
+prefixes = ["LSZB"]
+frequency = "121.690"
+facility_type = "DEL"
+
+[[positions]]
+id = "LSZG_TWR"
+prefixes = ["LSZG"]
+frequency = "120.105"
+facility_type = "TWR"
+
+# LSZC
+
+[[positions]]
+id = "LSZC_TWR"
+prefixes = ["LSZC"]
+frequency = "119.625"
+facility_type = "TWR"
+
+# LSZL
+
+[[positions]]
+id = "LSZL_TWR"
+prefixes = ["LSZL"]
+frequency = "134.825"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZL_GND"
+prefixes = ["LSZL"]
+frequency = "121.700"
+facility_type = "GND"
+
+#####
+### Radio stations
+#####
+
+[[positions]]
+id = "LSGB_I_TWR"
+prefixes = ["LSGB"]
+frequency = "122.155"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSGE_I_TWR"
+prefixes = ["LSGE"]
+frequency = "120.630"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSGK_I_TWR"
+prefixes = ["LSGK"]
+frequency = "119.430"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSGL_I_TWR"
+prefixes = ["LSGL"]
+frequency = "123.205"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSGN_I_TWR"
+prefixes = ["LSGN"]
+frequency = "123.605"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSPM_I_TWR"
+prefixes = ["LSPM"]
+frequency = "118.530"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSPV_I_TWR"
+prefixes = ["LSPV"]
+frequency = "123.205"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSTA_I_TWR"
+prefixes = ["LSTA"]
+frequency = "129.880"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSTZ_I_TWR"
+prefixes = ["LSTZ"]
+frequency = "121.230"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZE_I_TWR"
+prefixes = ["LSZE"]
+frequency = "123.505"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZF_I_TWR"
+prefixes = ["LSZF"]
+frequency = "123.555"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZI_I_TWR"
+prefixes = ["LSZI"]
+frequency = "119.555"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZM_I_TWR"
+prefixes = ["LSZM"]
+frequency = "134.830"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZO_I_TWR"
+prefixes = ["LSZO"]
+frequency = "122.455"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZP_I_TWR"
+prefixes = ["LSZP"]
+frequency = "123.155"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZS_I_TWR"
+prefixes = ["LSZS"]
+frequency = "135.330"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZT_I_TWR"
+prefixes = ["LSZT"]
+frequency = "119.305"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZV_I_TWR"
+prefixes = ["LSZV"]
+frequency = "118.355"
+facility_type = "TWR"
+
+[[positions]]
+id = "LSZW_I_TWR"
+prefixes = ["LSZW"]
+frequency = "123.255"
+facility_type = "TWR"

--- a/dataset/LS/stations.toml
+++ b/dataset/LS/stations.toml
@@ -1,0 +1,390 @@
+#####
+### Radar stations
+#####
+
+[[stations]]
+id = "LSAS_CTR"
+controlled_by = ["LSAS_CTR"]
+
+[[stations]]
+id = "LSAS_I_CTR"
+controlled_by = ["LSAS_I_CTR"]
+parent_id = "LSAS_CTR"
+
+# LSAG
+
+[[stations]]
+id = "LSAG_CTR"
+controlled_by = ["LSAG_CTR"]
+parent_id = "LSAS_CTR"
+
+[[stations]]
+id = "LSAG_E_CTR"
+controlled_by = ["LSAG_E_CTR"]
+parent_id = "LSAG_CTR"
+
+[[stations]]
+id = "LSAG_S_CTR"
+controlled_by = ["LSAG_S_CTR"]
+parent_id = "LSAG_E_CTR"
+
+[[stations]]
+id = "LSAG_N_CTR"
+controlled_by = ["LSAG_N_CTR"]
+parent_id = "LSAG_E_CTR"
+
+# LSAZ
+
+[[stations]]
+id = "LSAZ_CTR"
+controlled_by = ["LSAZ_CTR"]
+parent_id = "LSAS_CTR"
+
+[[stations]]
+id = "LSAZ_S_CTR"
+controlled_by = ["LSAZ_S_CTR"]
+parent_id = "LSAZ_CTR"
+
+[[stations]]
+id = "LSAZ_W_CTR"
+controlled_by = ["LSAZ_W_CTR"]
+parent_id = "LSAZ_S_CTR"
+
+[[stations]]
+id = "LSAZ_E_CTR"
+controlled_by = ["LSAZ_E_CTR"]
+parent_id = "LSAZ_S_CTR"
+
+[[stations]]
+id = "LSAZ_N_CTR"
+controlled_by = ["LSAZ_N_CTR"]
+parent_id = "LSAZ_E_CTR"
+
+#####
+### Majors
+#####
+
+# LSZH
+
+[[stations]]
+id = "LSZH_APP"
+controlled_by = ["LSZH_APP"]
+parent_id = "LSAZ_E_CTR"
+
+[[stations]]
+id = "LSZH_W_APP"
+controlled_by = ["LSZH_W_APP"]
+parent_id = "LSZH_APP"
+
+[[stations]]
+id = "LSZH_F_APP"
+controlled_by = ["LSZH_F_APP"]
+parent_id = "LSZH_W_APP"
+
+[[stations]]
+id = "LSZH_DEP"
+controlled_by = ["LSZH_DEP"]
+parent_id = "LSZH_W_APP"
+
+[[stations]]
+id = "LSZH_TWR"
+controlled_by = ["LSZH_TWR"]
+parent_id = "LSZH_DEP"
+
+[[stations]]
+id = "LSZH_2_TWR"
+controlled_by = ["LSZH_2_TWR"]
+parent_id = "LSZH_TWR"
+
+[[stations]]
+id = "LSZH_S_GND"
+controlled_by = ["LSZH_S_GND"]
+parent_id = "LSZH_TWR"
+
+[[stations]]
+id = "LSZH_N_GND"
+controlled_by = ["LSZH_N_GND"]
+parent_id = "LSZH_S_GND"
+
+[[stations]]
+id = "LSZH_GND"
+controlled_by = ["LSZH_GND"]
+parent_id = "LSZH_TWR"
+
+[[stations]]
+id = "LSZH_DEL"
+controlled_by = ["LSZH_DEL"]
+parent_id = "LSZH_N_GND"
+
+# LSGG
+
+[[stations]]
+id = "LSGG_APP"
+controlled_by = ["LSGG_APP"]
+parent_id = "LSAG_E_CTR"
+
+[[stations]]
+id = "LSGG_F_APP"
+controlled_by = ["LSGG_F_APP"]
+parent_id = "LSGG_APP"
+
+[[stations]]
+id = "LSGG_DEP"
+controlled_by = ["LSGG_DEP"]
+parent_id = "LSGG_APP"
+
+[[stations]]
+id = "LSGG_TWR"
+controlled_by = ["LSGG_TWR"]
+parent_id = "LSGG_DEP"
+
+[[stations]]
+id = "LSGG_A_GND"
+controlled_by = ["LSGG_A_GND"]
+parent_id = "LSGG_TWR"
+
+[[stations]]
+id = "LSGG_GND"
+controlled_by = ["LSGG_GND"]
+parent_id = "LSGG_A_GND"
+
+#####
+### Minors
+#####
+
+# ARFA & LSZR
+
+[[stations]]
+id = "LSFA_APP"
+controlled_by = [
+  "LSFA_APP",
+  "LSZH_APP",
+  "LSAZ_E_CTR",
+  "LSAZ_S_CTR",
+  "LSAZ_CTR",
+  "LSAS_CTR",
+  "EDMM_ZUG_CTR",
+  "EDMM_TRU_CTR",
+  "EDMM_RDG_CTR",
+]
+
+[[stations]]
+id = "LSZR_TWR"
+controlled_by = ["LSZR_TWR"]
+parent_id = "LSFA_APP"
+
+# LSGC
+
+[[stations]]
+id = "LSGC_TWR"
+controlled_by = ["LSGC_TWR"]
+parent_id = "LSAG_E_CTR"
+
+# LSGS
+
+[[stations]]
+id = "LSGS_APP"
+controlled_by = ["LSGS_APP"]
+parent_id = "LSAG_E_CTR"
+
+[[stations]]
+id = "LSGS_TWR"
+controlled_by = ["LSGS_TWR"]
+parent_id = "LSGS_APP"
+
+[[stations]]
+id = "LSGS_GND"
+controlled_by = ["LSGS_GND"]
+parent_id = "LSGS_TWR"
+
+# LSMA
+
+[[stations]]
+id = "LSMA_TWR"
+controlled_by = ["LSMA_TWR"]
+parent_id = "LSAZ_S_CTR"
+
+# LSMD
+
+[[stations]]
+id = "LSMD_APP"
+controlled_by = ["LSMD_APP"]
+parent_id = "LSZH_APP"
+
+[[stations]]
+id = "LSMD_TWR"
+controlled_by = ["LSMD_APP"]
+parent_id = "LSMD_APP"
+
+# LSME
+
+[[stations]]
+id = "LSME_APP"
+controlled_by = ["LSME_APP"]
+parent_id = "LSAZ_S_CTR"
+
+[[stations]]
+id = "LSME_TWR"
+controlled_by = ["LSME_TWR"]
+parent_id = "LSME_APP"
+
+# LSMM
+
+[[stations]]
+id = "LSMM_TWR"
+controlled_by = ["LSMM_TWR"]
+parent_id = "LSAZ_W_CTR"
+
+# LSMP
+
+[[stations]]
+id = "LSMP_APP"
+controlled_by = ["LSMP_APP"]
+parent_id = "LSAG_E_CTR"
+
+[[stations]]
+id = "LSMP_TWR"
+controlled_by = ["LSMP_TWR"]
+parent_id = "LSMP_APP"
+
+# LSZA
+
+[[stations]]
+id = "LSZA_TWR"
+controlled_by = [
+  "LSZA_TWR",
+  "LIMM_ANW_APP",
+  "LIMM_ANE_APP",
+  "LIMM_EN2_CTR",
+  "LIMM_WS2_CTR",
+  "LSAZ_S_CTR",
+  "LSAZ_CTR",
+  "LSAS_CTR",
+]
+
+[[stations]]
+id = "LSZA_DEL"
+controlled_by = ["LSZA_DEL"]
+parent_id = "LSZA_TWR"
+
+# LSZB & LSZG
+
+[[stations]]
+id = "LSZB_APP"
+controlled_by = ["LSZB_APP"]
+parent_id = "LSAZ_W_CTR"
+
+[[stations]]
+id = "LSZB_TWR"
+controlled_by = ["LSZB_TWR"]
+parent_id = "LSZB_APP"
+
+[[stations]]
+id = "LSZB_DEL"
+controlled_by = ["LSZB_DEL"]
+parent_id = "LSZB_TWR"
+
+[[stations]]
+id = "LSZG_TWR"
+controlled_by = ["LSZG_TWR"]
+parent_id = "LSZB_APP"
+
+# LSZC
+
+[[stations]]
+id = "LSZC_TWR"
+controlled_by = ["LSZC_TWR"]
+parent_id = "LSAZ_S_CTR"
+
+# LSZL
+
+[[stations]]
+id = "LSZL_TWR"
+controlled_by = ["LSZL_TWR"]
+parent_id = "LSAZ_S_CTR"
+
+[[stations]]
+id = "LSZL_GND"
+controlled_by = ["LSZL_GND"]
+parent_id = "LSZL_TWR"
+
+#####
+### Radio stations
+#####
+
+[[stations]]
+id = "LSGB_I_TWR"
+controlled_by = ["LSGB_I_TWR"]
+
+[[stations]]
+id = "LSGE_I_TWR"
+controlled_by = ["LSGE_I_TWR"]
+
+[[stations]]
+id = "LSGK_I_TWR"
+controlled_by = ["LSGK_I_TWR"]
+
+[[stations]]
+id = "LSGL_I_TWR"
+controlled_by = ["LSGL_I_TWR"]
+
+[[stations]]
+id = "LSGN_I_TWR"
+controlled_by = ["LSGN_I_TWR"]
+
+[[stations]]
+id = "LSPM_I_TWR"
+controlled_by = ["LSPM_I_TWR"]
+
+[[stations]]
+id = "LSPV_I_TWR"
+controlled_by = ["LSPV_I_TWR"]
+
+[[stations]]
+id = "LSTA_I_TWR"
+controlled_by = ["LSTA_I_TWR"]
+
+[[stations]]
+id = "LSTZ_I_TWR"
+controlled_by = ["LSTZ_I_TWR"]
+
+[[stations]]
+id = "LSZE_I_TWR"
+controlled_by = ["LSZE_I_TWR"]
+
+[[stations]]
+id = "LSZF_I_TWR"
+controlled_by = ["LSZF_I_TWR"]
+
+[[stations]]
+id = "LSZI_I_TWR"
+controlled_by = ["LSZI_I_TWR"]
+
+[[stations]]
+id = "LSZM_I_TWR"
+controlled_by = ["LSZM_I_TWR"]
+
+[[stations]]
+id = "LSZO_I_TWR"
+controlled_by = ["LSZO_I_TWR"]
+
+[[stations]]
+id = "LSZP_I_TWR"
+controlled_by = ["LSZP_I_TWR"]
+
+[[stations]]
+id = "LSZS_I_TWR"
+controlled_by = ["LSZS_I_TWR"]
+parent_id = "LSAZ_S_CTR"
+
+[[stations]]
+id = "LSZT_I_TWR"
+controlled_by = ["LSZT_I_TWR"]
+
+[[stations]]
+id = "LSZV_I_TWR"
+controlled_by = ["LSZV_I_TWR"]
+
+[[stations]]
+id = "LSZW_I_TWR"
+controlled_by = ["LSZW_I_TWR"]


### PR DESCRIPTION
### Description

Hello, I'm Marc, member of the Operation Department for vACC Switzerland. This PR adds a dataset for the LSAS FIR. This adds data for all our stations and positions, however some stations have missing data:

- Almost all the `LSxx_I_TWR` are missing their parent_id.
- We're also not exactly sure whether we need to setup `default_call_sources` or not.

For maintainers, we'd like to add the following persons:

- @wuestr, Roman Wuest, Operation Department Lead.
- @rissson, myself.

This PR also modifies some of our neighbours' datasets, namely `EDMM`, `LFEE`, `LI` and `LO`, as some of our positions are shared between our respective vACCs. GitHub should notify the maintainers of those datasets, and I hope they'll be able to take a quick look and verify that the changes made to those are correct. I'll include a brief summary below to hopefully save a bit of their time.

~First opening as draft to make sure the CI runs fine, without notifying a whole bunch of people.~ I stopped being lazy and booted up my linux laptop to run those.

#### `EDDM` changes

- Moved `LSZR_TWR` position to the `LS` dataset (profile_id has been removed, let me know if that's an issue).
- Moved `LSFA-ARFA` station to the `LS` dataset, and renamed to `LSFA_APP`.
- Moved `LSZR-TWR` station to the `LS` dataset, and renamed to `LSZR_TWR`.

#### `LFEE` changes

- Added Zurich Radar stations to the `controlled_by` list of the `LFSB_APP` station.

#### `LI` changes

- Moved `LSZA_TWR` position to the `LS` dataset (profile_id has been removed, let me know if that's an issue).
- Moved `LSZA-TWR` station to the `LS` dataset, and renamed to `LSZA_TWR`.

#### `LO` changes

- Renamed `LFSA-ARFA` to `LFSA_APP` in the `LOVV` profile, to match the station name in the `LS` dataset.

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [x] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
