### PR TITLE
Add East Midlands (EGNX)

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -1032,28 +1032,28 @@ id = "EGNX_APP"
 prefixes = ["EGNX"]
 frequency = "126.180"
 facility_type = "APP"
-profile_id = "EG-Central_LAG"
+profile_id = "EGNX"
 
 [[positions]]
 id = "EGNX_F_APP"
 prefixes = ["EGNX"]
 frequency = "120.130"
 facility_type = "APP"
-profile_id = "EG-Central_LAG"
+profile_id = "EGNX"
 
 [[positions]]
 id = "EGNX_TWR"
 prefixes = ["EGNX"]
 frequency = "124.005"
 facility_type = "TWR"
-profile_id = "EG-Central_LAG"
+profile_id = "EGNX"
 
 [[positions]]
 id = "EGNX_GND"
 prefixes = ["EGNX"]
 frequency = "121.905"
 facility_type = "GND"
-profile_id = "EG-Central_LAG"
+profile_id = "EGNX"
 
 [[positions]]
 id = "EGOE_TWR"

--- a/dataset/EG/profiles/EGNX.json
+++ b/dataset/EG/profiles/EGNX.json
@@ -67,7 +67,7 @@
           {
             "label": ["INT"],
             "station_id": "EGNX_APP"
-          },          
+          },
           {
             "label": []
           },
