### PR TITLE
Remove unused PRC positions

### DIFF
--- a/dataset/RCAA/profiles/RCAA.json
+++ b/dataset/RCAA/profiles/RCAA.json
@@ -375,10 +375,6 @@
             "station_id": "MNL_N_CTR"
           },
           {
-            "label": ["ZSHA", "CTR"],
-            "station_id": "ZSHA_CTR"
-          },
-          {
             "label": ["ZSSS", "S_CTR"],
             "station_id": "ZSSS_S_CTR"
           },
@@ -393,6 +389,9 @@
           {
             "label": ["ZGGG", "CTR"],
             "station_id": "ZGGG_CTR"
+          },
+          {
+            "label": []
           },
           {
             "label": []

--- a/dataset/VH/positions.json
+++ b/dataset/VH/positions.json
@@ -328,13 +328,6 @@
       "profile_id": "VHHK"
     },
     {
-      "id": "ZBBB_FSS",
-      "prefixes": ["PRC"],
-      "frequency": "133.075",
-      "facility_type": "FSS",
-      "profile_id": "VHHK"
-    },
-    {
       "id": "ZSSS_S_CTR",
       "prefixes": ["ZSSS"],
       "frequency": "120.900",
@@ -349,23 +342,9 @@
       "profile_id": "VHHK"
     },
     {
-      "id": "ZSHA_CTR",
-      "prefixes": ["ZSHA"],
-      "frequency": "124.550",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
       "id": "ZSAM_CTR",
       "prefixes": ["ZSAM"],
       "frequency": "125.700",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "ZJSA_CTR",
-      "prefixes": ["ZJSA"],
-      "frequency": "120.500",
       "facility_type": "CTR",
       "profile_id": "VHHK"
     },
@@ -380,13 +359,6 @@
       "id": "ZJSY_O_CTR",
       "prefixes": ["ZJSY"],
       "frequency": "130.200",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "ZGZU_CTR",
-      "prefixes": ["ZGZU"],
-      "frequency": "132.750",
       "facility_type": "CTR",
       "profile_id": "VHHK"
     },
@@ -423,13 +395,6 @@
       "prefixes": ["ZGGG"],
       "frequency": "128.350",
       "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "ZGGG_APP",
-      "prefixes": ["ZGGG"],
-      "frequency": "126.550",
-      "facility_type": "APP",
       "profile_id": "VHHK"
     }
   ]

--- a/dataset/VH/profiles/VHHK.json
+++ b/dataset/VH/profiles/VHHK.json
@@ -441,34 +441,6 @@
             "station_id": "MNL_CTR"
           },
           {
-            "label": ["ZGZU"],
-            "station_id": "ZGZU_CTR"
-          },
-          {
-            "label": ["ZJSA"],
-            "station_id": "ZJSA_CTR"
-          },
-          {
-            "label": ["ZSHA"],
-            "station_id": "ZSHA_CTR"
-          },
-          {
-            "label": ["ASEA"],
-            "station_id": "ASEA_FSS"
-          },
-          {
-            "label": ["PRC"],
-            "station_id": "ZBBB_FSS"
-          },
-          {
-            "label": ["RCTP-L"],
-            "station_id": "ALR"
-          },
-          {
-            "label": ["RPHI-N"],
-            "station_id": "MNL_N_CTR"
-          },
-          {
             "label": ["ZGGG"],
             "station_id": "ZGGG_CTR"
           },
