### PR TITLE
Updated stations to reflect changes in positions.toml

### DIFF
--- a/dataset/LK/stations.toml
+++ b/dataset/LK/stations.toml
@@ -11,21 +11,11 @@ controlled_by = [
 
 [[stations]]
 id = "LKAA WL"
-controlled_by = [
-  "LKAA_W_CTR", 
-  "LKAA_L_CTR", 
-  "LKAA_WU_CTR",
-  "LKAA_CTR"
-]
+controlled_by = ["LKAA_W_CTR", "LKAA_L_CTR", "LKAA_WU_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA WU"
-controlled_by = [
-  "LKAA_WU_CTR",
-  "LKAA_U_CTR",
-  "LKAA_W_CTR",
-  "LKAA_CTR"
-]
+controlled_by = ["LKAA_WU_CTR", "LKAA_U_CTR", "LKAA_W_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA MT"
@@ -40,21 +30,11 @@ controlled_by = [
 
 [[stations]]
 id = "LKAA NL"
-controlled_by = [
-  "LKAA_N_CTR",
-  "LKAA_NS_CTR",
-  "LKAA_L_CTR",
-  "LKAA_CTR"
-]
+controlled_by = ["LKAA_N_CTR", "LKAA_NS_CTR", "LKAA_L_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA NU"
-controlled_by = [
-  "LKAA_U_CTR",
-  "LKAA_N_CTR",
-  "LKAA_NS_CTR",
-  "LKAA_CTR"
-]
+controlled_by = ["LKAA_U_CTR", "LKAA_N_CTR", "LKAA_NS_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA TB"
@@ -69,63 +49,31 @@ controlled_by = [
 
 [[stations]]
 id = "LKAA SL"
-controlled_by = [
-  "LKAA_S_CTR",
-  "LKAA_NS_CTR",
-  "LKAA_L_CTR",
-  "LKAA_CTR"
-]
+controlled_by = ["LKAA_S_CTR", "LKAA_NS_CTR", "LKAA_L_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA SU"
-controlled_by = [
-  "LKAA_U_CTR",
-  "LKAA_S_CTR",
-  "LKAA_NS_CTR",
-  "LKAA_CTR"
-]
+controlled_by = ["LKAA_U_CTR", "LKAA_S_CTR", "LKAA_NS_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKAA FIC"
-controlled_by = [
-  "LKAA_FIC_FSS"
-]
+controlled_by = ["LKAA_FIC_FSS"]
 
 [[stations]]
 id = "LKPR ARR"
-controlled_by = [
-  "LKPR_APP",
-  "LKAA_L_CTR",
-  "LKAA_CTR"
-]
+controlled_by = ["LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKPR DEP"
-controlled_by = [
-  "LKPR_DEP",
-  "LKPR_APP",
-  "LKAA_L_CTR",
-  "LKAA_CTR"
-]
+controlled_by = ["LKPR_DEP", "LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKPR DIR"
-controlled_by = [
-  "LKPR_D_APP",
-  "LKPR_APP",
-  "LKAA_L_CTR",
-  "LKAA_CTR"
-]
+controlled_by = ["LKPR_D_APP", "LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKPR TWR"
-controlled_by = [
-  "LKPR_TWR",
-  "LKPR_D_APP",
-  "LKPR_APP",
-  "LKAA_L_CTR",
-  "LKAA_CTR"
-]
+controlled_by = ["LKPR_TWR", "LKPR_D_APP", "LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
 
 [[stations]]
 id = "LKPR GND"
@@ -221,29 +169,19 @@ controlled_by = [
 
 [[stations]]
 id = "LKKB APP"
-controlled_by = [
-  "LKKB_APP"
-]
+controlled_by = ["LKKB_APP"]
 
 [[stations]]
 id = "LKKB TWR"
-controlled_by = [
-  "LKKB_TWR",
-  "LKKB_APP"
-]
+controlled_by = ["LKKB_TWR", "LKKB_APP"]
 
 [[stations]]
 id = "LKVO APP"
-controlled_by = [
-  "LKVO_APP"
-]
+controlled_by = ["LKVO_APP"]
 
 [[stations]]
 id = "LKVO TWR"
-controlled_by = [
-  "LKVO_TWR", 
-  "LKVO_APP"
-]
+controlled_by = ["LKVO_TWR", "LKVO_APP"]
 
 [[stations]]
 id = "LKKV TWR"
@@ -291,12 +229,8 @@ controlled_by = [
 
 [[stations]]
 id = "LKCS AFIS"
-controlled_by = [
-  "LKCS_I_TWR"
-]
+controlled_by = ["LKCS_I_TWR"]
 
 [[stations]]
 id = "LKLT RDO"
-controlled_by = [
-  "LKLT_I_TWR"
-]
+controlled_by = ["LKLT_I_TWR"]

--- a/dataset/LK/stations.toml
+++ b/dataset/LK/stations.toml
@@ -5,16 +5,27 @@ controlled_by = [
   "LKAA_R_CTR",
   "LKAA_W_CTR",
   "LKAA_L_CTR",
+  "LKAA_WU_CTR",
   "LKAA_CTR",
 ]
 
 [[stations]]
 id = "LKAA WL"
-controlled_by = ["LKAA_W_CTR", "LKAA_L_CTR", "LKAA_CTR"]
+controlled_by = [
+  "LKAA_W_CTR", 
+  "LKAA_L_CTR", 
+  "LKAA_WU_CTR",
+  "LKAA_CTR"
+]
 
 [[stations]]
 id = "LKAA WU"
-controlled_by = ["LKAA_U_CTR", "LKAA_W_CTR", "LKAA_CTR"]
+controlled_by = [
+  "LKAA_WU_CTR",
+  "LKAA_U_CTR",
+  "LKAA_W_CTR",
+  "LKAA_CTR"
+]
 
 [[stations]]
 id = "LKAA MT"
@@ -22,17 +33,28 @@ controlled_by = [
   "LKMT_APP",
   "LKAA_R_CTR",
   "LKAA_N_CTR",
+  "LKAA_NS_CTR",
   "LKAA_L_CTR",
   "LKAA_CTR",
 ]
 
 [[stations]]
 id = "LKAA NL"
-controlled_by = ["LKAA_N_CTR", "LKAA_L_CTR", "LKAA_CTR"]
+controlled_by = [
+  "LKAA_N_CTR",
+  "LKAA_NS_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR"
+]
 
 [[stations]]
 id = "LKAA NU"
-controlled_by = ["LKAA_U_CTR", "LKAA_N_CTR", "LKAA_CTR"]
+controlled_by = [
+  "LKAA_U_CTR",
+  "LKAA_N_CTR",
+  "LKAA_NS_CTR",
+  "LKAA_CTR"
+]
 
 [[stations]]
 id = "LKAA TB"
@@ -40,37 +62,70 @@ controlled_by = [
   "LKTB_APP",
   "LKAA_R_CTR",
   "LKAA_S_CTR",
+  "LKAA_NS_CTR",
   "LKAA_L_CTR",
   "LKAA_CTR",
 ]
 
 [[stations]]
 id = "LKAA SL"
-controlled_by = ["LKAA_S_CTR", "LKAA_L_CTR", "LKAA_CTR"]
+controlled_by = [
+  "LKAA_S_CTR",
+  "LKAA_NS_CTR",
+  "LKAA_L_CTR",
+  "LKAA_CTR"
+]
 
 [[stations]]
 id = "LKAA SU"
-controlled_by = ["LKAA_U_CTR", "LKAA_S_CTR", "LKAA_CTR"]
+controlled_by = [
+  "LKAA_U_CTR",
+  "LKAA_S_CTR",
+  "LKAA_NS_CTR",
+  "LKAA_CTR"
+]
 
 [[stations]]
 id = "LKAA FIC"
-controlled_by = ["LKAA_I_CTR"]
+controlled_by = [
+  "LKAA_FIC_FSS"
+]
 
 [[stations]]
 id = "LKPR ARR"
-controlled_by = ["LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
+controlled_by = [
+  "LKPR_APP",
+  "LKAA_L_CTR",
+  "LKAA_CTR"
+]
 
 [[stations]]
 id = "LKPR DEP"
-controlled_by = ["LKPR_DEP", "LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
+controlled_by = [
+  "LKPR_DEP",
+  "LKPR_APP",
+  "LKAA_L_CTR",
+  "LKAA_CTR"
+]
 
 [[stations]]
 id = "LKPR DIR"
-controlled_by = ["LKPR_D_APP", "LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
+controlled_by = [
+  "LKPR_D_APP",
+  "LKPR_APP",
+  "LKAA_L_CTR",
+  "LKAA_CTR"
+]
 
 [[stations]]
 id = "LKPR TWR"
-controlled_by = ["LKPR_TWR", "LKPR_D_APP", "LKPR_APP", "LKAA_L_CTR", "LKAA_CTR"]
+controlled_by = [
+  "LKPR_TWR",
+  "LKPR_D_APP",
+  "LKPR_APP",
+  "LKAA_L_CTR",
+  "LKAA_CTR"
+]
 
 [[stations]]
 id = "LKPR GND"
@@ -166,19 +221,29 @@ controlled_by = [
 
 [[stations]]
 id = "LKKB APP"
-controlled_by = ["LKKB_APP"]
+controlled_by = [
+  "LKKB_APP"
+]
 
 [[stations]]
 id = "LKKB TWR"
-controlled_by = ["LKKB_TWR", "LKKB_APP"]
+controlled_by = [
+  "LKKB_TWR",
+  "LKKB_APP"
+]
 
 [[stations]]
 id = "LKVO APP"
-controlled_by = ["LKVO_APP"]
+controlled_by = [
+  "LKVO_APP"
+]
 
 [[stations]]
 id = "LKVO TWR"
-controlled_by = ["LKVO_TWR", "LKVO_APP"]
+controlled_by = [
+  "LKVO_TWR", 
+  "LKVO_APP"
+]
 
 [[stations]]
 id = "LKKV TWR"
@@ -226,8 +291,12 @@ controlled_by = [
 
 [[stations]]
 id = "LKCS AFIS"
-controlled_by = ["LKCS_I_TWR"]
+controlled_by = [
+  "LKCS_I_TWR"
+]
 
 [[stations]]
 id = "LKLT RDO"
-controlled_by = ["LKLT_I_TWR"]
+controlled_by = [
+  "LKLT_I_TWR"
+]


### PR DESCRIPTION
### Description

New positions LKAA_NS_CTR and LKAA_WU_CTR added.
LKAA_I_CTR renamed to LKAA_FIC_FSS.

Concerned stations were updated according to the new sector ownership rules.

### AIRAC dependency

- [x] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
