### PR TITLE
Add LPCS profile

### DIFF
--- a/dataset/LPPC/positions.toml
+++ b/dataset/LPPC/positions.toml
@@ -213,7 +213,7 @@ id = "LPCS_TWR"
 prefixes = ["LPCS"]
 frequency = "120.305"
 facility_type = "TWR"
-profile_id = "LPPC_Generic"
+profile_id = "TWRCAS"
 
 [[positions]]
 id = "LPEV_I_TWR"
@@ -311,7 +311,7 @@ id = "LPCS_GND"
 prefixes = ["LPCS"]
 frequency = "121.830"
 facility_type = "GND"
-profile_id = "LPPC_Generic"
+profile_id = "TWRCAS"
 
 [[positions]]
 id = "LPFR_GND"

--- a/dataset/LPPC/profiles/TWRCAS.json
+++ b/dataset/LPPC/profiles/TWRCAS.json
@@ -15,7 +15,7 @@
             "station_id": "LPPT_APP"
           },
           {
-            "label": ["TWR", "Sintra"],
+            "label": ["TWR", "STR"],
             "station_id": "LPST_TWR"
           },
           {
@@ -29,11 +29,11 @@
             "station_id": "LPPT_F_APP"
           },
           {
-            "label": ["TWR", "Montijo"],
+            "label": ["TWR", "MTJ"],
             "station_id": "LPMT_TWR"
           },
           {
-            "label": ["MIL", "ACC"],
+            "label": ["MIL", "EXE"],
             "station_id": "LPAM_CTR"
           },
           {
@@ -44,7 +44,7 @@
             "station_id": "LPPT_W_APP"
           },
           {
-            "label": ["TWR", "Lisboa"],
+            "label": ["TWR", "LIS"],
             "station_id": "LPPT_TWR"
           },
           {

--- a/dataset/LPPC/profiles/TWRCAS.json
+++ b/dataset/LPPC/profiles/TWRCAS.json
@@ -1,0 +1,57 @@
+{
+  "id": "TWRCAS",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["I"],
+      "page": {
+        "rows": 4,
+        "keys": [
+          {
+            "label": []
+          },
+          {
+            "label": ["APP", "EXE"],
+            "station_id": "LPPT_APP"
+          },
+          {
+            "label": ["TWR", "Sintra"],
+            "station_id": "LPST_TWR"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["ARR", "EXE"],
+            "station_id": "LPPT_F_APP"
+          },
+          {
+            "label": ["TWR", "Montijo"],
+            "station_id": "LPMT_TWR"
+          },
+          {
+            "label": ["MIL", "ACC"],
+            "station_id": "LPAM_CTR"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["ATMO", "EXE"],
+            "station_id": "LPPT_W_APP"
+          },
+          {
+            "label": ["TWR", "Lisboa"],
+            "station_id": "LPPT_TWR"
+          },
+          {
+            "label": []
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description

Adds the LPCS specific profile

### AIRAC dependency

- [x] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [x] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
