### PR TITLE
Remove empty label entry from OMDB.json, fixing formatting issue.

### DIFF
--- a/dataset/OM/profiles/OMDB.json
+++ b/dataset/OM/profiles/OMDB.json
@@ -24,9 +24,6 @@
             "station_id": "OMDB_2_GND"
           },
           {
-            "label": []
-          },
-          {
             "label": ["AIR 1 N"],
             "station_id": "OMDB_1_TWR"
           },


### PR DESCRIPTION
### Description

Removed an empty label entry from OMDB.json.

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
