### PR TITLE
Saudi FIR Revamp

### DIFF
--- a/dataset/OE/positions.json
+++ b/dataset/OE/positions.json
@@ -1,51 +1,10 @@
 {
   "positions": [
     {
-      "id": "OERD_CTR",
-      "prefixes": ["OERD"],
-      "frequency": "128.500",
-      "profile_id": "OERD",
-      "facility_type": "CTR",
-      "default_call_sources": ["OERD_CTR"]
-    },
-    {
-      "id": "OERD_E_CTR",
-      "prefixes": ["OERD"],
-      "frequency": "132.950",
-      "facility_type": "CTR",
-      "profile_id": "OERD",
-      "default_call_sources": ["OERD_E_CTR"]
-    },
-    {
-      "id": "OERD_N_CTR",
-      "prefixes": ["OERD"],
-      "frequency": "134.800",
-      "facility_type": "CTR",
-      "profile_id": "OERD",
-      "default_call_sources": ["OERD_N_CTR"]
-    },
-    {
-      "id": "OERD_NE_CTR",
-      "prefixes": ["OERD"],
-      "frequency": "132.250",
-      "facility_type": "CTR",
-      "profile_id": "OERD",
-      "default_call_sources": ["OERD_NE_CTR"]
-    },
-    {
-      "id": "OERD_1_CTR",
-      "prefixes": ["OERD"],
-      "frequency": "128.550",
-      "facility_type": "CTR",
-      "profile_id": "OERD",
-      "default_call_sources": ["OERD_1_CTR"]
-    },
-    {
       "id": "OEJD_1_CTR",
       "prefixes": ["OEJD"],
       "frequency": "126.500",
       "facility_type": "CTR",
-      "profile_id": "OEJD",
       "default_call_sources": ["OEJD_1_CTR"]
     },
     {
@@ -53,73 +12,118 @@
       "prefixes": ["OEJD"],
       "frequency": "133.900",
       "facility_type": "CTR",
-      "profile_id": "OEJD-2",
       "default_call_sources": ["OEJD_2_CTR"]
-    },
-    {
-      "id": "OEJD_N_CTR",
-      "prefixes": ["OEJD"],
-      "frequency": "128.750",
-      "facility_type": "CTR",
-      "profile_id": "OEJD",
-      "default_call_sources": ["OEJD_N_CTR"]
-    },
-    {
-      "id": "OEJD_S_CTR",
-      "prefixes": ["OEJD"],
-      "frequency": "132.100",
-      "facility_type": "CTR",
-      "profile_id": "OEJD",
-      "default_call_sources": ["OEJD_S_CTR"]
     },
     {
       "id": "OEJD_W_CTR",
       "prefixes": ["OEJD"],
       "frequency": "133.700",
       "facility_type": "CTR",
-      "profile_id": "OEJD",
       "default_call_sources": ["OEJD_W_CTR"]
-    },
-    {
-      "id": "OEJD_NE_CTR",
-      "prefixes": ["OEJD"],
-      "frequency": "127.650",
-      "facility_type": "CTR",
-      "profile_id": "OEJD",
-      "default_call_sources": ["OEJD_NE_CTR"]
-    },
-    {
-      "id": "OEJD_SE_CTR",
-      "prefixes": ["OEJD"],
-      "frequency": "134.500",
-      "facility_type": "CTR",
-      "profile_id": "OEJD-SE",
-      "default_call_sources": ["OEJD_SE_CTR"]
     },
     {
       "id": "OEJD_C_CTR",
       "prefixes": ["OEJD"],
       "frequency": "126.550",
       "facility_type": "CTR",
-      "profile_id": "OEJD",
       "default_call_sources": ["OEJD_C_CTR"]
     },
-
+    {
+      "id": "OEJD_S_CTR",
+      "prefixes": ["OEJD"],
+      "frequency": "132.100",
+      "facility_type": "CTR",
+      "default_call_sources": ["OEJD_S_CTR"]
+    },
+    {
+      "id": "OEJD_SE_CTR",
+      "prefixes": ["OEJD"],
+      "frequency": "134.500",
+      "facility_type": "CTR",
+      "default_call_sources": ["OEJD_SE_CTR"]
+    },
+    {
+      "id": "OEJD_3_CTR",
+      "prefixes": ["OEJD"],
+      "frequency": "133.300",
+      "facility_type": "CTR",
+      "default_call_sources": ["OEJD_3_CTR"]
+    },
+    {
+      "id": "OEJD_N_CTR",
+      "prefixes": ["OEJD"],
+      "frequency": "128.750",
+      "facility_type": "CTR",
+      "default_call_sources": ["OEJD_N_CTR"]
+    },
+    {
+      "id": "OEJD_E_CTR",
+      "prefixes": ["OEJD"],
+      "frequency": "134.400",
+      "facility_type": "CTR",
+      "default_call_sources": ["OEJD_E_CTR"]
+    },
+    {
+      "id": "OEJD_NE_CTR",
+      "prefixes": ["OEJD"],
+      "frequency": "127.650",
+      "facility_type": "CTR",
+      "default_call_sources": ["OEJD_NE_CTR"]
+    },
+    {
+      "id": "OERD_1_CTR",
+      "prefixes": ["OERD"],
+      "frequency": "128.550",
+      "facility_type": "CTR",
+      "default_call_sources": ["OERD_1_CTR"]
+    },
+    {
+      "id": "OERD_N_CTR",
+      "prefixes": ["OERD"],
+      "frequency": "134.800",
+      "facility_type": "CTR",
+      "default_call_sources": ["OERD_N_CTR"]
+    },
+    {
+      "id": "OERD_E_CTR",
+      "prefixes": ["OERD"],
+      "frequency": "132.950",
+      "facility_type": "CTR",
+      "default_call_sources": ["OERD_E_CTR"]
+    },
+    {
+      "id": "OERD_NE_CTR",
+      "prefixes": ["OERD"],
+      "frequency": "132.250",
+      "facility_type": "CTR",
+      "default_call_sources": ["OERD_NE_CTR"]
+    },
     {
       "id": "OEJN_W_CTR",
       "prefixes": ["OEJN"],
-      "frequency": "132.300",
+      "frequency": "125.450",
       "facility_type": "CTR",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_W_CTR"]
     },
-
+    {
+      "id": "OEJN_WU_CTR",
+      "prefixes": ["OEJN"],
+      "frequency": "124.825",
+      "facility_type": "CTR",
+      "default_call_sources": ["OEJN_WU_CTR"]
+    },
+    {
+      "id": "OEJN_E_CTR",
+      "prefixes": ["OEJN"],
+      "frequency": "119.100",
+      "facility_type": "CTR",
+      "default_call_sources": ["OEJN_E_CTR"]
+    },
     {
       "id": "OEJN_APP",
       "prefixes": ["OEJN"],
       "frequency": "124.000",
       "facility_type": "APP",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_APP"]
     },
     {
@@ -127,7 +131,6 @@
       "prefixes": ["OEJN"],
       "frequency": "123.800",
       "facility_type": "APP",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_FE_APP"]
     },
     {
@@ -135,7 +138,6 @@
       "prefixes": ["OEJN"],
       "frequency": "124.675",
       "facility_type": "APP",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_FW_APP"]
     },
     {
@@ -143,16 +145,13 @@
       "prefixes": ["OEJN"],
       "frequency": "125.850",
       "facility_type": "APP",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_FMC_APP"]
     },
-
     {
       "id": "OEJN_W_TWR",
       "prefixes": ["OEJN"],
       "frequency": "118.200",
       "facility_type": "TWR",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_W_TWR"]
     },
     {
@@ -160,7 +159,6 @@
       "prefixes": ["OEJN"],
       "frequency": "118.500",
       "facility_type": "TWR",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_E_TWR"]
     },
     {
@@ -168,32 +166,27 @@
       "prefixes": ["OEJN"],
       "frequency": "118.300",
       "facility_type": "TWR",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_C_TWR"]
-    },
-
-    {
-      "id": "OEJN_E_GND",
-      "prefixes": ["OEJN"],
-      "frequency": "121.700",
-      "facility_type": "GND",
-      "profile_id": "OEJN",
-      "default_call_sources": ["OEJN_E_GND"]
     },
     {
       "id": "OEJN_W_GND",
       "prefixes": ["OEJN"],
       "frequency": "121.600",
       "facility_type": "GND",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_W_GND"]
+    },
+    {
+      "id": "OEJN_E_GND",
+      "prefixes": ["OEJN"],
+      "frequency": "121.700",
+      "facility_type": "GND",
+      "default_call_sources": ["OEJN_E_GND"]
     },
     {
       "id": "OEJN_C_GND",
       "prefixes": ["OEJN"],
       "frequency": "121.900",
       "facility_type": "GND",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_C_GND"]
     },
     {
@@ -201,40 +194,48 @@
       "prefixes": ["OEJN"],
       "frequency": "121.750",
       "facility_type": "RMP",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_E_RMP"]
+    },
+    {
+      "id": "OEJN_N_RMP",
+      "prefixes": ["OEJN"],
+      "frequency": "121.975",
+      "facility_type": "RMP",
+      "default_call_sources": ["OEJN_N_RMP"]
     },
     {
       "id": "OEJN_DEL",
       "prefixes": ["OEJN"],
       "frequency": "121.800",
       "facility_type": "DEL",
-      "profile_id": "OEJN",
       "default_call_sources": ["OEJN_DEL"]
     },
-
     {
-      "id": "OERK_1_CTR",
-      "prefixes": ["OERK"],
-      "frequency": "121.550",
-      "facility_type": "CTR",
-      "profile_id": "OERK",
-      "default_call_sources": ["OERK_1_CTR"]
+      "id": "OEJN_P_DEL",
+      "prefixes": ["OEJN"],
+      "frequency": "118.350",
+      "facility_type": "DEL",
+      "default_call_sources": ["OEJN_P_DEL"]
     },
     {
       "id": "OERK_N_CTR",
       "prefixes": ["OERK"],
       "frequency": "126.000",
       "facility_type": "CTR",
-      "profile_id": "OERK",
       "default_call_sources": ["OERK_N_CTR"]
+    },
+    {
+      "id": "OERK_S_CTR",
+      "prefixes": ["OERK"],
+      "frequency": "124.100",
+      "facility_type": "CTR",
+      "default_call_sources": ["OERK_S_CTR"]
     },
     {
       "id": "OERK_APP",
       "prefixes": ["OERK"],
       "frequency": "120.000",
       "facility_type": "APP",
-      "profile_id": "OERK",
       "default_call_sources": ["OERK_APP"]
     },
     {
@@ -242,15 +243,27 @@
       "prefixes": ["OERK"],
       "frequency": "120.600",
       "facility_type": "APP",
-      "profile_id": "OERK",
       "default_call_sources": ["OERK_F_APP"]
+    },
+    {
+      "id": "OERK_FE_APP",
+      "prefixes": ["OERK"],
+      "frequency": "119.750",
+      "facility_type": "APP",
+      "default_call_sources": ["OERK_FE_APP"]
+    },
+    {
+      "id": "OERK_FW_APP",
+      "prefixes": ["OERK"],
+      "frequency": "120.450",
+      "facility_type": "APP",
+      "default_call_sources": ["OERK_FW_APP"]
     },
     {
       "id": "OERK_E_TWR",
       "prefixes": ["OERK"],
       "frequency": "118.600",
       "facility_type": "TWR",
-      "profile_id": "OERK",
       "default_call_sources": ["OERK_E_TWR"]
     },
     {
@@ -258,16 +271,13 @@
       "prefixes": ["OERK"],
       "frequency": "118.800",
       "facility_type": "TWR",
-      "profile_id": "OERK",
       "default_call_sources": ["OERK_W_TWR"]
     },
-
     {
       "id": "OERK_N_GND",
       "prefixes": ["OERK"],
       "frequency": "121.600",
       "facility_type": "GND",
-      "profile_id": "OERK",
       "default_call_sources": ["OERK_N_GND"]
     },
     {
@@ -275,7 +285,6 @@
       "prefixes": ["OERK"],
       "frequency": "121.800",
       "facility_type": "GND",
-      "profile_id": "OERK",
       "default_call_sources": ["OERK_S_GND"]
     },
     {
@@ -283,181 +292,27 @@
       "prefixes": ["OERK"],
       "frequency": "121.700",
       "facility_type": "DEL",
-      "profile_id": "OERK",
       "default_call_sources": ["OERK_DEL"]
     },
-
     {
-      "id": "OEGS_APP",
-      "prefixes": ["OEGS"],
-      "frequency": "119.150",
-      "facility_type": "APP",
-      "profile_id": "OEGS",
-      "default_call_sources": ["OEGS_APP"]
-    },
-    {
-      "id": "OEGS_TWR",
-      "prefixes": ["OEGS"],
-      "frequency": "118.000",
-      "facility_type": "TWR",
-      "profile_id": "OEGS",
-      "default_call_sources": ["OEGS_TWR"]
-    },
-    {
-      "id": "OEGS_GND",
-      "prefixes": ["OEGS"],
-      "frequency": "121.900",
-      "facility_type": "GND",
-      "profile_id": "OEGS",
-      "default_call_sources": ["OEGS_GND"]
-    },
-
-    {
-      "id": "OETF_GND",
-      "prefixes": ["OETF"],
-      "frequency": "121.900",
-      "facility_type": "GND",
-      "profile_id": "OETF",
-      "default_call_sources": ["OETF_GND"]
-    },
-    {
-      "id": "OETF_TWR",
-      "prefixes": ["OETF"],
-      "frequency": "118.700",
-      "facility_type": "TWR",
-      "profile_id": "OETF",
-      "default_call_sources": ["OETF_TWR"]
-    },
-    {
-      "id": "OETF_APP",
-      "prefixes": ["OETF"],
-      "frequency": "119.700",
-      "facility_type": "APP",
-      "profile_id": "OETF",
-      "default_call_sources": ["OETF_APP"]
-    },
-
-    {
-      "id": "OENG_GND",
-      "prefixes": ["OENG"],
-      "frequency": "121.900",
-      "facility_type": "GND",
-      "profile_id": "OENG",
-      "default_call_sources": ["OENG_GND"]
-    },
-    {
-      "id": "OENG_TWR",
-      "prefixes": ["OENG"],
-      "frequency": "118.500",
-      "facility_type": "TWR",
-      "profile_id": "OENG",
-      "default_call_sources": ["OENG_TWR"]
-    },
-
-    {
-      "id": "OEMA_GND",
-      "prefixes": ["OEMA"],
-      "frequency": "121.900",
-      "facility_type": "GND",
-      "profile_id": "OEMA",
-      "default_call_sources": ["OEMA_GND"]
-    },
-    {
-      "id": "OEMA_TWR",
-      "prefixes": ["OEMA"],
-      "frequency": "118.300",
-      "facility_type": "TWR",
-      "profile_id": "OEMA",
-      "default_call_sources": ["OEMA_TWR"]
-    },
-    {
-      "id": "OEMA_APP",
-      "prefixes": ["OEMA"],
-      "frequency": "127.700",
-      "facility_type": "APP",
-      "profile_id": "OEMA",
-      "default_call_sources": ["OEMA_APP"]
-    },
-
-    {
-      "id": "OETB_DEL",
-      "prefixes": ["OETB"],
-      "frequency": "128.750",
-      "facility_type": "DEL",
-      "profile_id": "OETB",
-      "default_call_sources": ["OETB_DEL"]
-    },
-    {
-      "id": "OETB_GND",
-      "prefixes": ["OETB"],
-      "frequency": "128.750",
-      "facility_type": "GND",
-      "profile_id": "OETB",
-      "default_call_sources": ["OETB_DEL"]
-    },
-    {
-      "id": "OETB_TWR",
-      "prefixes": ["OETB"],
-      "frequency": "125.900",
-      "facility_type": "TWR",
-      "profile_id": "OETB",
-      "default_call_sources": ["OETB_TWR"]
-    },
-    {
-      "id": "OETB_APP",
-      "prefixes": ["OETB"],
-      "frequency": "119.700",
-      "facility_type": "APP",
-      "profile_id": "OETB",
-      "default_call_sources": ["OETB_APP"]
-    },
-
-    {
-      "id": "OEHL_GND",
-      "prefixes": ["OEHL"],
-      "frequency": "121.900",
-      "facility_type": "GND",
-      "profile_id": "OEHL",
-      "default_call_sources": ["OEHL_GND"]
-    },
-    {
-      "id": "OEHL_TWR",
-      "prefixes": ["OEHL"],
-      "frequency": "118.700",
-      "facility_type": "TWR",
-      "profile_id": "OEHL",
-      "default_call_sources": ["OEHL_TWR"]
-    },
-    {
-      "id": "OEHL_APP",
-      "prefixes": ["OEHL"],
-      "frequency": "123.200",
-      "facility_type": "APP",
-      "profile_id": "OEHL",
-      "default_call_sources": ["OEHL_APP"]
-    },
-    {
-      "id": "OEDF_1_GND",
+      "id": "OEDF_APP",
       "prefixes": ["OEDF"],
-      "frequency": "121.750",
-      "facility_type": "GND",
-      "profile_id": "OEDF",
-      "default_call_sources": ["OEDF_1_GND"]
+      "frequency": "126.300",
+      "facility_type": "APP",
+      "default_call_sources": ["OEDF_APP"]
     },
     {
-      "id": "OEDF_2_GND",
+      "id": "OEDF_L_APP",
       "prefixes": ["OEDF"],
-      "frequency": "121.850",
-      "facility_type": "GND",
-      "profile_id": "OEDF",
-      "default_call_sources": ["OEDF_2_GND"]
+      "frequency": "126.100",
+      "facility_type": "APP",
+      "default_call_sources": ["OEDF_L_APP"]
     },
     {
       "id": "OEDF_1_TWR",
       "prefixes": ["OEDF"],
       "frequency": "124.350",
       "facility_type": "TWR",
-      "profile_id": "OEDF",
       "default_call_sources": ["OEDF_1_TWR"]
     },
     {
@@ -465,24 +320,224 @@
       "prefixes": ["OEDF"],
       "frequency": "118.200",
       "facility_type": "TWR",
-      "profile_id": "OEDF",
       "default_call_sources": ["OEDF_2_TWR"]
     },
     {
-      "id": "OEDF_L_APP",
+      "id": "OEDF_1_GND",
       "prefixes": ["OEDF"],
-      "frequency": "126.100",
-      "facility_type": "APP",
-      "profile_id": "OEDF",
-      "default_call_sources": ["OEDF_L_APP"]
+      "frequency": "121.750",
+      "facility_type": "GND",
+      "default_call_sources": ["OEDF_1_GND"]
     },
     {
-      "id": "OEDF_APP",
+      "id": "OEDF_2_GND",
       "prefixes": ["OEDF"],
-      "frequency": "126.300",
+      "frequency": "121.850",
+      "facility_type": "GND",
+      "default_call_sources": ["OEDF_2_GND"]
+    },
+    {
+      "id": "OEMA_APP",
+      "prefixes": ["OEMA"],
+      "frequency": "125.100",
       "facility_type": "APP",
-      "profile_id": "OEDF",
-      "default_call_sources": ["OEDF_APP"]
+      "default_call_sources": ["OEMA_APP"]
+    },
+    {
+      "id": "OEMA_TWR",
+      "prefixes": ["OEMA"],
+      "frequency": "118.300",
+      "facility_type": "TWR",
+      "default_call_sources": ["OEMA_TWR"]
+    },
+    {
+      "id": "OEMA_GND",
+      "prefixes": ["OEMA"],
+      "frequency": "121.900",
+      "facility_type": "GND",
+      "default_call_sources": ["OEMA_GND"]
+    },
+    {
+      "id": "OEAB_APP",
+      "prefixes": ["OEAB"],
+      "frequency": "124.500",
+      "facility_type": "APP",
+      "default_call_sources": ["OEAB_APP"]
+    },
+    {
+      "id": "OEAB_L_APP",
+      "prefixes": ["OEAB"],
+      "frequency": "130.500",
+      "facility_type": "APP",
+      "default_call_sources": ["OEAB_L_APP"]
+    },
+    {
+      "id": "OEAB_TWR",
+      "prefixes": ["OEAB"],
+      "frequency": "118.100",
+      "facility_type": "TWR",
+      "default_call_sources": ["OEAB_TWR"]
+    },
+    {
+      "id": "OEAB_GND",
+      "prefixes": ["OEAB"],
+      "frequency": "121.700",
+      "facility_type": "GND",
+      "default_call_sources": ["OEAB_GND"]
+    },
+    {
+      "id": "OEAH_I_TWR",
+      "prefixes": ["OEAH"],
+      "frequency": "118.200",
+      "facility_type": "TWR",
+      "default_call_sources": ["OEAH_I_TWR"]
+    },
+    {
+      "id": "OEAH_I_GND",
+      "prefixes": ["OEAH"],
+      "frequency": "121.900",
+      "facility_type": "GND",
+      "default_call_sources": ["OEAH_I_GND"]
+    },
+    {
+      "id": "OEGN_APP",
+      "prefixes": ["OEGN"],
+      "frequency": "124.900",
+      "facility_type": "APP",
+      "default_call_sources": ["OEGN_APP"]
+    },
+    {
+      "id": "OEGN_TWR",
+      "prefixes": ["OEGN"],
+      "frequency": "118.000",
+      "facility_type": "TWR",
+      "default_call_sources": ["OEGN_TWR"]
+    },
+    {
+      "id": "OEGN_GND",
+      "prefixes": ["OEGN"],
+      "frequency": "121.900",
+      "facility_type": "GND",
+      "default_call_sources": ["OEGN_GND"]
+    },
+    {
+      "id": "OEGS_APP",
+      "prefixes": ["OEGS"],
+      "frequency": "119.150",
+      "facility_type": "APP",
+      "default_call_sources": ["OEGS_APP"]
+    },
+    {
+      "id": "OEGS_TWR",
+      "prefixes": ["OEGS"],
+      "frequency": "118.000",
+      "facility_type": "TWR",
+      "default_call_sources": ["OEGS_TWR"]
+    },
+    {
+      "id": "OEGS_GND",
+      "prefixes": ["OEGS"],
+      "frequency": "121.900",
+      "facility_type": "GND",
+      "default_call_sources": ["OEGS_GND"]
+    },
+    {
+      "id": "OEHL_APP",
+      "prefixes": ["OEHL"],
+      "frequency": "123.200",
+      "facility_type": "APP",
+      "default_call_sources": ["OEHL_APP"]
+    },
+    {
+      "id": "OEHL_TWR",
+      "prefixes": ["OEHL"],
+      "frequency": "118.700",
+      "facility_type": "TWR",
+      "default_call_sources": ["OEHL_TWR"]
+    },
+    {
+      "id": "OEHL_GND",
+      "prefixes": ["OEHL"],
+      "frequency": "121.900",
+      "facility_type": "GND",
+      "default_call_sources": ["OEHL_GND"]
+    },
+    {
+      "id": "OENG_TWR",
+      "prefixes": ["OENG"],
+      "frequency": "118.500",
+      "facility_type": "TWR",
+      "default_call_sources": ["OENG_TWR"]
+    },
+    {
+      "id": "OENG_GND",
+      "prefixes": ["OENG"],
+      "frequency": "121.900",
+      "facility_type": "GND",
+      "default_call_sources": ["OENG_GND"]
+    },
+    {
+      "id": "OETB_APP",
+      "prefixes": ["OETB"],
+      "frequency": "119.700",
+      "facility_type": "APP",
+      "default_call_sources": ["OETB_APP"]
+    },
+    {
+      "id": "OETB_TWR",
+      "prefixes": ["OETB"],
+      "frequency": "125.900",
+      "facility_type": "TWR",
+      "default_call_sources": ["OETB_TWR"]
+    },
+    {
+      "id": "OETB_GND",
+      "prefixes": ["OETB"],
+      "frequency": "126.300",
+      "facility_type": "GND",
+      "default_call_sources": ["OETB_GND"]
+    },
+    {
+      "id": "OETB_DEL",
+      "prefixes": ["OETB"],
+      "frequency": "128.750",
+      "facility_type": "DEL",
+      "default_call_sources": ["OETB_DEL"]
+    },
+    {
+      "id": "OETF_APP",
+      "prefixes": ["OETF"],
+      "frequency": "119.700",
+      "facility_type": "APP",
+      "default_call_sources": ["OETF_APP"]
+    },
+    {
+      "id": "OETF_TWR",
+      "prefixes": ["OETF"],
+      "frequency": "118.700",
+      "facility_type": "TWR",
+      "default_call_sources": ["OETF_TWR"]
+    },
+    {
+      "id": "OETF_GND",
+      "prefixes": ["OETF"],
+      "frequency": "121.900",
+      "facility_type": "GND",
+      "default_call_sources": ["OETF_GND"]
+    },
+    {
+      "id": "OEYN_TWR",
+      "prefixes": ["OEYN"],
+      "frequency": "118.100",
+      "facility_type": "TWR",
+      "default_call_sources": ["OEYN_TWR"]
+    },
+    {
+      "id": "OEYN_GND",
+      "prefixes": ["OEYN"],
+      "frequency": "121.900",
+      "facility_type": "GND",
+      "default_call_sources": ["OEYN_GND"]
     }
   ]
 }

