### PR TITLE
Add AC South Profile

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -416,49 +416,49 @@ id = "SOLENT_APP"
 prefixes = ["SOLENT"]
 frequency = "120.230"
 facility_type = "APP"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGHH_APP"
 prefixes = ["EGHH"]
 frequency = "119.480"
 facility_type = "APP"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGHH_F_APP"
 prefixes = ["EGHH"]
 frequency = "118.655"
 facility_type = "APP"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGHH_TWR"
 prefixes = ["EGHH"]
 frequency = "125.605"
 facility_type = "TWR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGHH_GND"
 prefixes = ["EGHH"]
 frequency = "121.705"
 facility_type = "GND"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGHI_APP"
 prefixes = ["EGHI"]
 frequency = "122.730"
 facility_type = "APP"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGHI_TWR"
 prefixes = ["EGHI"]
 frequency = "118.205"
 facility_type = "TWR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGHQ_APP"
@@ -577,35 +577,35 @@ id = "EGKA_APP"
 prefixes = ["EGKA"]
 frequency = "123.155"
 facility_type = "APP"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGKA_TWR"
 prefixes = ["EGKA"]
 frequency = "125.405"
 facility_type = "TWR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGKB_A_APP"
 prefixes = ["EGKB"]
 frequency = "129.405"
 facility_type = "APP"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGKB_TWR"
 prefixes = ["EGKB"]
 frequency = "134.805"
 facility_type = "TWR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGKB_GND"
 prefixes = ["EGKB"]
 frequency = "121.630"
 facility_type = "GND"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGKK_APP"
@@ -668,35 +668,35 @@ id = "EGKR_TWR"
 prefixes = ["EGKR"]
 frequency = "119.605"
 facility_type = "TWR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "THAMES_APP"
 prefixes = ["THAMES"]
 frequency = "132.700"
 facility_type = "APP"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGLC_APP"
 prefixes = ["EGLC"]
 frequency = "128.025"
 facility_type = "APP"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGLC_TWR"
 prefixes = ["EGLC"]
 frequency = "118.080"
 facility_type = "TWR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGLC_GND"
 prefixes = ["EGLC"]
 frequency = "121.830"
 facility_type = "GND"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGLF_APP"
@@ -815,42 +815,42 @@ id = "EGLW_TWR"
 prefixes = ["EGLW"]
 frequency = "134.280"
 facility_type = "TWR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGMC_APP"
 prefixes = ["EGMC"]
 frequency = "128.965"
 facility_type = "APP"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGMC_L_APP"
 prefixes = ["EGMC"]
 frequency = "130.780"
 facility_type = "APP"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGMC_TWR"
 prefixes = ["EGMC"]
 frequency = "127.730"
 facility_type = "TWR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGMD_A_APP"
 prefixes = ["EGMD"]
 frequency = "120.705"
 facility_type = "APP"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGMD_TWR"
 prefixes = ["EGMD"]
 frequency = "119.380"
 facility_type = "TWR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "EGNH_A_APP"
@@ -2071,21 +2071,21 @@ id = "LON_DK_CTR"
 prefixes = ["LON"]
 frequency = "128.430"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LON_DL_CTR"
 prefixes = ["LON"]
 frequency = "133.485"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LON_D_CTR"
 prefixes = ["LON"]
 frequency = "134.905"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LON_EN_CTR"
@@ -2113,14 +2113,14 @@ id = "LON_HW_CTR"
 prefixes = ["LON"]
 frequency = "127.830"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LON_H_CTR"
 prefixes = ["LON"]
 frequency = "134.440"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LON_ME_CTR"
@@ -2183,7 +2183,7 @@ id = "LON_O_CTR"
 prefixes = ["LON"]
 frequency = "129.080"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LON_SC_CTR"
@@ -2197,28 +2197,28 @@ id = "LON_SF_CTR"
 prefixes = ["LON"]
 frequency = "135.055"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LON_SN_CTR"
 prefixes = ["LON"]
 frequency = "132.165"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LON_SU_CTR"
 prefixes = ["LON"]
 frequency = "132.840"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LON_S_CTR"
 prefixes = ["LON"]
 frequency = "129.430"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LON_WB_CTR"
@@ -2361,21 +2361,21 @@ id = "LTC_SE_CTR"
 prefixes = ["LTC"]
 frequency = "120.530"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LTC_SW_CTR"
 prefixes = ["LTC"]
 frequency = "133.180"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 [[positions]]
 id = "LTC_S_CTR"
 prefixes = ["LTC"]
 frequency = "134.125"
 facility_type = "CTR"
-profile_id = "EG-South_LAG"
+profile_id = "EG-AC_South"
 
 #######################
 # Scottish Area

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -416,49 +416,49 @@ id = "SOLENT_APP"
 prefixes = ["SOLENT"]
 frequency = "120.230"
 facility_type = "APP"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGHH_APP"
 prefixes = ["EGHH"]
 frequency = "119.480"
 facility_type = "APP"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGHH_F_APP"
 prefixes = ["EGHH"]
 frequency = "118.655"
 facility_type = "APP"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGHH_TWR"
 prefixes = ["EGHH"]
 frequency = "125.605"
 facility_type = "TWR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGHH_GND"
 prefixes = ["EGHH"]
 frequency = "121.705"
 facility_type = "GND"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGHI_APP"
 prefixes = ["EGHI"]
 frequency = "122.730"
 facility_type = "APP"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGHI_TWR"
 prefixes = ["EGHI"]
 frequency = "118.205"
 facility_type = "TWR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGHQ_APP"
