### PR TITLE
Update ADC OEDF logon callsigns

### DIFF
--- a/dataset/OE/positions.json
+++ b/dataset/OE/positions.json
@@ -315,32 +315,32 @@
       "default_call_sources": ["OEDF_L_APP"]
     },
     {
-      "id": "OEDF_1_TWR",
+      "id": "OEDF_W_TWR",
       "prefixes": ["OEDF"],
       "frequency": "124.350",
       "facility_type": "TWR",
-      "default_call_sources": ["OEDF_1_TWR"]
+      "default_call_sources": ["OEDF_W_TWR"]
     },
     {
-      "id": "OEDF_2_TWR",
+      "id": "OEDF_E_TWR",
       "prefixes": ["OEDF"],
       "frequency": "118.200",
       "facility_type": "TWR",
-      "default_call_sources": ["OEDF_2_TWR"]
+      "default_call_sources": ["OEDF_E_TWR"]
     },
     {
-      "id": "OEDF_1_GND",
+      "id": "OEDF_W_GND",
       "prefixes": ["OEDF"],
       "frequency": "121.750",
       "facility_type": "GND",
-      "default_call_sources": ["OEDF_1_GND"]
+      "default_call_sources": ["OEDF_2_GND"]
     },
     {
-      "id": "OEDF_2_GND",
+      "id": "OEDF_E_GND",
       "prefixes": ["OEDF"],
       "frequency": "121.850",
       "facility_type": "GND",
-      "default_call_sources": ["OEDF_2_GND"]
+      "default_call_sources": ["OEDF_E_GND"]
     },
     {
       "id": "OEMA_APP",

--- a/dataset/OE/positions.json
+++ b/dataset/OE/positions.json
@@ -305,6 +305,7 @@
       "prefixes": ["OEDF"],
       "frequency": "126.300",
       "facility_type": "APP",
+      "profile_id": "OEDF",
       "default_call_sources": ["OEDF_APP"]
     },
     {
@@ -312,6 +313,7 @@
       "prefixes": ["OEDF"],
       "frequency": "126.100",
       "facility_type": "APP",
+      "profile_id": "OEDF",
       "default_call_sources": ["OEDF_L_APP"]
     },
     {
@@ -319,6 +321,7 @@
       "prefixes": ["OEDF"],
       "frequency": "124.350",
       "facility_type": "TWR",
+      "profile_id": "OEDF",
       "default_call_sources": ["OEDF_W_TWR"]
     },
     {
@@ -326,6 +329,7 @@
       "prefixes": ["OEDF"],
       "frequency": "118.200",
       "facility_type": "TWR",
+      "profile_id": "OEDF",
       "default_call_sources": ["OEDF_E_TWR"]
     },
     {
@@ -333,6 +337,7 @@
       "prefixes": ["OEDF"],
       "frequency": "121.750",
       "facility_type": "GND",
+      "profile_id": "OEDF",
       "default_call_sources": ["OEDF_W_GND"]
     },
     {
@@ -340,6 +345,7 @@
       "prefixes": ["OEDF"],
       "frequency": "121.850",
       "facility_type": "GND",
+      "profile_id": "OEDF",
       "default_call_sources": ["OEDF_E_GND"]
     },
     {

--- a/dataset/OE/positions.json
+++ b/dataset/OE/positions.json
@@ -333,7 +333,7 @@
       "prefixes": ["OEDF"],
       "frequency": "121.750",
       "facility_type": "GND",
-      "default_call_sources": ["OEDF_2_GND"]
+      "default_call_sources": ["OEDF_W_GND"]
     },
     {
       "id": "OEDF_E_GND",

--- a/dataset/OE/profiles/OE-NE.json
+++ b/dataset/OE/profiles/OE-NE.json
@@ -84,8 +84,8 @@
             "station_id": "OBBB_CL_CTR"
           },
           {
-            "label": ["OEDF", "GMC 1"],
-            "station_id": "OEDF_1_GND"
+            "label": ["OEDF", "GMC W"],
+            "station_id": "OEDF_W_GND"
           },
           {
             "label": ["OTDF", "SOUTH", "245+"],
@@ -99,8 +99,8 @@
             "label": [""]
           },
           {
-            "label": ["OEDF", "GMC 2"],
-            "station_id": "OEDF_2_GND"
+            "label": ["OEDF", "GMC E"],
+            "station_id": "OEDF_E_GND"
           }
         ]
       }