@@ -481,18 +453,19 @@
             "station_id": "ZSSS_CTR"
           },
           {
-            "label": []
+            "label": ["ASEA"],
+            "station_id": "ASEA_FSS"
           },
           {
             "label": []
           },
           {
-            "label": ["RCTP-E"],
-            "station_id": "AER"
+            "label": ["RCTP-L"],
+            "station_id": "ALR"
           },
           {
-            "label": ["RPHI-NW"],
-            "station_id": "MNL_NW_CTR"
+            "label": ["RPHI-N"],
+            "station_id": "MNL_N_CTR"
           },
           {
             "label": ["ZGNN"],
@@ -513,11 +486,12 @@
             "label": []
           },
           {
-            "label": ["RCTP-N"],
-            "station_id": "ANR"
+            "label": ["RCTP-E"],
+            "station_id": "AER"
           },
           {
-            "label": []
+            "label": ["RPHI-NW"],
+            "station_id": "MNL_NW_CTR"
           },
           {
             "label": ["ZGJD"],
@@ -537,8 +511,8 @@
             "label": []
           },
           {
-            "label": ["RCTP-S"],
-            "station_id": "ASR"
+            "label": ["RCTP-N"],
+            "station_id": "ANR"
           },
           {
             "label": []
@@ -560,7 +534,8 @@
             "label": []
           },
           {
-            "label": []
+            "label": ["RCTP-S"],
+            "station_id": "ASR"
           },
           {
             "label": []
@@ -568,6 +543,27 @@
           {
             "label": ["ZGZJ"],
             "station_id": "ZGZJ_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
           },
           {
             "label": []

--- a/dataset/VH/stations.json
+++ b/dataset/VH/stations.json
@@ -204,10 +204,6 @@
       "controlled_by": ["ASEA_FSS"]
     },
     {
-      "id": "ZBBB_FSS",
-      "controlled_by": ["ZBBB_FSS"]
-    },
-    {
       "id": "ZSSS_S_CTR",
       "parent_id": "ZSSS_CTR",
       "controlled_by": ["ZSSS_S_CTR"]
@@ -218,17 +214,9 @@
       "controlled_by": ["ZSSS_CTR"]
     },
     {
-      "id": "ZSHA_CTR",
-      "controlled_by": ["ZSHA_CTR"]
-    },
-    {
       "id": "ZSAM_CTR",
       "parent_id": "ZSHA_CTR",
       "controlled_by": ["ZSAM_CTR"]
-    },
-    {
-      "id": "ZJSA_CTR",
-      "controlled_by": ["ZJSA_CTR"]
     },
     {
       "id": "ZJSY_L_CTR",
@@ -239,10 +227,6 @@
       "id": "ZJSY_O_CTR",
       "parent_id": "ZJSA_CTR",
       "controlled_by": ["ZJSY_O_CTR"]
-    },
-    {
-      "id": "ZGZU_CTR",
-      "controlled_by": ["ZGZU_CTR"]
     },
     {
       "id": "ZGNN_CTR",
@@ -273,11 +257,6 @@
       "id": "ZGGG_CTR",
       "parent_id": "ZGZU_CTR",
       "controlled_by": ["ZGGG_CTR"]
-    },
-    {
-      "id": "ZGGG_APP",
-      "parent_id": "ZGGG_CTR",
-      "controlled_by": ["ZGGG_APP"]
     }
   ]
 }

--- a/dataset/VH/stations.json
+++ b/dataset/VH/stations.json
@@ -235,11 +235,7 @@
     },
     {
       "id": "ZGOW_APP",
-      "controlled_by": [
-        "ZGOW_APP",
-        "ZGGG_CTR",
-        "ZSAM_CTR"
-      ]
+      "controlled_by": ["ZGOW_APP", "ZGGG_CTR", "ZSAM_CTR"]
     },
     {
       "id": "ZGJD_APP",

--- a/dataset/VH/stations.json
+++ b/dataset/VH/stations.json
@@ -210,27 +210,22 @@
     },
     {
       "id": "ZSSS_CTR",
-      "parent_id": "ZSHA_CTR",
       "controlled_by": ["ZSSS_CTR"]
     },
     {
       "id": "ZSAM_CTR",
-      "parent_id": "ZSHA_CTR",
       "controlled_by": ["ZSAM_CTR"]
     },
     {
       "id": "ZJSY_L_CTR",
-      "parent_id": "ZJSA_CTR",
       "controlled_by": ["ZJSY_L_CTR"]
     },
     {
       "id": "ZJSY_O_CTR",
-      "parent_id": "ZJSA_CTR",
       "controlled_by": ["ZJSY_O_CTR"]
     },
     {
       "id": "ZGNN_CTR",
-      "parent_id": "ZGZU_CTR",
       "controlled_by": ["ZGNN_CTR"]
     },
     {
@@ -243,9 +238,7 @@
       "controlled_by": [
         "ZGOW_APP",
         "ZGGG_CTR",
-        "ZGZU_CTR",
-        "ZSAM_CTR",
-        "ZSHA_CTR"
+        "ZSAM_CTR"
       ]
     },
     {
@@ -255,7 +248,6 @@
     },
     {
       "id": "ZGGG_CTR",
-      "parent_id": "ZGZU_CTR",
       "controlled_by": ["ZGGG_CTR"]
     }
   ]


### PR DESCRIPTION
### Description

Removed unused PRC positions

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [X] Dataset files are in the correct `dataset/{FIR}/` directory.
- [X] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