@@ -577,35 +577,35 @@ id = "EGKA_APP"
 prefixes = ["EGKA"]
 frequency = "123.155"
 facility_type = "APP"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGKA_TWR"
 prefixes = ["EGKA"]
 frequency = "125.405"
 facility_type = "TWR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGKB_A_APP"
 prefixes = ["EGKB"]
 frequency = "129.405"
 facility_type = "APP"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGKB_TWR"
 prefixes = ["EGKB"]
 frequency = "134.805"
 facility_type = "TWR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGKB_GND"
 prefixes = ["EGKB"]
 frequency = "121.630"
 facility_type = "GND"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGKK_APP"
@@ -668,35 +668,35 @@ id = "EGKR_TWR"
 prefixes = ["EGKR"]
 frequency = "119.605"
 facility_type = "TWR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "THAMES_APP"
 prefixes = ["THAMES"]
 frequency = "132.700"
 facility_type = "APP"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGLC_APP"
 prefixes = ["EGLC"]
 frequency = "128.025"
 facility_type = "APP"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGLC_TWR"
 prefixes = ["EGLC"]
 frequency = "118.080"
 facility_type = "TWR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGLC_GND"
 prefixes = ["EGLC"]
 frequency = "121.830"
 facility_type = "GND"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGLF_APP"
@@ -815,42 +815,42 @@ id = "EGLW_TWR"
 prefixes = ["EGLW"]
 frequency = "134.280"
 facility_type = "TWR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGMC_APP"
 prefixes = ["EGMC"]
 frequency = "128.965"
 facility_type = "APP"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGMC_L_APP"
 prefixes = ["EGMC"]
 frequency = "130.780"
 facility_type = "APP"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGMC_TWR"
 prefixes = ["EGMC"]
 frequency = "127.730"
 facility_type = "TWR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGMD_A_APP"
 prefixes = ["EGMD"]
 frequency = "120.705"
 facility_type = "APP"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGMD_TWR"
 prefixes = ["EGMD"]
 frequency = "119.380"
 facility_type = "TWR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "EGNH_A_APP"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -2361,21 +2361,21 @@ id = "LTC_SE_CTR"
 prefixes = ["LTC"]
 frequency = "120.530"
 facility_type = "CTR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "LTC_SW_CTR"
 prefixes = ["LTC"]
 frequency = "133.180"
 facility_type = "CTR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 [[positions]]
 id = "LTC_S_CTR"
 prefixes = ["LTC"]
 frequency = "134.125"
 facility_type = "CTR"
-profile_id = "EG-AC_South"
+profile_id = "EG-South_LAG"
 
 #######################
 # Scottish Area

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -2028,6 +2028,13 @@ frequency = "118.330"
 facility_type = "TWR"
 profile_id = "EG-Swanwick_Military"
 
