### PR TITLE
Adds OE-E, OEJD-2 profiles and OE-N as a placeholder.

### DIFF
--- a/dataset/OE/positions.json
+++ b/dataset/OE/positions.json
@@ -24,6 +24,13 @@
       "default_call_sources": ["OEJD_W_CTR"]
     },
     {
+      "id": "OEJD_W1_CTR",
+      "prefixes": ["OEJD"],
+      "frequency": "132.300",
+      "facility_type": "CTR",
+      "default_call_sources": ["OEJD_W1_CTR"]
+    },
+    {
       "id": "OEJD_C_CTR",
       "prefixes": ["OEJD"],
       "frequency": "126.550",
@@ -64,6 +71,7 @@
       "prefixes": ["OEJD"],
       "frequency": "134.400",
       "facility_type": "CTR",
+      "profile_id": "OE-E",
       "default_call_sources": ["OEJD_E_CTR"]
     },
     {
@@ -94,6 +102,7 @@
       "prefixes": ["OERD"],
       "frequency": "132.950",
       "facility_type": "CTR",
+      "profile_id": "OE-E",
       "default_call_sources": ["OERD_E_CTR"]
     },
     {

--- a/dataset/OE/profiles/OE-E.json
+++ b/dataset/OE/profiles/OE-E.json
@@ -1,0 +1,107 @@
+{
+  "id": "OE-E",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["ACC", "E"],
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": ["RD", "NORTH", "345+"],
+            "station_id": "OERD_N_CTR"
+          },
+          {
+            "label": ["JD", "NORTH", "245-345"],
+            "station_id": "OEJD_N_CTR"
+          },
+          {
+            "label": ["HAS", "TMA", "155-"],
+            "station_id": "OEHL_APP"
+          },
+          {
+            "label": ["JD", "WEST", "345+"],
+            "station_id": "OEJD_W_CTR"
+          },
+          {
+            "label": ["RD", "EAST", "345+"],
+            "station_id": "OERD_E_CTR"
+          },
+          {
+            "label": ["JD", "EAST", "245-345"],
+            "station_id": "OEJD_E_CTR"
+          },
+          {
+            "label": ["GAS", "TMA", "165-"],
+            "station_id": "OEGS_APP"
+          },
+          {
+            "label": ["JD", "WEST", "345-"],
+            "station_id": "OEJD_W1_CTR"
+          },
+          {
+            "label": ["RD", "NE", "345+"],
+            "station_id": "OERD_NE_CTR"
+          },
+          {
+            "label": ["JD", "NE", "245-345"],
+            "station_id": "OEJD_NE_CTR"
+          },
+          {
+            "label": ["MED", "CTA", "245-"],
+            "station_id": "OEMA_APP"
+          },
+          {
+            "label": ["JD", "CENT"],
+            "station_id": "OEJD_C_CTR"
+          },
+          {
+            "label": ["ORBB", "SOUTH HI", "345+"],
+            "station_id": "ORBB_SU_CTR"
+          },
+          {
+            "label": ["ORBB", "SOUTH LO", "345-"],
+            "station_id": "ORBB_S_CTR"
+          },
+          {
+            "label": ["RUH CTA", "NORTH"],
+            "station_id": "OERK_N_CTR"
+          },
+          {
+            "label": ["RUH CTA", "SOUTH"],
+            "station_id": "OERK_S_CTR"
+          },
+          {
+            "label": ["OKAC", "ACCH", "350+"],
+            "station_id": "OKKK_APP"
+          },
+          {
+            "label": ["OKAC", "ACCL", "350-"],
+            "station_id": "OMAE_S_CTR"
+          },
+          {
+            "label": ["KWI", "TMA", "150-"],
+            "station_id": "OKKK_APP"
+          },
+          {
+            "label": [""]
+          },
+          {
+            "label": ["OEGS", "TWR"],
+            "station_id": "OEGS_TWR"
+          },
+          {
+            "label": ["OEGS", "GND"],
+            "station_id": "OEGS_GND"
+          },
+          {
+            "label": [""]
+          },
+          {
+            "label": [""]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dataset/OE/profiles/OE-N.json
+++ b/dataset/OE/profiles/OE-N.json
@@ -1,0 +1,17 @@
+{
+  "id": "OE-N",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["ACC", "N"],
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": ["THIS TAB", "IS INOP"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dataset/OE/profiles/OE-NE.json
+++ b/dataset/OE/profiles/OE-NE.json
@@ -52,7 +52,8 @@
             "station_id": "OMAE_S_CTR"
           },
           {
-            "label": [""]
+            "label": ["OEDF", "AIR 1"],
+            "station_id": "OEDF_1_TWR"
           },
           {
             "label": ["OBBB", "NH", "345+"],
@@ -67,7 +68,8 @@
             "station_id": "OBBI_APP"
           },
           {
-            "label": [""]
+            "label": ["OEDF", "AIR 2"],
+            "station_id": "OEDF_2_TWR"
           },
           {
             "label": ["OBBB", "CS", "345+"],
@@ -82,7 +84,8 @@
             "station_id": "OBBB_CL_CTR"
           },
           {
-            "label": [""]
+            "label": ["OEDF", "GMC 1"],
+            "station_id": "OEDF_1_GND"
           },
           {
             "label": ["OTDF", "SOUTH", "245+"],
@@ -96,7 +99,8 @@
             "label": [""]
           },
           {
-            "label": [""]
+            "label": ["OEDF", "GMC 2"],
+            "station_id": "OEDF_2_GND"
           }
         ]
       }