@@ -89,7 +89,7 @@
           {
             "label": [],
             "station_id": ""
-          },          
+          },
           {
             "label": ["PC", "SE"],
             "station_id": "MAN_SE_CTR"
@@ -103,15 +103,15 @@
             "label": []
           },
           {
-            "label": ["CC","INT"],
+            "label": ["CC", "INT"],
             "station_id": "EGCC_S_APP"
           },
           {
-            "label": ["BB","RAD"],
+            "label": ["BB", "RAD"],
             "station_id": "EGBB_APP"
-          },          
+          },
           {
-            "label": ["PC","NE"],
+            "label": ["PC", "NE"],
             "station_id": "MAN_E_CTR"
           },
           {
@@ -134,7 +134,7 @@
       }
     },
     {
-"label": ["SUP", "Flow"],
+      "label": ["SUP", "Flow"],
       "page": {
         "rows": 4,
         "keys": [
@@ -153,7 +153,7 @@
           {
             "label": ["UK", "FMP", "3"],
             "station_id": "UK_B_FMP"
-          },          
+          },
           {
             "label": ["MAN", "GS"],
             "station_id": "MAN_GS_CTR"

--- a/dataset/EG/profiles/EGNX.json
+++ b/dataset/EG/profiles/EGNX.json
@@ -7,7 +7,6 @@
       "page": {
         "rows": 5,
         "keys": [
-
           {
             "label": ["GMC"],
             "station_id": "EGNX_GND"

--- a/dataset/EG/profiles/EGNX.json
+++ b/dataset/EG/profiles/EGNX.json
@@ -1,0 +1,177 @@
+{
+  "id": "EGNX",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": "EGNX",
+      "page": {
+        "rows": 5,
+        "keys": [
+          {
+            "label": [""],
+            "station_id": ""
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": [""],
+            "station_id": ""
+          },
+          {
+            "label": [""],
+            "station_id": ""
+          },
+          {
+            "label": ["GMC"],
+            "station_id": "EGNX_GND"
+          },
+          {
+            "label": [""]
+          },
+          {
+            "label": ["AIR"],
+            "station_id": "EGNX_TWR"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["FIN"],
+            "station_id": "EGNX_F_APP"
+          },
+          {
+            "label": ["INT"],
+            "station_id": "EGNX_APP"
+          },          
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": [],
+            "station_id": ""
+          },          
+          {
+            "label": ["PC", "SE"],
+            "station_id": "MAN_SE_CTR"
+          },
+          {
+            "label": ["TC", "MIDS"],
+            "station_id": "LTC_M_CTR"
+          },
+
+          {
+            "label": []
+          },
+          {
+            "label": ["CC","INT"],
+            "station_id": "EGCC_S_APP"
+          },
+          {
+            "label": ["BB","RAD"],
+            "station_id": "EGBB_APP"
+          },          
+          {
+            "label": ["PC","NE"],
+            "station_id": "MAN_E_CTR"
+          },
+          {
+            "label": [""],
+            "station_id": ""
+          },
+
+          {
+            "label": []
+          },
+          {
+            "label": [""],
+            "station_id": ""
+          },
+          {
+            "label": [""],
+            "station_id": ""
+          }
+        ]
+      }
+    },
+    {
+"label": ["SUP", "Flow"],
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": ["UK", "FMP"],
+            "station_id": "UK_FMP"
+          },
+          {
+            "label": ["LTC", "FMP"],
+            "station_id": "LTC_FMP"
+          },
+          {
+            "label": ["UK", "FMP", "2"],
+            "station_id": "UK_A_FMP"
+          },
+          {
+            "label": ["UK", "FMP", "3"],
+            "station_id": "UK_B_FMP"
+          },          
+          {
+            "label": ["MAN", "GS"],
+            "station_id": "MAN_GS_CTR"
+          },
+          {
+            "label": ["MAN", "FMP"],
+            "station_id": "MAN_FMP"
+          },
+          {
+            "label": ["LAC", "GS"],
+            "station_id": "LON_GS_CTR"
+          },
+          {
+            "label": ["LTC", "GS"],
+            "station_id": "LTC_GS_CTR"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dataset/EG/profiles/EGNX.json
+++ b/dataset/EG/profiles/EGNX.json
@@ -7,21 +7,7 @@
       "page": {
         "rows": 5,
         "keys": [
-          {
-            "label": [""]
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": [""]
-          },
-          {
-            "label": [""]
-          },
+
           {
             "label": ["GMC"],
             "station_id": "EGNX_GND"

--- a/dataset/EG/profiles/EGNX.json
+++ b/dataset/EG/profiles/EGNX.json
@@ -8,8 +8,7 @@
         "rows": 5,
         "keys": [
           {
-            "label": [""],
-            "station_id": ""
+            "label": [""]
           },
           {
             "label": []
@@ -18,12 +17,10 @@
             "label": []
           },
           {
-            "label": [""],
-            "station_id": ""
+            "label": [""]
           },
           {
-            "label": [""],
-            "station_id": ""
+            "label": [""]
           },
           {
             "label": ["GMC"],
@@ -87,8 +84,7 @@
             "label": []
           },
           {
-            "label": [],
-            "station_id": ""
+            "label": []
           },
           {
             "label": ["PC", "SE"],
@@ -115,20 +111,17 @@
             "station_id": "MAN_E_CTR"
           },
           {
-            "label": [""],
-            "station_id": ""
+            "label": [""]
           },
 
           {
             "label": []
           },
           {
-            "label": [""],
-            "station_id": ""
+            "label": [""]
           },
           {
-            "label": [""],
-            "station_id": ""
+            "label": [""]
           }
         ]
       }

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -1258,6 +1258,16 @@ parent_id = "EGNV_APP"
 controlled_by = ["EGNV_F_APP"]
 
 [[stations]]
+id = "EGNX_GND"
+parent_id = "EGNX_TWR"
+controlled_by = ["EGNX_GND"]
+
+[[stations]]
+id = "EGNX_TWR"
+parent_id = "EGNX_APP"
+controlled_by = ["EGNX_TWR"]
+
+[[stations]]
 id = "EGNX_APP"
 parent_id = "LTC_MW_CTR"
 controlled_by = ["EGNX_APP", "EGNX_F_APP"]


### PR DESCRIPTION
### Description
Add a profile for East Midlands (EGNX)

<img width="767" height="452" alt="image" src="https://github.com/user-attachments/assets/cb2d3a18-eecb-4aa1-b3a7-fba5f30a3e56" />

Aerodrome

<img width="242" height="464" alt="image" src="https://github.com/user-attachments/assets/415a4b9f-64f7-41e8-8550-fbc791406913" />

Flow

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
