### PR TITLE
LKAA AIRAC 2608 - Added positions NS, WU, renamed FIC

### DIFF
--- a/dataset/LK/positions.toml
+++ b/dataset/LK/positions.toml
@@ -65,7 +65,7 @@ profile_id = "LKAA"
 id = "LKAA_FIC_FSS"
 prefixes = ["LKAA"]
 frequency = "126.100"
-facility_type = "CTR"
+facility_type = "FSS"
 profile_id = "LKAA"
 
 [[positions]]

--- a/dataset/LK/positions.toml
+++ b/dataset/LK/positions.toml
@@ -41,6 +41,13 @@ facility_type = "CTR"
 profile_id = "LKAA"
 
 [[positions]]
+id = "LKAA_NS_CTR"
+prefixes = ["LKAA"]
+frequency = "132.890"
+facility_type = "CTR"
+profile_id = "LKAA"
+
+[[positions]]
 id = "LKAA_W_CTR"
 prefixes = ["LKAA"]
 frequency = "120.275"
@@ -48,7 +55,14 @@ facility_type = "CTR"
 profile_id = "LKAA"
 
 [[positions]]
-id = "LKAA_I_CTR"
+id = "LKAA_WU_CTR"
+prefixes = ["LKAA"]
+frequency = "132.065"
+facility_type = "CTR"
+profile_id = "LKAA"
+
+[[positions]]
+id = "LKAA_FIC_FSS"
 prefixes = ["LKAA"]
 frequency = "126.100"
 facility_type = "CTR"

--- a/dataset/LK/stations.toml
+++ b/dataset/LK/stations.toml
@@ -54,7 +54,7 @@ controlled_by = ["LKAA_U_CTR", "LKAA_S_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA FIC"
-controlled_by = ["LKAA_I_CTR"]
+controlled_by = ["LKAA_FIC_FSS"]
 
 [[stations]]
 id = "LKPR ARR"

--- a/dataset/LK/stations.toml
+++ b/dataset/LK/stations.toml
@@ -5,16 +5,17 @@ controlled_by = [
   "LKAA_R_CTR",
   "LKAA_W_CTR",
   "LKAA_L_CTR",
+  "LKAA_WU_CTR",
   "LKAA_CTR",
 ]
 
 [[stations]]
 id = "LKAA WL"
-controlled_by = ["LKAA_W_CTR", "LKAA_L_CTR", "LKAA_CTR"]
+controlled_by = ["LKAA_W_CTR", "LKAA_L_CTR", "LKAA_WU_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA WU"
-controlled_by = ["LKAA_U_CTR", "LKAA_W_CTR", "LKAA_CTR"]
+controlled_by = ["LKAA_WU_CTR", "LKAA_U_CTR", "LKAA_W_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA MT"
@@ -22,17 +23,18 @@ controlled_by = [
   "LKMT_APP",
   "LKAA_R_CTR",
   "LKAA_N_CTR",
+  "LKAA_NS_CTR",
   "LKAA_L_CTR",
   "LKAA_CTR",
 ]
 
 [[stations]]
 id = "LKAA NL"
-controlled_by = ["LKAA_N_CTR", "LKAA_L_CTR", "LKAA_CTR"]
+controlled_by = ["LKAA_N_CTR", "LKAA_NS_CTR", "LKAA_L_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA NU"
-controlled_by = ["LKAA_U_CTR", "LKAA_N_CTR", "LKAA_CTR"]
+controlled_by = ["LKAA_U_CTR", "LKAA_N_CTR", "LKAA_NS_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA TB"
@@ -40,17 +42,18 @@ controlled_by = [
   "LKTB_APP",
   "LKAA_R_CTR",
   "LKAA_S_CTR",
+  "LKAA_NS_CTR",
   "LKAA_L_CTR",
   "LKAA_CTR",
 ]
 
 [[stations]]
 id = "LKAA SL"
-controlled_by = ["LKAA_S_CTR", "LKAA_L_CTR", "LKAA_CTR"]
+controlled_by = ["LKAA_S_CTR", "LKAA_NS_CTR", "LKAA_L_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA SU"
-controlled_by = ["LKAA_U_CTR", "LKAA_S_CTR", "LKAA_CTR"]
+controlled_by = ["LKAA_U_CTR", "LKAA_S_CTR", "LKAA_NS_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA FIC"


### PR DESCRIPTION
New positions LKAA_NS_CTR and LKAA_WU_CTR added.
Position LKAA_I_CTR renamed to LKAA_FIC_FSS.

### Description

New positions LKAA_NS_CTR and LKAA_WU_CTR added.
Position LKAA_I_CTR renamed to LKAA_FIC_FSS.


### AIRAC dependency

- [x] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
