### PR TITLE
EISN Update

### DIFF
--- a/dataset/EI/positions.toml
+++ b/dataset/EI/positions.toml
@@ -246,7 +246,7 @@ profile_id = "EISG"
 [[positions]]
 id = "EIWF_TWR"
 prefixes = ["EIWF"]
-frequency = "129.850"
+frequency = "129.855"
 facility_type = "TWR"
 profile_id = "EIWF"
 
@@ -288,7 +288,7 @@ profile_id = "EIKN"
 [[positions]]
 id = "EIWF_GND"
 prefixes = ["EIWF"]
-frequency = "121.600"
+frequency = "121.605"
 facility_type = "GND"
 profile_id = "EIWF"
 

--- a/dataset/EI/positions.toml
+++ b/dataset/EI/positions.toml
@@ -139,6 +139,13 @@ facility_type = "CTR"
 profile_id = "EISN"
 
 [[positions]]
+id = "MUNSTER_APP"
+prefixes = ["MUNSTER"]
+frequency = "120.200"
+facility_type = "APP"
+profile_id = "MUNSTER"
+
+[[positions]]
 id = "EICK_APP"
 prefixes = ["EICK"]
 frequency = "119.900"
@@ -148,7 +155,7 @@ profile_id = "EICK"
 [[positions]]
 id = "EIDW_APP"
 prefixes = ["EIDW"]
-frequency = "121.100"
+frequency = "121.105"
 facility_type = "APP"
 profile_id = "EIDW_ACC"
 
@@ -190,7 +197,7 @@ profile_id = "EIDL"
 [[positions]]
 id = "EIDW_S_TWR"
 prefixes = ["EIDW"]
-frequency = "118.600"
+frequency = "118.605"
 facility_type = "TWR"
 profile_id = "EIDW_VCT"
 
@@ -246,7 +253,7 @@ profile_id = "EIWF"
 [[positions]]
 id = "EIWT_TWR"
 prefixes = ["EIWT"]
-frequency = "122.400"
+frequency = "122.405"
 facility_type = "TWR"
 profile_id = "EIWT"
 
@@ -260,7 +267,7 @@ profile_id = "EICK"
 [[positions]]
 id = "EIDW_S_GND"
 prefixes = ["EIDW"]
-frequency = "121.800"
+frequency = "121.805"
 facility_type = "GND"
 profile_id = "EIDW_VCT"
 
@@ -309,7 +316,7 @@ profile_id = "EINN"
 [[positions]]
 id = "EIWT_GND"
 prefixes = ["EIWT"]
-frequency = "119.425"
+frequency = "119.430"
 facility_type = "GND"
 profile_id = "EIWT"
 

--- a/dataset/EI/profiles/MUNSTER.json
+++ b/dataset/EI/profiles/MUNSTER.json
@@ -1,0 +1,59 @@
+{
+  "id": "MUNSTER",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["MUNSTER"],
+      "page": {
+        "rows": 3,
+        "keys": [
+          {
+            "label": ["EINN", "APP"],
+            "color": "lilac",
+            "station_id": "EINN_APP"
+          },
+          {
+            "label": ["EICK", "APP", ""],
+            "color": "blush",
+            "station_id": "EICK_APP"
+          },
+          {
+            "label": ["EISN", "", ""],
+            "color": "mint",
+            "station_id": "EISN_LS_CTR"
+          },
+          {
+            "label": ["EINN", "TWR"],
+            "color": "lilac",
+            "station_id": "EINN_TWR"
+          },
+          {
+            "label": ["EICK", "TWR"],
+            "color": "blush",
+            "station_id": "EICK_TWR"
+          },
+          {
+            "label": ["FIS"],
+            "color": "mint",
+            "station_id": "EISN_I_CTR"
+          },
+          {
+            "label": ["EINN", "GND"],
+            "color": "lilac",
+            "station_id": "EINN_GND"
+          },
+          {
+            "label": ["EICK", "GND"],
+            "color": "blush",
+            "station_id": "EICK_GND"
+          },
+          {
+            "label": ["EIKY"],
+            "color": "snow",
+            "station_id": "EIKY_TWR"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dataset/EI/stations.toml
+++ b/dataset/EI/stations.toml
@@ -74,7 +74,7 @@ parent_id = "EINN_APP"
 [[stations]]
 id = "EINN_APP"
 controlled_by = ["EINN_APP"]
-parent_id = "EISN_LS_CTR"
+parent_id = "MUNSTER_APP"
 
 ### EICK ###
 
@@ -91,6 +91,13 @@ parent_id = "EICK_APP"
 [[stations]]
 id = "EICK_APP"
 controlled_by = ["EICK_APP"]
+parent_id = "MUNSTER_APP"
+
+### MUNSTER ###
+
+[[stations]]
+id = "MUNSTER_APP"
+controlled_by = ["MUNSTER_APP"]
 parent_id = "EISN_LS_CTR"
 
 ### EIME ###
@@ -120,7 +127,7 @@ parent_id = "EISN_LN_CTR"
 [[stations]]
 id = "EIKY_TWR"
 controlled_by = ["EIKY_TWR"]
-parent_id = "EISN_LS_CTR"
+parent_id = "MUNSTER_APP"
 
 [[stations]]
 id = "EISG_TWR"


### PR DESCRIPTION
### Description
- Update freqs to 8.33 kHz spacing
- Introduce new Munster Radar position and associated profile

### AIRAC dependency

- [x] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
