### PR TITLE
feat(LO): add Salzburg Arrival position & station

### DIFF
--- a/dataset/LO/positions.json
+++ b/dataset/LO/positions.json
@@ -355,6 +355,14 @@
       "default_call_sources": ["LOWS_APP"]
     },
     {
+      "id": "LOWS_F_APP",
+      "prefixes": ["LOWS"],
+      "frequency": "132.460",
+      "facility_type": "APP",
+      "profile_id": "LOVV",
+      "default_call_sources": ["LOWS_F_APP"]
+    },
+    {
       "id": "LOWW_APP",
       "prefixes": ["LOWW"],
       "frequency": "134.675",

--- a/dataset/LO/positions.toml
+++ b/dataset/LO/positions.toml
@@ -338,6 +338,14 @@ profile_id = "LOVV"
 default_call_sources = ["LOWS_APP"]
 
 [[positions]]
+id = "LOWS_F_APP"
+prefixes = ["LOWS"]
+frequency = "132.460"
+facility_type = "APP"
+profile_id = "LOVV"
+default_call_sources = ["LOWS_F_APP"]
+
+[[positions]]
 id = "LOWW_APP"
 prefixes = ["LOWW"]
 frequency = "134.675"

--- a/dataset/LO/profiles/LOVV.json
+++ b/dataset/LO/profiles/LOVV.json
@@ -362,11 +362,12 @@
                         "label": []
                       },
                       {
-                        "label": []
-                      },
-                      {
                         "label": ["LOWS", "APP", "PLC"],
                         "station_id": "LOWS_APP"
+                      },
+                      {
+                        "label": ["LOWS", "DIR", "PLC"],
+                        "station_id": "LOWS_F_APP"
                       },
                       {
                         "label": ["LOWS", "TWR", "PLC"],

--- a/dataset/LO/stations.json
+++ b/dataset/LO/stations.json
@@ -375,6 +375,11 @@
       ]
     },
     {
+      "id": "LOWS_F_APP",
+      "parent_id": "LOWS_APP",
+      "controlled_by": ["LOWS_F_APP"]
+    },
+    {
       "id": "LOWS_TWR",
       "parent_id": "LOWS_APP",
       "controlled_by": ["LOWS_TWR"]

--- a/dataset/LO/stations.toml
+++ b/dataset/LO/stations.toml
@@ -373,6 +373,11 @@ controlled_by = [
 ]
 
 [[stations]]
+id = "LOWS_F_APP"
+parent_id = "LOWS_APP"
+controlled_by = ["LOWS_F_APP"]
+
+[[stations]]
 id = "LOWS_TWR"
 parent_id = "LOWS_APP"
 controlled_by = ["LOWS_TWR"]


### PR DESCRIPTION
### Description

Add Salzburg Arrival position and station
Add LOWS_F_APP to LOVV profile

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [X] Dataset files are in the correct `dataset/{FIR}/` directory.
- [X] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
