### PR TITLE
NAT: Operationalise Edmonton

### DIFF
--- a/dataset/NAT/profiles/NAT-EVENT.json
+++ b/dataset/NAT/profiles/NAT-EVENT.json
@@ -13,16 +13,9 @@
       "gap": 0.75,
       "children": [
         {
-          "label": ["Edmonton", "(INOP)"],
+          "label": ["Edmonton"],
           "size": 7,
-          "page": {
-            "rows": 5,
-            "keys": [
-              {
-                "label": ["INOP"]
-              }
-            ]
-          }
+          "station_id": "CZEG-FSS"
         },
         {
           "label": ["Montreal", "(INOP)"],

--- a/dataset/NAT/profiles/NAT.json
+++ b/dataset/NAT/profiles/NAT.json
@@ -13,16 +13,9 @@
       "gap": 0.75,
       "children": [
         {
-          "label": ["Edmonton", "(INOP)"],
+          "label": ["Edmonton"],
           "size": 7,
-          "page": {
-            "rows": 5,
-            "keys": [
-              {
-                "label": ["INOP"]
-              }
-            ]
-          }
+          "station_id": "CZEG-FSS"
         },
         {
           "label": ["Montreal", "(INOP)"],


### PR DESCRIPTION
Makes Edmonton callable from NAT profiles (they touch in the North-Western corner, CZEG Clyde sector).

Ownership of Clyde sector is (from vatglasses):
`ZEG_CY_CTR`
`ZEG_PR_CTR`
`CZEG_FSS`

As only `CZEG_FSS` is callable in vacs, that has been set, the rest are event-only positions.

<img width="694" height="379" alt="image" src="https://github.com/user-attachments/assets/372d1e48-839b-4a63-b4be-7534661a52ca" />

<img width="1401" height="1087" alt="image" src="https://github.com/user-attachments/assets/b9d7b197-0cde-4488-9886-304d7c043686" />