+[[positions]]
+id = "STHRN_APP"
+prefixes = ["STHRN"]
+frequency = "134.035"
+facility_type = "APP"
+profile_id = "EG-Swanwick_Military"
+
 #######################
 # London Area
 #######################

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -418,7 +418,7 @@
             "station_id": "LFRR_QI"
           },
           {
-            "label": ["PAR", "TP"],
+            "label": ["LFFF", "TP"],
             "color": "lavender",
             "station_id": "PAR_TP"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -328,7 +328,7 @@
             "station_id": "EG-Sector-27-32"
           },
           {
-            "label": ["AC", "S34", "DTY"],
+            "label": ["AC", "S34", "DTY N"],
             "color": "blush",
             "station_id": "EG-Sector-34"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -226,7 +226,7 @@
             "station_id": "EGKA_APP"
           },
           {
-            "label": ["CI", "ORTAC"],
+            "label": ["EGJJ"],
             "color": "azure",
             "station_id": "EGJJ_C_APP"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -83,7 +83,7 @@
             "station_id": "LON_GS_CTR"
           },
           {
-            "label": ["BREST", "W"],
+            "label": ["LFRR", "W"],
             "color": "lavender",
             "station_id": "LFRR_WS"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -441,7 +441,7 @@
             "label": []
           },
           {
-            "label": ["REIMS", "HN"],
+            "label": ["LFEE", "HN", "F345+"],
             "color": "lavender",
             "station_id": "LFEE_HN"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -98,7 +98,7 @@
             "station_id": "EGTT_I_CTR"
           },
           {
-            "label": ["SOL", "APC"],
+            "label": ["SOLENT", "RAD"],
             "color": "azure",
             "station_id": "SOLENT_APP"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -446,7 +446,7 @@
             "station_id": "LFEE_HN"
           },
           {
-            "label": ["REIMS", "UN"],
+            "label": ["LFEE", "UN", "F265-345"],
             "color": "lavender",
             "station_id": "LFEE_UN"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -323,7 +323,7 @@
             "station_id": "EG-Sector-15"
           },
           {
-            "label": ["AC", "S27/32", "DTY"],
+            "label": ["AC", "S27/32", "DTY S"],
             "color": "blush",
             "station_id": "EG-Sector-27-32"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -103,7 +103,7 @@
             "station_id": "SOLENT_APP"
           },
           {
-            "label": ["CI", "ORTAC"],
+            "label": ["EGJJ"],
             "color": "azure",
             "station_id": "EGJJ_C_APP"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -1,0 +1,505 @@
+{
+  "id": "EG-AC_South",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["1", "Main"],
+      "page": {
+        "rows": 5,
+        "keys": [
+          {
+            "label": ["AC", "DTY"],
+            "color": "blush",
+            "station_id": "LON_M_CTR"
+          },
+          {
+            "label": ["AC", "WOR"],
+            "color": "blush",
+            "station_id": "LON_H_CTR"
+          },
+          {
+            "label": ["AC", "W"],
+            "color": "blush",
+            "station_id": "LON_W_CTR"
+          },
+          {
+            "label": ["TC", "NW"],
+            "color": "blush",
+            "station_id": "LTC_NW_CTR"
+          },
+          {
+            "label": ["TC", "SW"],
+            "color": "blush",
+            "station_id": "LTC_SW_CTR"
+          },
+          {
+            "label": ["AC", "CLN"],
+            "color": "blush",
+            "station_id": "LON_E_CTR"
+          },
+          {
+            "label": ["AC", "DVR"],
+            "color": "blush",
+            "station_id": "LON_D_CTR"
+          },
+          {
+            "label": ["TC", "MIDS"],
+            "color": "blush",
+            "station_id": "LTC_M_CTR"
+          },
+          {
+            "label": ["TC", "NE"],
+            "color": "blush",
+            "station_id": "LTC_NE_CTR"
+          },
+          {
+            "label": ["TC", "SE"],
+            "color": "blush",
+            "station_id": "LTC_SE_CTR"
+          },
+          {
+            "label": ["LL", "INT"],
+            "color": "blush",
+            "station_id": "EGLL_N_APP"
+          },
+          {
+            "label": ["KK", "INT"],
+            "color": "blush",
+            "station_id": "EGKK_APP"
+          },
+          {
+            "label": ["TMS", "RDR"],
+            "color": "blush",
+            "station_id": "THAMES_APP"
+          },
+          {
+            "label": ["TC", "E"],
+            "color": "blush",
+            "station_id": "LTC_E_CTR"
+          },
+          {
+            "label": ["AC", "GS"],
+            "color": "mint",
+            "station_id": "LON_GS_CTR"
+          },
+          {
+            "label": ["BREST", "W"],
+            "color": "lavender",
+            "station_id": "LFRR_WS"
+          },
+          {
+            "label": ["BREST", "E"],
+            "color": "lavender",
+            "station_id": "LFRR_QS"
+          },
+          {
+            "label": ["FIS"],
+            "color": "azure",
+            "station_id": "EGTT_I_CTR"
+          },
+          {
+            "label": ["SOL", "APC"],
+            "color": "azure",
+            "station_id": "SOLENT_APP"
+          },
+          {
+            "label": ["CI", "ORTAC"],
+            "color": "azure",
+            "station_id": "EGJJ_C_APP"
+          },
+          {
+            "label": ["REIMS", "N"],
+            "color": "lavender",
+            "station_id": "LFEE_HN"
+          },
+          {
+            "label": ["MAAS", "KOK"],
+            "color": "lavender",
+            "station_id": "EDYY-KOH"
+          },
+          {
+            "label": ["BRU", "W"],
+            "color": "lavender",
+            "station_id": "EBBU-WLS"
+          },
+          {
+            "label": ["PAR", "TP"],
+            "color": "lavender",
+            "station_id": "PAR_TP"
+          },
+          {
+            "label": ["PAR", "TN"],
+            "color": "lavender",
+            "station_id": "PAR_TN"
+          }
+        ]
+      }
+    },
+    {
+      "label": ["2", "AD"],
+      "page": {
+        "rows": 5,
+        "keys": [
+          {
+            "label": ["LL", "INT"],
+            "color": "blush",
+            "station_id": "EGLL_S_APP"
+          },
+          {
+            "label": ["KK", "INT"],
+            "color": "blush",
+            "station_id": "EGKK_APP"
+          },
+          {
+            "label": ["TMS", "RDR"],
+            "color": "blush",
+            "station_id": "THAMES_APP"
+          },
+          {
+            "label": ["EGMC", "APC"],
+            "color": "azure",
+            "station_id": "EGMC_APP"
+          },
+          {
+            "label": ["SOL", "APC"],
+            "color": "azure",
+            "station_id": "SOLENT_APP"
+          },
+          {
+            "label": ["LL", "TWR"],
+            "color": "azure",
+            "station_id": "EGLL_S_TWR"
+          },
+          {
+            "label": ["KK", "TWR"],
+            "color": "azure",
+            "station_id": "EGKK_TWR"
+          },
+          {
+            "label": ["LC", "TWR"],
+            "color": "azure",
+            "station_id": "EGLC_TWR"
+          },
+          {
+            "label": ["EGKB", "APC"],
+            "color": "azure",
+            "station_id": "EGKB_A_APP"
+          },
+          {
+            "label": ["EGHH", "APC"],
+            "color": "azure",
+            "station_id": "EGHH_APP"
+          },
+          {
+            "label": ["LL", "GMP"],
+            "color": "azure",
+            "station_id": "EGLL_DEL"
+          },
+          {
+            "label": ["KK", "GMP"],
+            "color": "azure",
+            "station_id": "EGKK_DEL"
+          },
+          {
+            "label": ["LC", "GMC"],
+            "color": "azure",
+            "station_id": "EGLC_GND"
+          },
+          {
+            "label": ["EGUB", "APC"],
+            "color": "azure",
+            "station_id": "EGUB_APP"
+          },
+          {
+            "label": ["EGDY", "APC"],
+            "color": "azure",
+            "station_id": "EGDY_APP"
+          },
+          {
+            "label": ["EGLF", "APC"],
+            "color": "azure",
+            "station_id": "EGLF_APP"
+          },
+          {
+            "label": ["EGKA", "APC"],
+            "color": "azure",
+            "station_id": "EGKA_APP"
+          },
+          {
+            "label": ["CI", "SKERY"],
+            "color": "azure",
+            "station_id": "EGJJ_C_APP"
+          },
+          {
+            "label": ["EGVO", "APC"],
+            "color": "azure",
+            "station_id": "EGVO_APP"
+          },
+          {
+            "label": ["LFRN", "APC"],
+            "color": "lavender",
+            "station_id": "LFRN_JC_APP"
+          },
+          {
+            "label": ["EGMD", "APC"],
+            "color": "azure",
+            "station_id": "EGMD_A_APP"
+          },
+          {
+            "label": ["MIL", "W"],
+            "color": "azure",
+            "station_id": "EGVV_W_CTR"
+          },
+          {
+            "label": ["MIL S", "APC"],
+            "color": "azure"
+          },
+          {
+            "label": ["EGDM", "APC"],
+            "color": "azure",
+            "station_id": "EGDM_APP"
+          },
+          {
+            "label": ["LFQQ", "APC"],
+            "color": "lavender",
+            "station_id": "LFQQ_QE_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["EGVP", "APC"],
+            "color": "azure",
+            "station_id": "EGVP_APP"
+          },
+          {
+            "label": ["EBOS", "APC"],
+            "color": "lavender",
+            "station_id": "EBOS-APP"
+          }
+        ]
+      }
+    },
+    {
+      "label": ["3", "Event"],
+      "page": {
+        "rows": 5,
+        "keys": [
+          {
+            "label": ["AC", "LUS"],
+            "color": "blush",
+            "station_id": "LON_SU_CTR"
+          },
+          {
+            "label": ["AC", "LMS"],
+            "color": "blush",
+            "station_id": "LON_SN_CTR"
+          },
+          {
+            "label": ["AC", "HURN"],
+            "color": "blush",
+            "station_id": "LON_HW_CTR"
+          },
+          {
+            "label": ["AC", "S18", "SFD"],
+            "color": "blush",
+            "station_id": "LON_SF_CTR"
+          },
+          {
+            "label": ["AC", "S16/17", "LYD"],
+            "color": "blush",
+            "station_id": "LON_DL_CTR"
+          },
+          {
+            "label": ["AC", "S15", "DVR"],
+            "color": "blush",
+            "station_id": "LON_D_CTR"
+          },
+          {
+            "label": ["AC", "S27/32", "DTY"],
+            "color": "blush",
+            "station_id": "LON_MW_CTR"
+          },
+          {
+            "label": ["AC", "S34", "DTY"],
+            "color": "blush",
+            "station_id": "LON_ME_CTR"
+          },
+          {
+            "label": ["AC", "S28", "DTY"],
+            "color": "blush",
+            "station_id": "LON_ML_CTR"
+          },
+          {
+            "label": ["AC", "S23", "W"],
+            "color": "blush",
+            "station_id": "LON_23_CTR"
+          },
+          {
+            "label": ["AC", "S12", "CLN"],
+            "color": "blush",
+            "station_id": "LON_EN_CTR"
+          },
+          {
+            "label": ["AC", "S13", "CLN"],
+            "color": "blush",
+            "station_id": "LON_ES_CTR"
+          },
+          {
+            "label": ["AC", "BCN", "HI"],
+            "color": "blush",
+            "station_id": "LON_WB_CTR"
+          },
+          {
+            "label": ["AC", "BCN", "LO"],
+            "color": "blush",
+            "station_id": "LON_WL_CTR"
+          },
+          {
+            "label": ["AC", "EXMOR"],
+            "color": "blush",
+            "station_id": "LON_WX_CTR"
+          },
+          {
+            "label": ["TC", "COWLY"],
+            "color": "blush",
+            "station_id": "LTC_MC_CTR"
+          },
+          {
+            "label": ["TC", "WELIN"],
+            "color": "blush",
+            "station_id": "LTC_MW_CTR"
+          },
+          {
+            "label": ["TC", "JACKO"],
+            "color": "blush",
+            "station_id": "LTC_EJ_CTR"
+          },
+          {
+            "label": ["TC", "DAGGA"],
+            "color": "blush",
+            "station_id": "LTC_ED_CTR"
+          },
+          {
+            "label": ["TC", "SABER"],
+            "color": "blush",
+            "station_id": "LTC_ES_CTR"
+          },
+          {
+            "label": ["TC", "LOREL"],
+            "color": "blush",
+            "station_id": "LTC_NL_CTR"
+          },
+          {
+            "label": ["TC", "LAM"],
+            "color": "blush",
+            "station_id": "LTC_N2_CTR"
+          },
+          {
+            "label": ["BREST", "V"],
+            "color": "lavender",
+            "station_id": "LFRR_VI"
+          },
+          {
+            "label": ["BREST", "J"],
+            "color": "lavender",
+            "station_id": "LFRR_J"
+          },
+          {
+            "label": ["BREST", "E", "HI"],
+            "color": "lavender",
+            "station_id": "LFRR_QI"
+          },
+          {
+            "label": ["PAR", "TP"],
+            "color": "lavender",
+            "station_id": "PAR_TP"
+          },
+          {
+            "label": ["PAR", "TN"],
+            "color": "lavender",
+            "station_id": "PAR_TN"
+          },
+          {
+            "label": ["PAR", "TB"],
+            "color": "lavender",
+            "station_id": "PAR_TB"
+          },
+          {
+            "label": ["BREST", "E", "LO"],
+            "color": "lavender",
+            "station_id": "LFRR_QS"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["REIMS", "HN"],
+            "color": "lavender",
+            "station_id": "LFEE_HN"
+          },
+          {
+            "label": ["REIMS", "UN"],
+            "color": "lavender",
+            "station_id": "LFEE_UN"
+          },
+          {
+            "label": ["REIMS", "UB"],
+            "color": "lavender",
+            "station_id": "LFEE_UB"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          }
+        ]
+      }
+    },
+    {
+      "label": ["4", "SUP"],
+      "page": {
+        "rows": 3,
+        "keys": [
+          {
+            "label": ["UK", "FMP"],
+            "color": "mint",
+            "station_id": "UK_FMP"
+          },
+          {
+            "label": ["LTC", "FMP"],
+            "color": "mint",
+            "station_id": "LTC_FMP"
+          },
+          {
+            "label": ["UK", "FMP", "2"],
+            "color": "mint",
+            "station_id": "UK_A_FMP"
+          },
+          {
+            "label": ["UK", "FMP", "3"],
+            "color": "mint",
+            "station_id": "UK_B_FMP"
+          },
+          {
+            "label": ["LAC", "GS"],
+            "color": "mint",
+            "station_id": "LON_GS_CTR"
+          },
+          {
+            "label": ["LTC", "GS"],
+            "color": "mint",
+            "station_id": "LTC_GS_CTR"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -451,7 +451,7 @@
             "station_id": "LFEE_UN"
           },
           {
-            "label": ["REIMS", "UB"],
+            "label": ["LFEE", "UB", "F265-345"],
             "color": "lavender",
             "station_id": "LFEE_UB"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -333,7 +333,7 @@
             "station_id": "EG-Sector-34"
           },
           {
-            "label": ["AC", "S28", "DTY"],
+            "label": ["AC", "S28", "DTY N LO"],
             "color": "blush",
             "station_id": "EG-Sector-28"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -108,7 +108,7 @@
             "station_id": "EGJJ_C_APP"
           },
           {
-            "label": ["REIMS", "N"],
+            "label": ["LFEE", "N"],
             "color": "lavender",
             "station_id": "LFEE_HN"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -310,7 +310,7 @@
           {
             "label": ["AC", "S18", "SFD"],
             "color": "blush",
-            "station_id": "LON_SF_CTR"
+            "station_id": "EG-Sector-18"
           },
           {
             "label": ["AC", "S16/17", "LYD"],
@@ -320,47 +320,47 @@
           {
             "label": ["AC", "S15", "DVR"],
             "color": "blush",
-            "station_id": "LON_D_CTR"
+            "station_id": "EG-Sector-15"
           },
           {
             "label": ["AC", "S27/32", "DTY"],
             "color": "blush",
-            "station_id": "LON_MW_CTR"
+            "station_id": "EG-Sector-27-32"
           },
           {
             "label": ["AC", "S34", "DTY"],
             "color": "blush",
-            "station_id": "LON_ME_CTR"
+            "station_id": "EG-Sector-34"
           },
           {
             "label": ["AC", "S28", "DTY"],
             "color": "blush",
-            "station_id": "LON_ML_CTR"
+            "station_id": "EG-Sector-28"
           },
           {
             "label": ["AC", "S23"],
             "color": "blush",
-            "station_id": "LON_23_CTR"
+            "station_id": "EG-Sector-23"
           },
           {
             "label": ["AC", "S12", "CLN"],
             "color": "blush",
-            "station_id": "LON_EN_CTR"
+            "station_id": "EG-Sector-12"
           },
           {
             "label": ["AC", "S13", "CLN"],
             "color": "blush",
-            "station_id": "LON_ES_CTR"
+            "station_id": "EG-Sector-13"
           },
           {
             "label": ["AC", "S35", "BCN HI"],
             "color": "blush",
-            "station_id": "LON_WB_CTR"
+            "station_id": "EG-Sector-35"
           },
           {
             "label": ["AC", "S5", "BCN LO"],
             "color": "blush",
-            "station_id": "LON_WL_CTR"
+            "station_id": "EG-Sector-5"
           },
           {
             "label": ["AC", "S6/36", "EXMOOR"],
@@ -370,37 +370,37 @@
           {
             "label": ["TC", "COWLY"],
             "color": "blush",
-            "station_id": "LTC_MC_CTR"
+            "station_id": "EG-TC-COWLY"
           },
           {
             "label": ["TC", "WELIN"],
             "color": "blush",
-            "station_id": "LTC_MW_CTR"
+            "station_id": "EG-TC-WELIN"
           },
           {
             "label": ["TC", "JACKO"],
             "color": "blush",
-            "station_id": "LTC_EJ_CTR"
+            "station_id": "EG-TC-JACKO"
           },
           {
             "label": ["TC", "DAGGA"],
             "color": "blush",
-            "station_id": "LTC_ED_CTR"
+            "station_id": "EG-TC-DAGGA"
           },
           {
             "label": ["TC", "SABER"],
             "color": "blush",
-            "station_id": "LTC_ES_CTR"
+            "station_id": "EG-TC-SABER"
           },
           {
             "label": ["TC", "LOREL"],
             "color": "blush",
-            "station_id": "LTC_NL_CTR"
+            "station_id": "EG-TC-LOREL"
           },
           {
             "label": ["TC", "LAM"],
             "color": "blush",
-            "station_id": "LTC_N2_CTR"
+            "station_id": "EG-TC-LAM"
           },
           {
             "label": ["LFRR", "V"],

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -252,7 +252,8 @@
           },
           {
             "label": ["MIL S", "APC"],
-            "color": "azure"
+            "color": "azure",
+            "station_id": "STHRN_APP"
           },
           {
             "label": ["EGDM", "APC"],

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -68,7 +68,7 @@
             "station_id": "EGKK_APP"
           },
           {
-            "label": ["TMS", "RDR"],
+            "label": ["TMS", "RAD"],
             "color": "blush",
             "station_id": "THAMES_APP"
           },
@@ -118,17 +118,17 @@
             "station_id": "EDYY-KOH"
           },
           {
-            "label": ["BRU", "W"],
+            "label": ["EBBU", "W"],
             "color": "lavender",
             "station_id": "EBBU-WLS"
           },
           {
-            "label": ["PAR", "TP"],
+            "label": ["LFFF", "TP"],
             "color": "lavender",
             "station_id": "PAR_TP"
           },
           {
-            "label": ["PAR", "TN"],
+            "label": ["LFFF", "TN"],
             "color": "lavender",
             "station_id": "PAR_TN"
           }
@@ -151,7 +151,7 @@
             "station_id": "EGKK_APP"
           },
           {
-            "label": ["TMS", "RDR"],
+            "label": ["TMS", "RAD"],
             "color": "blush",
             "station_id": "THAMES_APP"
           },
@@ -161,7 +161,7 @@
             "station_id": "EGMC_APP"
           },
           {
-            "label": ["SOL", "APC"],
+            "label": ["SOLENT", "RAD"],
             "color": "azure",
             "station_id": "SOLENT_APP"
           },
@@ -186,7 +186,7 @@
             "station_id": "EGKB_A_APP"
           },
           {
-            "label": ["EGHH", "APC"],
+            "label": ["EGHH", "RAD"],
             "color": "azure",
             "station_id": "EGHH_APP"
           },
@@ -236,7 +236,7 @@
             "station_id": "EGVO_APP"
           },
           {
-            "label": ["LFRN", "APC"],
+            "label": ["LFRN"],
             "color": "lavender",
             "station_id": "LFRN_JC_APP"
           },
@@ -261,7 +261,7 @@
             "station_id": "EGDM_APP"
           },
           {
-            "label": ["LFQQ", "APC"],
+            "label": ["LFQQ"],
             "color": "lavender",
             "station_id": "LFQQ_QE_APP"
           },
@@ -280,7 +280,7 @@
             "station_id": "EGVP_APP"
           },
           {
-            "label": ["EBOS", "APC"],
+            "label": ["EBOS"],
             "color": "lavender",
             "station_id": "EBOS-APP"
           }
