### PR TITLE
EG 2607 changes & 2606 missed changes

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -1343,16 +1343,9 @@ facility_type = "CTR"
 profile_id = "EG-UK_ALL"
 
 [[positions]]
-id = "EGQL_APP"
+id = "EGQL_A_APP"
 prefixes = ["EGQL"]
 frequency = "126.505"
-facility_type = "APP"
-profile_id = "EG-Swanwick_Military"
-
-[[positions]]
-id = "EGQL_P_APP"
-prefixes = ["EGQL"]
-frequency = "123.300"
 facility_type = "APP"
 profile_id = "EG-Swanwick_Military"
 

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -2678,13 +2678,6 @@ facility_type = "TWR"
 profile_id = "EG-AFIS_AGCS"
 
 [[positions]]
-id = "EGBE_I_TWR"
-prefixes = ["EGBE"]
-frequency = "123.830"
-facility_type = "TWR"
-profile_id = "EG-AFIS_AGCS"
-
-[[positions]]
 id = "EGBF_R_TWR"
 prefixes = ["EGBF"]
 frequency = "119.030"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -1812,6 +1812,13 @@ facility_type = "TWR"
 profile_id = "EG-Swanwick_Military"
 
 [[positions]]
+id = "EGWC_GND"
+prefixes = ["EGWC"]
+frequency = "128.655"
+facility_type = "GND"
+profile_id = "EG-Swanwick_Military"
+
+[[positions]]
 id = "EGWU_APP"
 prefixes = ["EGWU"]
 frequency = "126.450"

--- a/dataset/EG/profiles/EGPX.json
+++ b/dataset/EG/profiles/EGPX.json
@@ -958,12 +958,10 @@
                   {
                     "label": ["QL", "Approach"],
                     "color": "azure",
-                    "station_id": "EGQL_APP"
+                    "station_id": "EGQL_A_APP"
                   },
                   {
-                    "label": ["QL", "Talkdown"],
-                    "color": "azure",
-                    "station_id": "EGQL_P_APP"
+                    "label": [""]
                   },
                   {
                     "label": ["QL", "Tower"],

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -1428,18 +1428,13 @@ parent_id = "EGPO_A_APP"
 controlled_by = ["EGPO_TWR"]
 
 [[stations]]
-id = "EGQL_APP"
+id = "EGQL_A_APP"
 parent_id = "EGVV_N_CTR"
-controlled_by = ["EGQL_APP", "EGQL_P_APP"]
-
-[[stations]]
-id = "EGQL_P_APP"
-parent_id = "EGQL_APP"
-controlled_by = ["EGQL_P_APP"]
+controlled_by = ["EGQL_A_APP"]
 
 [[stations]]
 id = "EGQL_TWR"
-parent_id = "EGQL_APP"
+parent_id = "EGQL_A_APP"
 controlled_by = ["EGQL_TWR"]
 
 [[stations]]


### PR DESCRIPTION
- Amends Leuchars (EGQL) positions (2607), and
- Adds changes missed in 2606, namely
    - Coventry (EGBE) removed.
    - Cosford (EGWC) Ground established.

## Profile capture

<img width="766" height="939" alt="image" src="https://github.com/user-attachments/assets/516a37fb-f5a1-4438-9e24-0bbadab47a0b" />