--- a/dataset/OE/profiles/OE-NE.json
+++ b/dataset/OE/profiles/OE-NE.json
@@ -52,8 +52,8 @@
             "station_id": "OMAE_S_CTR"
           },
           {
-            "label": ["OEDF", "AIR 1"],
-            "station_id": "OEDF_1_TWR"
+            "label": ["OEDF", "AIR W"],
+            "station_id": "OEDF_W_TWR"
           },
           {
             "label": ["OBBB", "NH", "345+"],
@@ -68,8 +68,8 @@
             "station_id": "OBBI_APP"
           },
           {
-            "label": ["OEDF", "AIR 2"],
-            "station_id": "OEDF_2_TWR"
+            "label": ["OEDF", "AIR E"],
+            "station_id": "OEDF_E_TWR"
           },
           {
             "label": ["OBBB", "CS", "345+"],

--- a/dataset/OE/profiles/OEDF.json
+++ b/dataset/OE/profiles/OEDF.json
@@ -3,42 +3,106 @@
   "type": "Tabbed",
   "tabs": [
     {
-      "label": ["OEDF"],
+      "label": ["ADC"],
       "page": {
-        "rows": 3,
+        "rows": 2,
         "keys": [
-          { "label": ["W_GND"], "station_id": "OEDF_W_GND", "color": "mint" },
-          { "label": ["E_GND"], "station_id": "OEDF_E_GND", "color": "mint" },
-          { "label": [], "color": "snow" },
-          { "label": ["W_TWR"], "station_id": "OEDF_W_TWR", "color": "lagoon" },
-          { "label": ["E_TWR"], "station_id": "OEDF_E_TWR", "color": "lagoon" },
-          { "label": [], "color": "snow" }
+          {
+            "label": ["AIR W"],
+            "station_id": "OEDF_W_GND",
+            "color": "lagoon"
+          },
+          {
+            "label": ["GMC W"],
+            "station_id": "OEDF_W_TWR",
+            "color": "mint"
+          },
+          {
+            "label": ["AIR E"],
+            "station_id": "OEDF_W_TWR",
+            "color": "lagoon"
+          },
+          {
+            "label": ["GMC E"],
+            "station_id": "OEDF_E_GND",
+            "color": "mint"
+          },
+          {
+            "label": [""],
+            "color": "snow"
+          },
+          {
+            "label": [""],
+            "color": "snow"
+          },
+          {
+            "label": ["CTA"],
+            "station_id": "OEDF_APP",
+            "color": "cadet"
+          },
+          {
+            "label": ["TMA"],
+            "station_id": "OEDF_L_APP",
+            "color": "cadet"
+          },
+          {
+            "label": [""],
+            "color": "snow"
+          },
+          {
+            "label": ["JD NE"],
+            "station_id": "OEDF_L_APP",
+            "color": "cadet"
+          }
         ]
       }
     },
     {
-      "label": ["ACC+"],
+      "label": ["TMA+"],
       "page": {
         "rows": 3,
         "keys": [
           {
-            "label": ["APP LOWER", "FL155-"],
-            "station_id": "OEDF_L_APP",
-            "color": "azure"
+            "label": ["JD", "NE", "245+"],
+            "station_id": "OEJD_NE_CTR",
+            "color": "lagoon"
           },
           {
-            "label": ["APP UPPER", "FL155-FL245"],
+            "label": ["DMM", "CTA", "155-245"],
             "station_id": "OEDF_APP",
-            "color": "azure"
+            "color": "mint"
           },
-          { "label": [], "color": "snow" },
           {
-            "label": ["JED NE", "FL245+"],
-            "station_id": "OERD_NE_CTR",
+            "label": ["DMM", "TMA", "155-"],
+            "station_id": "OEDF_L_APP",
+            "color": "mint"
+          },
+          {
+            "label": [""]
+          },
+          {
+            "label": [""]
+          },
+          {
+            "label": ["BAH", "TMA", "170-"],
+            "station_id": "OBBI_APP",
             "color": "azure"
           },
-          { "label": ["BAH APP"], "station_id": "OBBI_APP", "color": "lilac" },
-          { "label": [], "color": "snow" }
+          {
+            "label": ["OBBB", "CS", "345+"],
+            "station_id": "OBBB_1_CTR",
+            "color": "cadet"
+          },
+          {
+            "label": ["OBBB", "CH", "295-345"],
+            "station_id": "OBBB_1_CTR",
+            "color": "cadet"
+          },
+          {
+            "label": ["OBBB", "CL", "295-"],
+            "station_id": "OBBB_CL_CTR",
+            "color": "cadet"
+          }
         ]
       }
     }

--- a/dataset/OE/profiles/OEDF.json
+++ b/dataset/OE/profiles/OEDF.json
@@ -7,11 +7,11 @@
       "page": {
         "rows": 3,
         "keys": [
-          { "label": ["1_GND"], "station_id": "OEDF_1_GND", "color": "mint" },
-          { "label": ["2_GND"], "station_id": "OEDF_2_GND", "color": "mint" },
+          { "label": ["W_GND"], "station_id": "OEDF_W_GND", "color": "mint" },
+          { "label": ["E_GND"], "station_id": "OEDF_E_GND", "color": "mint" },
           { "label": [], "color": "snow" },
-          { "label": ["1_TWR"], "station_id": "OEDF_1_TWR", "color": "lagoon" },
-          { "label": ["2_TWR"], "station_id": "OEDF_2_TWR", "color": "lagoon" },
+          { "label": ["W_TWR"], "station_id": "OEDF_W_TWR", "color": "lagoon" },
+          { "label": ["E_TWR"], "station_id": "OEDF_E_TWR", "color": "lagoon" },
           { "label": [], "color": "snow" }
         ]
       }

--- a/dataset/OE/profiles/OEJD-2.json
+++ b/dataset/OE/profiles/OEJD-2.json
@@ -196,8 +196,8 @@
             "station_id": "OBBB_CL_CTR"
           },
           {
-            "label": ["OEDF", "GMC 1"],
-            "station_id": "OEDF_1_GND"
+            "label": ["OEDF", "GMC W"],
+            "station_id": "OEDF_W_GND"
           },
           {
             "label": ["OTDF", "SOUTH", "245+"],
@@ -211,8 +211,8 @@
             "label": [""]
           },
           {
-            "label": ["OEDF", "GMC 2"],
-            "station_id": "OEDF_2_GND"
+            "label": ["OEDF", "GMC E"],
+            "station_id": "OEDF_E_GND"
           }
         ]
       }