@@ -338,7 +338,7 @@
             "station_id": "LON_ML_CTR"
           },
           {
-            "label": ["AC", "S23", "W"],
+            "label": ["AC", "S23"],
             "color": "blush",
             "station_id": "LON_23_CTR"
           },
@@ -353,17 +353,17 @@
             "station_id": "LON_ES_CTR"
           },
           {
-            "label": ["AC", "BCN", "HI"],
+            "label": ["AC", "S35", "BCN HI"],
             "color": "blush",
             "station_id": "LON_WB_CTR"
           },
           {
-            "label": ["AC", "BCN", "LO"],
+            "label": ["AC", "S5", "BCN LO"],
             "color": "blush",
             "station_id": "LON_WL_CTR"
           },
           {
-            "label": ["AC", "EXMOR"],
+            "label": ["AC", "S6/36", "EXMOOR"],
             "color": "blush",
             "station_id": "LON_WX_CTR"
           },
@@ -403,17 +403,17 @@
             "station_id": "LTC_N2_CTR"
           },
           {
-            "label": ["BREST", "V"],
+            "label": ["LFRR", "V"],
             "color": "lavender",
             "station_id": "LFRR_VI"
           },
           {
-            "label": ["BREST", "J"],
+            "label": ["LFRR", "J"],
             "color": "lavender",
             "station_id": "LFRR_J"
           },
           {
-            "label": ["BREST", "E", "HI"],
+            "label": ["LFRR", "UE", "F345+"],
             "color": "lavender",
             "station_id": "LFRR_QI"
           },