--- a/dataset/OE/profiles/OEJD-2.json
+++ b/dataset/OE/profiles/OEJD-2.json
@@ -3,17 +3,52 @@
   "type": "Tabbed",
   "tabs": [
     {
-      "label": ["ACC 2"],
+      "label": ["ACC", "N"],
       "page": {
-        "rows": 2,
+        "rows": 4,
         "keys": [
           {
-            "label": ["RD", "CTA"],
+            "label": ["THIS TAB", "IS INOP"]
+          }
+        ]
+      }
+    },
+    {
+      "label": ["ACC", "E"],
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": ["RD", "NORTH", "345+"],
+            "station_id": "OERD_N_CTR"
+          },
+          {
+            "label": ["JD", "NORTH", "245-345"],
+            "station_id": "OEJD_N_CTR"
+          },
+          {
+            "label": ["HAS", "TMA", "155-"],
+            "station_id": "OEHL_APP"
+          },
+          {
+            "label": ["JD", "WEST", "345+"],
+            "station_id": "OEJD_W_CTR"
+          },
+          {
+            "label": ["RD", "EAST", "345+"],
             "station_id": "OERD_E_CTR"
           },
           {
-            "label": ["JD", "ACC", "SOUTH"],
-            "station_id": "OEJD_S_CTR"
+            "label": ["JD", "EAST", "245-345"],
+            "station_id": "OEJD_E_CTR"
+          },
+          {
+            "label": ["GAS", "TMA", "165-"],
+            "station_id": "OEGS_APP"
+          },
+          {
+            "label": ["JD", "WEST", "345-"],
+            "station_id": "OEJD_W1_CTR"
           },
           {
             "label": ["RD", "NE", "345+"],
@@ -21,49 +56,163 @@
           },
           {
             "label": ["JD", "NE", "245-345"],
-            "station_id": "OERD_NE_CTR"
+            "station_id": "OEJD_NE_CTR"
           },
           {
-            "label": ["JD", "TERM"],
-            "station_id": "OEJN_W_CTR"
+            "label": ["MED", "CTA", "245-"],
+            "station_id": "OEMA_APP"
           },
           {
-            "label": ["JD", "CTR", "245-"],
+            "label": ["JD", "CENT"],
             "station_id": "OEJD_C_CTR"
           },
           {
-            "label": ["RD", "BBX", "UNL"],
-            "station_id": "OERD_1_CTR"
+            "label": ["ORBB", "SOUTH HI", "345+"],
+            "station_id": "ORBB_SU_CTR"
           },
           {
-            "label": []
+            "label": ["ORBB", "SOUTH LO", "345-"],
+            "station_id": "ORBB_S_CTR"
           },
           {
-            "label": []
+            "label": ["RUH CTA", "NORTH"],
+            "station_id": "OERK_N_CTR"
+          },
+          {
+            "label": ["RUH CTA", "SOUTH"],
+            "station_id": "OERK_S_CTR"
+          },
+          {
+            "label": ["OKAC", "ACCH", "350+"],
+            "station_id": "OKKK_APP"
+          },
+          {
+            "label": ["OKAC", "ACCL", "350-"],
+            "station_id": "OMAE_S_CTR"
+          },
+          {
+            "label": ["KWI", "TMA", "150-"],
+            "station_id": "OKKK_APP"
+          },
+          {
+            "label": [""]
+          },
+          {
+            "label": ["OEGS", "TWR"],
+            "station_id": "OEGS_TWR"
+          },
+          {
+            "label": ["OEGS", "GND"],
+            "station_id": "OEGS_GND"
+          },
+          {
+            "label": [""]
+          },
+          {
+            "label": [""]
+          }
+        ]
+      }
+    },
+    {
+      "label": ["ACC", "NE"],
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": ["RD", "EAST", "345+"],
+            "station_id": "OERD_E_CTR"
+          },
+          {
+            "label": ["JD", "EAST", "245-345"],
+            "station_id": "OEJD_E_CTR"
+          },
+          {
+            "label": ["RUH CTA", "NORTH"],
+            "station_id": "OERK_N_CTR"
+          },
+          {
+            "label": ["RUH CTA", "SOUTH"],
+            "station_id": "OERK_S_CTR"
+          },
+          {
+            "label": ["RD", "NE", "345+"],
+            "station_id": "OERD_NE_CTR"
+          },
+          {
+            "label": ["JD", "NE", "245-345"],
+            "station_id": "OEJD_NE_CTR"
+          },
+          {
+            "label": ["DMM", "CTA", "155-245"],
+            "station_id": "OEDF_APP"
+          },
+          {
+            "label": ["DMM", "TMA", "155-"],
+            "station_id": "OEDF_L_APP"
+          },
+          {
+            "label": ["KWI", "TMA", "150-"],
+            "station_id": "OKKK_APP"
+          },
+          {
+            "label": ["OKAC", "ACCH", "350+"],
+            "station_id": "OKKK_APP"
+          },
+          {
+            "label": ["OKAC", "ACCL", "350-"],
+            "station_id": "OMAE_S_CTR"
+          },
+          {
+            "label": ["OEDF", "AIR 1"],
+            "station_id": "OEDF_1_TWR"
+          },
+          {
+            "label": ["OBBB", "NH", "345+"],
+            "station_id": "OBBB_3_CTR"
+          },
+          {
+            "label": ["OBBB", "NL", "345-"],
+            "station_id": "OBBB_3_CTR"
+          },
+          {
+            "label": ["BAH", "TMA", "170-"],
+            "station_id": "OBBI_APP"
+          },
+          {
+            "label": ["OEDF", "AIR 2"],
+            "station_id": "OEDF_2_TWR"
+          },
+          {
+            "label": ["OBBB", "CS", "345+"],
+            "station_id": "OBBB_1_CTR"
+          },
+          {
+            "label": ["OBBB", "CH", "295-345"],
+            "station_id": "OBBB_1_CTR"
+          },
+          {
+            "label": ["OBBB", "CL", "295-"],
+            "station_id": "OBBB_CL_CTR"
+          },
+          {
+            "label": ["OEDF", "GMC 1"],
+            "station_id": "OEDF_1_GND"
+          },
+          {
+            "label": ["OTDF", "SOUTH", "245+"],
+            "station_id": "OTDF_2_CTR"
           },
           {
             "label": ["DOH", "R2", "245-"],
             "station_id": "DOH_R2_APP"
           },
           {
-            "label": ["OTDF", "ACC 2", "245+"],
-            "station_id": "OTDF_2_CTR"
+            "label": [""]
           },
           {
-            "label": ["UAE", "SOUTH"],
-            "station_id": "OMAE_S_CTR"
-          },
-          {
-            "label": ["OOMM", "ACC S"],
-            "station_id": "OOMM_5_CTR"
-          },
-          {
-            "label": ["OOMM", "ACC C"],
-            "station_id": "OOMM_6_CTR"
-          },
-          {
-            "label": ["OOMM", "ACC M"],
-            "station_id": "OOMM_4_CTR"
+            "label": ["OEDF", "GMC 2"],
+            "station_id": "OEDF_2_GND"
           }
         ]
       }

--- a/dataset/OE/stations.json
+++ b/dataset/OE/stations.json
@@ -16,6 +16,11 @@
       "controlled_by": ["OEJD_W_CTR"]
     },
     {
+      "id": "OEJD_W1_CTR",
+      "parent_id": "OEJD_W_CTR",
+      "controlled_by": ["OEJD_W1_CTR"]
+    },
+    {
       "id": "OEJD_C_CTR",
       "parent_id": "OEJD_2_CTR",
       "controlled_by": ["OEJD_C_CTR"]


### PR DESCRIPTION
### Description

- Adds a new OE-E profile which is added to OEJD_E_CTR and OERD_E_CTR
- Adds a OEJD-2 bandbox profile.
- Updates OE-NE profile

<img width="1584" height="1213" alt="image" src="https://github.com/user-attachments/assets/275fb4de-28b1-4ed3-9a9d-912d411137d8" />
<img width="1609" height="1239" alt="image" src="https://github.com/user-attachments/assets/b8a44725-bf68-4c51-9a57-7b727df70d35" />


### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