--- a/dataset/OE/profiles/OEJD-2.json
+++ b/dataset/OE/profiles/OEJD-2.json
@@ -164,8 +164,8 @@
             "station_id": "OMAE_S_CTR"
           },
           {
-            "label": ["OEDF", "AIR 1"],
-            "station_id": "OEDF_1_TWR"
+            "label": ["OEDF", "AIR W"],
+            "station_id": "OEDF_W_TWR"
           },
           {
             "label": ["OBBB", "NH", "345+"],
@@ -180,8 +180,8 @@
             "station_id": "OBBI_APP"
           },
           {
-            "label": ["OEDF", "AIR 2"],
-            "station_id": "OEDF_2_TWR"
+            "label": ["OEDF", "AIR E"],
+            "station_id": "OEDF_E_TWR"
           },
           {
             "label": ["OBBB", "CS", "345+"],

--- a/dataset/OE/stations.json
+++ b/dataset/OE/stations.json
@@ -221,24 +221,24 @@
       "controlled_by": ["OEDF_L_APP"]
     },
     {
-      "id": "OEDF_1_TWR",
+      "id": "OEDF_W_TWR",
       "parent_id": "OEDF_APP",
-      "controlled_by": ["OEDF_1_TWR"]
+      "controlled_by": ["OEDF_W_TWR"]
     },
     {
-      "id": "OEDF_2_TWR",
-      "parent_id": "OEDF_1_TWR",
-      "controlled_by": ["OEDF_2_TWR"]
+      "id": "OEDF_E_TWR",
+      "parent_id": "OEDF_W_TWR",
+      "controlled_by": ["OEDF_E_TWR"]
     },
     {
-      "id": "OEDF_1_GND",
-      "parent_id": "OEDF_1_TWR",
-      "controlled_by": ["OEDF_1_GND"]
+      "id": "OEDF_W_GND",
+      "parent_id": "OEDF_W_TWR",
+      "controlled_by": ["OEDF_W_GND"]
     },
     {
-      "id": "OEDF_2_GND",
-      "parent_id": "OEDF_1_GND",
-      "controlled_by": ["OEDF_2_GND"]
+      "id": "OEDF_E_GND",
+      "parent_id": "OEDF_W_GND",
+      "controlled_by": ["OEDF_E_GND"]
     },
     {
       "id": "OEMA_APP",


### PR DESCRIPTION
### Description

<!-- What does this PR change and why? -->
Updates OEDF logon callsigns inline with AIRAC 2607 changes

<img width="1534" height="1204" alt="image" src="https://github.com/user-attachments/assets/37c9f148-1082-4026-998f-f74fb9274afc" />


### AIRAC dependency

- [x] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