--- a/dataset/OE/positions.json
+++ b/dataset/OE/positions.json
@@ -5,6 +5,7 @@
       "prefixes": ["OEJD"],
       "frequency": "126.500",
       "facility_type": "CTR",
+      "profile_id": "OEJD",
       "default_call_sources": ["OEJD_1_CTR"]
     },
     {
@@ -12,6 +13,7 @@
       "prefixes": ["OEJD"],
       "frequency": "133.900",
       "facility_type": "CTR",
+      "profile_id": "OEJD-2",
       "default_call_sources": ["OEJD_2_CTR"]
     },
     {
@@ -40,6 +42,7 @@
       "prefixes": ["OEJD"],
       "frequency": "134.500",
       "facility_type": "CTR",
+      "profile_id": "OEJD-SE",
       "default_call_sources": ["OEJD_SE_CTR"]
     },
     {
@@ -68,6 +71,7 @@
       "prefixes": ["OEJD"],
       "frequency": "127.650",
       "facility_type": "CTR",
+      "profile_id": "OE-NE",
       "default_call_sources": ["OEJD_NE_CTR"]
     },
     {
@@ -75,6 +79,7 @@
       "prefixes": ["OERD"],
       "frequency": "128.550",
       "facility_type": "CTR",
+      "profile_id": "OERD",
       "default_call_sources": ["OERD_1_CTR"]
     },
     {
@@ -96,6 +101,7 @@
       "prefixes": ["OERD"],
       "frequency": "132.250",
       "facility_type": "CTR",
+      "profile_id": "OE-NE",
       "default_call_sources": ["OERD_NE_CTR"]
     },
     {

--- a/dataset/OE/profiles/OE-NE.json
+++ b/dataset/OE/profiles/OE-NE.json
@@ -1,5 +1,5 @@
 {
-  "id": "OEJD-NE",
+  "id": "OE-NE",
   "type": "Tabbed",
   "tabs": [
     {

--- a/dataset/OE/profiles/OEJD-NE.json
+++ b/dataset/OE/profiles/OEJD-NE.json
@@ -1,0 +1,105 @@
+{
+  "id": "OEJD-NE",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["ACC", "NE"],
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": ["RD", "EAST", "345+"],
+            "station_id": "OERD_E_CTR"
+          },
+          {
+            "label": ["JD", "EAST", "245-345"],
+            "station_id": "OEJD_E_CTR"
+          },
+          {
+            "label": ["RUH CTA", "NORTH"],
+            "station_id": "OERK_N_CTR"
+          },
+          {
+            "label": ["RUH CTA", "SOUTH"],
+            "station_id": "OERK_S_CTR"
+          },
+          {
+            "label": ["RD", "NE", "345+"],
+            "station_id": "OERD_NE_CTR"
+          },
+          {
+            "label": ["JD", "NE", "245-345"],
+            "station_id": "OEJD_NE_CTR"
+          },
+          {
+            "label": ["DMM", "CTA", "155-245"],
+            "station_id": "OEDF_APP"
+          },
+          {
+            "label": ["DMM", "TMA", "155-"],
+            "station_id": "OEDF_L_APP"
+          },
+          {
+            "label": ["KWI", "TMA", "150-"],
+            "station_id": "OKKK_APP"
+          },
+          {
+            "label": ["OKAC", "ACCH", "350+"],
+            "station_id": "OKKK_APP"
+          },
+          {
+            "label": ["OKAC", "ACCL", "350-"],
+            "station_id": "OMAE_S_CTR"
+          },
+          {
+            "label": [""]
+          },
+          {
+            "label": ["OBBB", "NH", "345+"],
+            "station_id": "OBBB_3_CTR"
+          },
+          {
+            "label": ["OBBB", "NL", "345-"],
+            "station_id": "OBBB_3_CTR"
+          },
+          {
+            "label": ["BAH", "TMA", "170-"],
+            "station_id": "OBBI_APP"
+          },
+          {
+            "label": [""]
+          },
+          {
+            "label": ["OBBB", "CS", "345+"],
+            "station_id": "OBBB_1_CTR"
+          },
+          {
+            "label": ["OBBB", "CH", "295-345"],
+            "station_id": "OBBB_1_CTR"
+          },
+          {
+            "label": ["OBBB", "CL", "295-"],
+            "station_id": "OBBB_CL_CTR"
+          },
+          {
+            "label": [""]
+          },
+          {
+            "label": ["OTDF", "SOUTH", "245+"],
+            "station_id": "OTDF_2_CTR"
+          },
+          {
+            "label": ["DOH", "R2", "245-"],
+            "station_id": "DOH_R2_APP"
+          },
+          {
+            "label": [""]
+          },
+          {
+            "label": [""]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dataset/OE/profiles/OEJD.json
+++ b/dataset/OE/profiles/OEJD.json
@@ -48,6 +48,7 @@
             "station_id": "OERD_1_CTR",
             "color": "azure"
           },
+          { "label": [] },
           { "label": [] }
         ]
       }

--- a/dataset/OE/stations.json
+++ b/dataset/OE/stations.json
@@ -1,31 +1,5 @@
 {
   "stations": [
-    { "id": "OERD_CTR", "controlled_by": ["OERD_CTR"] },
-    {
-      "id": "OERD_E_CTR",
-      "parent_id": "OERD_CTR",
-      "controlled_by": ["OERD_E_CTR"]
-    },
-    {
-      "id": "OERD_N_CTR",
-      "parent_id": "OERD_CTR",
-      "controlled_by": ["OERD_N_CTR"]
-    },
-    {
-      "id": "OERD_NE_CTR",
-      "parent_id": "OERD_N_CTR",
-      "controlled_by": ["OERD_NE_CTR"]
-    },
-    {
-      "id": "OERD_1_CTR",
-      "parent_id": "OERD_CTR",
-      "controlled_by": ["OERD_1_CTR"]
-    },
-    {
-      "id": "OERK_N_CTR",
-      "parent_id": "OERD_1_CTR",
-      "controlled_by": ["OERK_N_CTR"]
-    },
     {
       "id": "OEJD_1_CTR",
       "parent_id": "GULF_W_FSS",
@@ -37,9 +11,14 @@
       "controlled_by": ["OEJD_2_CTR"]
     },
     {
-      "id": "OEJD_N_CTR",
-      "parent_id": "OEJD_1_CTR",
-      "controlled_by": ["OEJD_N_CTR"]
+      "id": "OEJD_W_CTR",
+      "parent_id": "OEJD_2_CTR",
+      "controlled_by": ["OEJD_W_CTR"]
+    },
+    {
+      "id": "OEJD_C_CTR",
+      "parent_id": "OEJD_2_CTR",
+      "controlled_by": ["OEJD_C_CTR"]
     },
     {
       "id": "OEJD_S_CTR",
@@ -47,32 +26,65 @@
       "controlled_by": ["OEJD_S_CTR"]
     },
     {
-      "id": "OEJD_W_CTR",
-      "parent_id": "OEJD_2_CTR",
-      "controlled_by": ["OEJD_W_CTR"]
-    },
-    {
-      "id": "OEJD_NE_CTR",
-      "parent_id": "OEJD_N_CTR",
-      "controlled_by": ["OEJD_NE_CTR"]
-    },
-    {
       "id": "OEJD_SE_CTR",
-      "parent_id": "OEJD_S_CTR",
+      "parent_id": "OEJD_2_CTR",
       "controlled_by": ["OEJD_SE_CTR"]
     },
     {
-      "id": "OEJD_C_CTR",
-      "parent_id": "OEJD_2_CTR",
-      "controlled_by": ["OEJD_C_CTR"]
+      "id": "OEJD_3_CTR",
+      "parent_id": "OEJD_1_CTR",
+      "controlled_by": ["OEJD_3_CTR"]
     },
-
+    {
+      "id": "OEJD_N_CTR",
+      "parent_id": "OEJD_3_CTR",
+      "controlled_by": ["OEJD_N_CTR"]
+    },
+    {
+      "id": "OEJD_E_CTR",
+      "parent_id": "OEJD_3_CTR",
+      "controlled_by": ["OEJD_E_CTR"]
+    },
+    {
+      "id": "OEJD_NE_CTR",
+      "parent_id": "OEJD_3_CTR",
+      "controlled_by": ["OEJD_NE_CTR"]
+    },
+    {
+      "id": "OERD_1_CTR",
+      "parent_id": "OEJD_3_CTR",
+      "controlled_by": ["OERD_1_CTR"]
+    },
+    {
+      "id": "OERD_N_CTR",
+      "parent_id": "OEJD_N_CTR",
+      "controlled_by": ["OERD_N_CTR"]
+    },
+    {
+      "id": "OERD_E_CTR",
+      "parent_id": "OEJD_E_CTR",
+      "controlled_by": ["OERD_E_CTR"]
+    },
+    {
+      "id": "OERD_NE_CTR",
+      "parent_id": "OEJD_NE_CTR",
+      "controlled_by": ["OERD_NE_CTR"]
+    },
     {
       "id": "OEJN_W_CTR",
-      "parent_id": "OEJD_1_CTR",
+      "parent_id": "OEJD_2_CTR",
       "controlled_by": ["OEJN_W_CTR"]
     },
-
+    {
+      "id": "OEJN_WU_CTR",
+      "parent_id": "OEJN_W_CTR",
+      "controlled_by": ["OEJN_WU_CTR"]
+    },
+    {
+      "id": "OEJN_E_CTR",
+      "parent_id": "OEJN_W_CTR",
+      "controlled_by": ["OEJN_E_CTR"]
+    },
     {
       "id": "OEJN_APP",
       "parent_id": "OEJN_W_CTR",
@@ -85,7 +97,7 @@
     },
     {
       "id": "OEJN_FW_APP",
-      "parent_id": "OEJN_APP",
+      "parent_id": "OEJN_FE_APP",
       "controlled_by": ["OEJN_FW_APP"]
     },
     {
@@ -93,7 +105,6 @@
       "parent_id": "OEJN_APP",
       "controlled_by": ["OEJN_FMC_APP"]
     },
-
     {
       "id": "OEJN_W_TWR",
       "parent_id": "OEJN_APP",
@@ -101,23 +112,13 @@
     },
     {
       "id": "OEJN_E_TWR",
-      "parent_id": "OEJN_APP",
+      "parent_id": "OEJN_W_TWR",
       "controlled_by": ["OEJN_E_TWR"]
     },
     {
       "id": "OEJN_C_TWR",
-      "parent_id": "OEJN_APP",
+      "parent_id": "OEJN_E_TWR",
       "controlled_by": ["OEJN_C_TWR"]
-    },
-    {
-      "id": "OEJN_E_RMP",
-      "parent_id": "OEJN_E_GND",
-      "controlled_by": ["OEJN_E_RMP"]
-    },
-    {
-      "id": "OEJN_E_GND",
-      "parent_id": "OEJN_W_TWR",
-      "controlled_by": ["OEJN_E_GND"]
     },
     {
       "id": "OEJN_W_GND",
@@ -125,24 +126,48 @@
       "controlled_by": ["OEJN_W_GND"]
     },
     {
+      "id": "OEJN_E_GND",
+      "parent_id": "OEJN_W_GND",
+      "controlled_by": ["OEJN_E_GND"]
+    },
+    {
       "id": "OEJN_C_GND",
-      "parent_id": "OEJN_C_TWR",
+      "parent_id": "OEJN_W_GND",
       "controlled_by": ["OEJN_C_GND"]
     },
     {
+      "id": "OEJN_E_RMP",
+      "parent_id": "OEJN_E_GND",
+      "controlled_by": ["OEJN_E_RMP"]
+    },
+    {
+      "id": "OEJN_N_RMP",
+      "parent_id": "OEJN_W_CTR",
+      "controlled_by": ["OEJN_N_RMP"]
+    },
+    {
       "id": "OEJN_DEL",
-      "parent_id": "OEJN_C_GND",
+      "parent_id": "OEJN_W_GND",
       "controlled_by": ["OEJN_DEL"]
     },
-
     {
-      "id": "OERK_1_CTR",
-      "parent_id": "OERD_CTR",
-      "controlled_by": ["OERK_1_CTR"]
+      "id": "OEJN_P_DEL",
+      "parent_id": "OEJN_DEL",
+      "controlled_by": ["OEJN_P_DEL"]
+    },
+    {
+      "id": "OERK_N_CTR",
+      "parent_id": "OEJD_3_CTR",
+      "controlled_by": ["OERK_N_CTR"]
+    },
+    {
+      "id": "OERK_S_CTR",
+      "parent_id": "OERK_N_CTR",
+      "controlled_by": ["OERK_S_CTR"]
     },
     {
       "id": "OERK_APP",
-      "parent_id": "OERK_1_CTR",
+      "parent_id": "OERK_N_CTR",
       "controlled_by": ["OERK_APP"]
     },
     {
@@ -150,7 +175,16 @@
       "parent_id": "OERK_APP",
       "controlled_by": ["OERK_F_APP"]
     },
-
+    {
+      "id": "OERK_FE_APP",
+      "parent_id": "OERK_APP",
+      "controlled_by": ["OERK_FE_APP"]
+    },
+    {
+      "id": "OERK_FW_APP",
+      "parent_id": "OERK_APP",
+      "controlled_by": ["OERK_FW_APP"]
+    },
     {
       "id": "OERK_E_TWR",
       "parent_id": "OERK_APP",
@@ -158,10 +192,9 @@
     },
     {
       "id": "OERK_W_TWR",
-      "parent_id": "OERK_APP",
+      "parent_id": "OERK_E_TWR",
       "controlled_by": ["OERK_W_TWR"]
     },
-
     {
       "id": "OERK_N_GND",
       "parent_id": "OERK_E_TWR",
@@ -169,18 +202,107 @@
     },
     {
       "id": "OERK_S_GND",
-      "parent_id": "OERK_W_TWR",
+      "parent_id": "OERK_N_GND",
       "controlled_by": ["OERK_S_GND"]
     },
     {
       "id": "OERK_DEL",
-      "parent_id": "OERK_S_GND",
+      "parent_id": "OERK_N_GND",
       "controlled_by": ["OERK_DEL"]
     },
-
+    {
+      "id": "OEDF_APP",
+      "parent_id": "OEJD_NE_CTR",
+      "controlled_by": ["OEDF_APP"]
+    },
+    {
+      "id": "OEDF_L_APP",
+      "parent_id": "OEDF_APP",
+      "controlled_by": ["OEDF_L_APP"]
+    },
+    {
+      "id": "OEDF_1_TWR",
+      "parent_id": "OEDF_APP",
+      "controlled_by": ["OEDF_1_TWR"]
+    },
+    {
+      "id": "OEDF_2_TWR",
+      "parent_id": "OEDF_1_TWR",
+      "controlled_by": ["OEDF_2_TWR"]
+    },
+    {
+      "id": "OEDF_1_GND",
+      "parent_id": "OEDF_1_TWR",
+      "controlled_by": ["OEDF_1_GND"]
+    },
+    {
+      "id": "OEDF_2_GND",
+      "parent_id": "OEDF_1_GND",
+      "controlled_by": ["OEDF_2_GND"]
+    },
+    {
+      "id": "OEMA_APP",
+      "parent_id": "OEJD_W_CTR",
+      "controlled_by": ["OEMA_APP"]
+    },
+    {
+      "id": "OEMA_TWR",
+      "parent_id": "OEMA_APP",
+      "controlled_by": ["OEMA_TWR"]
+    },
+    {
+      "id": "OEMA_GND",
+      "parent_id": "OEMA_TWR",
+      "controlled_by": ["OEMA_GND"]
+    },
+    {
+      "id": "OEAB_APP",
+      "parent_id": "OEJD_S_CTR",
+      "controlled_by": ["OEAB_APP"]
+    },
+    {
+      "id": "OEAB_L_APP",
+      "parent_id": "OEAB_APP",
+      "controlled_by": ["OEAB_L_APP"]
+    },
+    {
+      "id": "OEAB_TWR",
+      "parent_id": "OEAB_APP",
+      "controlled_by": ["OEAB_TWR"]
+    },
+    {
+      "id": "OEAB_GND",
+      "parent_id": "OEAB_TWR",
+      "controlled_by": ["OEAB_GND"]
+    },
+    {
+      "id": "OEAH_I_TWR",
+      "parent_id": "OEDF_APP",
+      "controlled_by": ["OEAH_I_TWR"]
+    },
+    {
+      "id": "OEAH_I_GND",
+      "parent_id": "OEAH_I_TWR",
+      "controlled_by": ["OEAH_I_GND"]
+    },
+    {
+      "id": "OEGN_APP",
+      "parent_id": "OEAB_APP",
+      "controlled_by": ["OEGN_APP"]
+    },
+    {
+      "id": "OEGN_TWR",
+      "parent_id": "OEGN_APP",
+      "controlled_by": ["OEGN_TWR"]
+    },
+    {
+      "id": "OEGN_GND",
+      "parent_id": "OEGN_TWR",
+      "controlled_by": ["OEGN_GND"]
+    },
     {
       "id": "OEGS_APP",
-      "parent_id": "OERD_CTR",
+      "parent_id": "OEJD_E_CTR",
       "controlled_by": ["OEGS_APP"]
     },
     {
@@ -193,16 +315,10 @@
       "parent_id": "OEGS_TWR",
       "controlled_by": ["OEGS_GND"]
     },
-
     {
-      "id": "OETF_GND",
-      "parent_id": "OETF_TWR",
-      "controlled_by": ["OETF_GND"]
-    },
-    {
-      "id": "OEHL_GND",
-      "parent_id": "OEHL_TWR",
-      "controlled_by": ["OEHL_GND"]
+      "id": "OEHL_APP",
+      "parent_id": "OEJD_N_CTR",
+      "controlled_by": ["OEHL_APP"]
     },
     {
       "id": "OEHL_TWR",
@@ -210,56 +326,14 @@
       "controlled_by": ["OEHL_TWR"]
     },
     {
-      "id": "OEHL_APP",
-      "parent_id": "OEJD_N_CTR",
-      "controlled_by": ["OEHL_APP"]
+      "id": "OEHL_GND",
+      "parent_id": "OEHL_TWR",
+      "controlled_by": ["OEHL_GND"]
     },
     {
-      "id": "OETB_DEL",
-      "parent_id": "OETB_GND",
-      "controlled_by": ["OETB_DEL"]
-    },
-
-    {
-      "id": "OETB_GND",
-      "parent_id": "OETB_TWR",
-      "controlled_by": ["OETB_GND"]
-    },
-    {
-      "id": "OETB_TWR",
-      "parent_id": "OETB_APP",
-      "controlled_by": ["OETB_TWR"]
-    },
-    {
-      "id": "OETB_APP",
-      "parent_id": "OEJD_C_CTR",
-      "controlled_by": ["OETB_APP"]
-    },
-
-    {
-      "id": "OEMA_GND",
-      "parent_id": "OEMA_TWR",
-      "controlled_by": ["OEMA_GND"]
-    },
-    {
-      "id": "OEMA_TWR",
-      "parent_id": "OEMA_APP",
-      "controlled_by": ["OEMA_TWR"]
-    },
-    {
-      "id": "OEMA_APP",
-      "parent_id": "OEJD_N_CTR",
-      "controlled_by": ["OEMA_APP"]
-    },
-    {
-      "id": "OETF_TWR",
-      "parent_id": "OETF_APP",
-      "controlled_by": ["OETF_TWR"]
-    },
-    {
-      "id": "OETF_APP",
-      "parent_id": "OEJD_N_CTR",
-      "controlled_by": ["OETF_APP"]
+      "id": "OENG_TWR",
+      "parent_id": "OEJD_S_CTR",
+      "controlled_by": ["OENG_TWR"]
     },
     {
       "id": "OENG_GND",
@@ -267,39 +341,49 @@
       "controlled_by": ["OENG_GND"]
     },
     {
-      "id": "OENG_TWR",
-      "parent_id": "OEJD_1_CTR",
-      "controlled_by": ["OENG_TWR"]
+      "id": "OETB_APP",
+      "parent_id": "OEJD_N_CTR",
+      "controlled_by": ["OETB_APP"]
     },
     {
-      "id": "OEDF_1_GND",
-      "parent_id": "OEDF_1_TWR",
-      "controlled_by": ["OEDF_1_GND"]
+      "id": "OETB_TWR",
+      "parent_id": "OETB_APP",
+      "controlled_by": ["OETB_TWR"]
     },
     {
-      "id": "OEDF_2_GND",
-      "parent_id": "OEDF_2_TWR",
-      "controlled_by": ["OEDF_2_GND"]
+      "id": "OETB_GND",
+      "parent_id": "OETB_TWR",
+      "controlled_by": ["OETB_GND"]
     },
     {
-      "id": "OEDF_1_TWR",
-      "parent_id": "OEDF_L_APP",
-      "controlled_by": ["OEDF_1_TWR"]
+      "id": "OETB_DEL",
+      "parent_id": "OETB_GND",
+      "controlled_by": ["OETB_DEL"]
     },
     {
-      "id": "OEDF_2_TWR",
-      "parent_id": "OEDF_L_APP",
-      "controlled_by": ["OEDF_2_TWR"]
+      "id": "OETF_APP",
+      "parent_id": "OEJN_E_CTR",
+      "controlled_by": ["OETF_APP"]
     },
     {
-      "id": "OEDF_L_APP",
-      "parent_id": "OEDF_APP",
-      "controlled_by": ["OEDF_L_APP"]
+      "id": "OETF_TWR",
+      "parent_id": "OETF_APP",
+      "controlled_by": ["OETF_TWR"]
     },
     {
-      "id": "OEDF_APP",
-      "parent_id": "OERD_NE_CTR",
-      "controlled_by": ["OEDF_APP"]
+      "id": "OETF_GND",
+      "parent_id": "OETF_TWR",
+      "controlled_by": ["OETF_GND"]
+    },
+    {
+      "id": "OEYN_TWR",
+      "parent_id": "OEJD_W_CTR",
+      "controlled_by": ["OEYN_TWR"]
+    },
+    {
+      "id": "OEYN_GND",
+      "parent_id": "OEYN_TWR",
+      "controlled_by": ["OEYN_GND"]
     }
   ]
 }


### PR DESCRIPTION
### Description

Completely overhauls the Saudi FIR (OE) to be accurate positions based on the .ese and adds a NE ACC profile.

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