@@ -428,12 +428,12 @@
             "station_id": "PAR_TN"
           },
           {
-            "label": ["PAR", "TB"],
+            "label": ["LFFF", "TB"],
             "color": "lavender",
             "station_id": "PAR_TB"
           },
           {
-            "label": ["BREST", "E", "LO"],
+            "label": ["LFRR", "E", "F295-345"],
             "color": "lavender",
             "station_id": "LFRR_QS"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -423,7 +423,7 @@
             "station_id": "PAR_TP"
           },
           {
-            "label": ["PAR", "TN"],
+            "label": ["LFFF", "TN"],
             "color": "lavender",
             "station_id": "PAR_TN"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -88,7 +88,7 @@
             "station_id": "LFRR_WS"
           },
           {
-            "label": ["BREST", "E"],
+            "label": ["LFRR", "E"],
             "color": "lavender",
             "station_id": "LFRR_QS"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -226,7 +226,7 @@
             "station_id": "EGKA_APP"
           },
           {
-            "label": ["CI", "SKERY"],
+            "label": ["CI", "ORTAC"],
             "color": "azure",
             "station_id": "EGJJ_C_APP"
           },

--- a/dataset/EG/profiles/EG-AC_South.json
+++ b/dataset/EG/profiles/EG-AC_South.json
@@ -360,7 +360,7 @@
           {
             "label": ["AC", "S5", "BCN LO"],
             "color": "blush",
-            "station_id": "EG-Sector-5"
+            "station_id": "EG-Sector-05"
           },
           {
             "label": ["AC", "S6/36", "EXMOOR"],

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -1015,6 +1015,11 @@ parent_id = "EGDM_APP"
 controlled_by = ["EGDM_P_APP"]
 
 [[stations]]
+id = "EGDY_APP"
+parent_id = "EGVV_A_CTR"
+controlled_by = ["EGDY_APP"]
+
+[[stations]]
 id = "EGCC_F_APP"
 parent_id = "EGCC_S_APP"
 controlled_by = ["EGCC_F_APP"]

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -1000,6 +1000,21 @@ parent_id = "EGCC_S_APP"
 controlled_by = ["EGCC_N_APP"]
 
 [[stations]]
+id = "EGDM_TWR"
+parent_id = "EGDM_APP"
+controlled_by = ["EGDM_TWR"]
+
+[[stations]]
+id = "EGDM_APP"
+parent_id = "EGVV_W_CTR"
+controlled_by = ["EGDM_APP", "EGDM_P_APP"]
+
+[[stations]]
+id = "EGDM_P_APP"
+parent_id = "EGDM_APP"
+controlled_by = ["EGDM_P_APP"]
+
+[[stations]]
 id = "EGCC_F_APP"
 parent_id = "EGCC_S_APP"
 controlled_by = ["EGCC_F_APP"]
@@ -1038,6 +1053,31 @@ controlled_by = ["EGGW_APP", "EGGW_F_APP", "ESSEX_APP"]
 id = "EGGW_F_APP"
 parent_id = "EGGW_APP"
 controlled_by = ["EGGW_F_APP"]
+
+[[stations]]
+id = "EGKA_TWR"
+parent_id = "EGKA_APP"
+controlled_by = ["EGKA_TWR"]
+
+[[stations]]
+id = "EGKA_APP"
+parent_id = "LTC_SW_CTR"
+controlled_by = ["EGKA_APP"]
+
+[[stations]]
+id = "EGKB_GND"
+parent_id = "EGKB_TWR"
+controlled_by = ["EGKB_GND"]
+
+[[stations]]
+id = "EGKB_TWR"
+parent_id = "EGKB_A_APP"
+controlled_by = ["EGKB_TWR"]
+
+[[stations]]
+id = "EGKB_A_APP"
+parent_id = "EGLC_APP"
+controlled_by = ["EGKB_A_APP"]
 
 [[stations]]
 id = "EGHH_APP"
@@ -1179,6 +1219,11 @@ id = "EGLD_I_TWR"
 controlled_by = ["EGLD_I_TWR"]
 
 [[stations]]
+id = "EGLF_TWR"
+parent_id = "EGLF_APP"
+controlled_by = ["EGLF_TWR"]
+
+[[stations]]
 id = "EGLF_APP"
 parent_id = "LTC_SW_CTR"
 controlled_by = ["EGLF_APP", "EGLF_F_APP", "EGLF_L_APP"]
@@ -1256,6 +1301,31 @@ controlled_by = ["EGLM_R_TWR"]
 id = "EGLW_TWR"
 parent_id = "EGLL-CTR-TC_SVFR"
 controlled_by = ["EGLW_TWR"]
+
+[[stations]]
+id = "EGMC_TWR"
+parent_id = "EGMC_APP"
+controlled_by = ["EGMC_TWR"]
+
+[[stations]]
+id = "EGMC_APP"
+parent_id = "THAMES_APP"
+controlled_by = ["EGMC_APP", "EGMC_L_APP"]
+
+[[stations]]
+id = "EGMC_L_APP"
+parent_id = "EGMC_APP"
+controlled_by = ["EGMC_L_APP"]
+
+[[stations]]
+id = "EGMD_TWR"
+parent_id = "EGMD_A_APP"
+controlled_by = ["EGMD_TWR"]
+
+[[stations]]
+id = "EGMD_A_APP"
+parent_id = "LTC_SE_CTR"
+controlled_by = ["EGMD_A_APP"]
 
 [[stations]]
 id = "EGNH_A_APP"
@@ -1602,8 +1672,32 @@ id = "EGSU_I_TWR"
 controlled_by = ["EGSU_I_TWR"]
 
 [[stations]]
+id = "EGTC_A_APP"
+controlled_by = ["EGTC_A_APP"]
+
+[[stations]]
 id = "EGTF_R_TWR"
 controlled_by = ["EGTF_R_TWR"]
+
+[[stations]]
+id = "EGUB_GND"
+parent_id = "EGUB_TWR"
+controlled_by = ["EGUB_GND"]
+
+[[stations]]
+id = "EGUB_TWR"
+parent_id = "EGUB_APP"
+controlled_by = ["EGUB_TWR"]
+
+[[stations]]
+id = "EGUB_APP"
+parent_id = "EGVV_W_CTR"
+controlled_by = ["EGUB_APP", "EGUB_P_APP"]
+
+[[stations]]
+id = "EGUB_P_APP"
+parent_id = "EGUB_APP"
+controlled_by = ["EGUB_P_APP"]
 
 [[stations]]
 id = "EGUL_APP"
@@ -1614,6 +1708,87 @@ controlled_by = ["EGUL_APP", "EGUL_P_APP"]
 id = "EGUL_P_APP"
 parent_id = "EGUL_APP"
 controlled_by = ["EGUL_P_APP"]
+
+[[stations]]
+id = "EGUW_TWR"
+parent_id = "EGUW_APP"
+controlled_by = ["EGUW_TWR"]
+
+[[stations]]
+id = "EGUW_APP"
+parent_id = "EGVV_W_CTR"
+controlled_by = ["EGUW_APP", "EGUW_P_APP"]
+
+[[stations]]
+id = "EGUW_P_APP"
+parent_id = "EGUW_APP"
+controlled_by = ["EGUW_P_APP"]
+
+[[stations]]
+id = "EGVN_GND"
+parent_id = "EGVN_TWR"
+controlled_by = ["EGVN_GND"]
+
+[[stations]]
+id = "EGVN_TWR"
+parent_id = "EGVN_APP"
+controlled_by = ["EGVN_TWR"]
+
+[[stations]]
+id = "EGVN_APP"
+parent_id = "EGVV_W_CTR"
+controlled_by = [
+  "EGVN_APP",
+  "EGVN_F_APP",
+  "EGVN_L_APP",
+  "EGVN_Z_APP",
+  "EGVN_P_APP",
+]
+
+[[stations]]
+id = "EGVN_F_APP"
+parent_id = "EGVN_APP"
+controlled_by = ["EGVN_F_APP"]
+
+[[stations]]
+id = "EGVN_L_APP"
+parent_id = "EGVN_APP"
+controlled_by = ["EGVN_L_APP"]
+
+[[stations]]
+id = "EGVN_Z_APP"
+parent_id = "EGVN_APP"
+controlled_by = ["EGVN_Z_APP"]
+
+[[stations]]
+id = "EGVN_P_APP"
+parent_id = "EGVN_APP"
+controlled_by = ["EGVN_P_APP"]
+
+[[stations]]
+id = "EGVO_TWR"
+parent_id = "EGVO_APP"
+controlled_by = ["EGVO_TWR"]
+
+[[stations]]
+id = "EGVO_APP"
+parent_id = "EGVV_W_CTR"
+controlled_by = ["EGVO_APP", "EGVO_P_APP"]
+
+[[stations]]
+id = "EGVO_P_APP"
+parent_id = "EGVO_APP"
+controlled_by = ["EGVO_P_APP"]
+
+[[stations]]
+id = "EGVP_TWR"
+parent_id = "EGVP_APP"
+controlled_by = ["EGVP_TWR"]
+
+[[stations]]
+id = "EGVP_APP"
+parent_id = "EGVV_W_CTR"
+controlled_by = ["EGVP_APP"]
 
 [[stations]]
 id = "EGWU_GND"

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -1696,7 +1696,7 @@ controlled_by = ["EGUB_TWR"]
 
 [[stations]]
 id = "EGUB_APP"
-parent_id = "EGVV_W_CTR"
+parent_id = "STHRN_APP"
 controlled_by = ["EGUB_APP", "EGUB_P_APP"]
 
 [[stations]]
@@ -1777,7 +1777,7 @@ controlled_by = ["EGVO_TWR"]
 
 [[stations]]
 id = "EGVO_APP"
-parent_id = "EGVV_W_CTR"
+parent_id = "STHRN_APP"
 controlled_by = ["EGVO_APP", "EGVO_P_APP"]
 
 [[stations]]
@@ -1866,6 +1866,11 @@ controlled_by = ["ISLAND_CTR"]
 id = "SOLENT_APP"
 parent_id = "LON_HW_CTR"
 controlled_by = ["SOLENT_APP"]
+
+[[stations]]
+id = "STHRN_APP"
+parent_id = "EGVV_D_CTR"
+controlled_by = ["STHRN_APP"]
 
 [[stations]]
 id = "THAMES_APP"


### PR DESCRIPTION
### Description

<!-- What does this PR change and why? -->
Adds AC South profile.

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.

<img width="1000" height="753" alt="image" src="https://github.com/user-attachments/assets/75d83eb8-ce7d-4a14-b414-dcc31f4395a6" />
<img width="1000" height="753" alt="image" src="https://github.com/user-attachments/assets/f61acb52-be6a-4ee1-999f-c9da6b19ddca" />
<img width="1000" height="753" alt="image" src="https://github.com/user-attachments/assets/8abd5a16-d952-4fbc-8dda-aee3fb8cb39a" />
<img width="1000" height="753" alt="image" src="https://github.com/user-attachments/assets/7d2c6bff-ff69-4993-ba1f-cb5144880214" />
