### PR TITLE
Gatwick (EGKK) rework

### DIFF
--- a/dataset/EG/profiles/EGKK.json
+++ b/dataset/EG/profiles/EGKK.json
@@ -74,7 +74,8 @@
             "label": []
           },
           {
-            "label": []
+            "label": ["EGKA"],
+            "station_id": "EGKA_APP"
           },
           {
             "label": []

--- a/dataset/EG/profiles/EGKK.json
+++ b/dataset/EG/profiles/EGKK.json
@@ -90,7 +90,7 @@
             "label": []
           },
           {
-            "label": ["Solent", "RAD"],
+            "label": ["SOLENT", "RAD"],
             "station_id": "SOLENT_APP"
           },
           {

--- a/dataset/EG/profiles/EGKK.json
+++ b/dataset/EG/profiles/EGKK.json
@@ -69,7 +69,7 @@
           {
             "label": ["INT"],
             "station_id": "EGKK_APP"
-          },          
+          },
           {
             "label": []
           },
@@ -133,7 +133,7 @@
         ]
       }
     },
-        {
+    {
       "label": ["SUP", "Flow"],
       "page": {
         "rows": 2,

--- a/dataset/EG/profiles/EGKK.json
+++ b/dataset/EG/profiles/EGKK.json
@@ -105,7 +105,7 @@
             "label": []
           },
           {
-            "label": ["LL", "INT"],
+            "label": ["LL", "INT S"],
             "station_id": "EGLL_S_APP"
           },
           {

--- a/dataset/EG/profiles/EGKK.json
+++ b/dataset/EG/profiles/EGKK.json
@@ -3,9 +3,9 @@
   "type": "Tabbed",
   "tabs": [
     {
-      "label": "ADC",
+      "label": "EGKK",
       "page": {
-        "rows": 4,
+        "rows": 5,
         "keys": [
           {
             "label": ["GMP"],
@@ -15,15 +15,10 @@
             "label": []
           },
           {
-            "label": ["GMC", "North"],
-            "station_id": "EGKK_N_GND"
+            "label": []
           },
           {
-            "label": ["GMC", "South"],
-            "station_id": "EGKK_S_GND"
-          },
-          {
-            "label": ["GMP", "Assist"],
+            "label": ["GMP", "AST"],
             "station_id": "EGKK_A_DEL"
           },
           {
@@ -31,121 +26,12 @@
             "station_id": "EGKK_P_GND"
           },
           {
-            "label": ["AIR"],
-            "station_id": "EGKK_TWR"
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": ["EGKR"],
-            "station_id": "EGKR_TWR"
-          },
-          {
-            "label": []
-          },
-          {
-            "label": ["INT"],
-            "station_id": "EGKK_APP"
-          },
-          {
-            "label": ["FIN"],
-            "station_id": "EGKK_F_APP"
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": ["Solent", "RAD"],
-            "station_id": "SOLENT_APP"
-          },
-          {
-            "label": []
-          },
-          {
-            "label": ["TC", "SW"],
-            "station_id": "LTC_SW_CTR"
-          },
-          {
-            "label": ["TC", "Heathrow", "INT S"],
-            "station_id": "EGLL_S_APP"
-          },
-          {
-            "label": ["LF", "RAD"],
-            "station_id": "EGLF_APP"
-          },
-          {
-            "label": ["TC", "NE"],
-            "station_id": "LTC_NE_CTR"
-          },
-          {
-            "label": ["TC", "SE"],
-            "station_id": "LTC_SE_CTR"
-          },
-          {
-            "label": ["TC", "Thames"],
-            "station_id": "THAMES_APP"
-          },
-          {
-            "label": ["LF", "LARS"],
-            "station_id": "EGLF_L_APP"
-          }
-        ]
-      }
-    },
-    {
-      "label": "APC",
-      "page": {
-        "rows": 4,
-        "keys": [
-          {
-            "label": ["GMP"],
-            "station_id": "EGKK_DEL"
-          },
-          {
-            "label": []
-          },
-          {
-            "label": ["GMC", "North"],
+            "label": ["GMC", "NOR"],
             "station_id": "EGKK_N_GND"
           },
           {
-            "label": ["GMC", "South"],
+            "label": ["GMC", "STH"],
             "station_id": "EGKK_S_GND"
-          },
-          {
-            "label": ["GMP", "Assist"],
-            "station_id": "EGKK_A_DEL"
           },
           {
             "label": []
@@ -167,6 +53,9 @@
             "label": []
           },
           {
+            "label": []
+          },
+          {
             "label": ["EGKR"],
             "station_id": "EGKR_TWR"
           },
@@ -174,18 +63,38 @@
             "label": []
           },
           {
-            "label": ["INT"],
-            "station_id": "EGKK_APP"
-          },
-          {
             "label": ["FIN"],
             "station_id": "EGKK_F_APP"
           },
           {
+            "label": ["INT"],
+            "station_id": "EGKK_APP"
+          },          
+          {
             "label": []
           },
           {
             "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["Solent", "RAD"],
+            "station_id": "SOLENT_APP"
+          },
+          {
+            "label": ["TC", "NW"],
+            "station_id": "LTC_NW_CTR"
           },
           {
             "label": ["TC", "SW"],
@@ -195,7 +104,12 @@
             "label": []
           },
           {
-            "label": []
+            "label": ["LL", "INT"],
+            "station_id": "EGLL_S_APP"
+          },
+          {
+            "label": ["LF", "RAD"],
+            "station_id": "EGLF_APP"
           },
           {
             "label": ["TC", "NE"],
@@ -209,31 +123,7 @@
             "label": []
           },
           {
-            "label": ["Solent", "RAD"],
-            "station_id": "SOLENT_APP"
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": ["TC", "Heathrow", "INT S"],
-            "station_id": "EGLL_S_APP"
-          },
-          {
-            "label": ["LF", "RAD"],
-            "station_id": "EGLF_APP"
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": ["TC", "Thames"],
+            "label": ["TC", "TMS"],
             "station_id": "THAMES_APP"
           },
           {
@@ -271,15 +161,15 @@
             "label": []
           },
           {
-            "label": ["LAC", "Group", "Supvisr"],
+            "label": ["LAC", "GS"],
             "station_id": "LON_GS_CTR"
           },
           {
-            "label": ["LTC", "Group", "Supvisr"],
+            "label": ["LTC", "GS"],
             "station_id": "LTC_GS_CTR"
           },
           {
-            "label": ["MAN", "Group", "Supvisr"],
+            "label": ["MAN", "GS"],
             "station_id": "MAN_GS_CTR"
           },
           {
@@ -300,11 +190,11 @@
             "station_id": "SCL_FMP"
           },
           {
-            "label": ["ScAC", "Group", "Supvisr"],
+            "label": ["ScAC", "GS"],
             "station_id": "SCO_GS_CTR"
           },
           {
-            "label": ["SCL", "Group", "Supvisr"],
+            "label": ["SCL", "GS"],
             "station_id": "SCL_GS_CTR"
           }
         ]

--- a/dataset/EG/profiles/EGKK.json
+++ b/dataset/EG/profiles/EGKK.json
@@ -26,11 +26,11 @@
             "station_id": "EGKK_P_GND"
           },
           {
-            "label": ["GMC", "NOR"],
+            "label": ["GMC", "N"],
             "station_id": "EGKK_N_GND"
           },
           {
-            "label": ["GMC", "STH"],
+            "label": ["GMC", "S"],
             "station_id": "EGKK_S_GND"
           },
           {

--- a/dataset/EG/profiles/EGKK.json
+++ b/dataset/EG/profiles/EGKK.json
@@ -133,7 +133,7 @@
         ]
       }
     },
-    {
+        {
       "label": ["SUP", "Flow"],
       "page": {
         "rows": 2,
@@ -151,51 +151,16 @@
             "station_id": "UK_A_FMP"
           },
           {
-            "label": ["UK", "FMP", "3"],
-            "station_id": "UK_B_FMP"
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": ["LAC", "GS"],
-            "station_id": "LON_GS_CTR"
-          },
-          {
             "label": ["LTC", "GS"],
             "station_id": "LTC_GS_CTR"
           },
           {
-            "label": ["MAN", "GS"],
-            "station_id": "MAN_GS_CTR"
+            "label": ["UK", "FMP", "3"],
+            "station_id": "UK_B_FMP"
           },
           {
-            "label": ["MAN", "FMP"],
-            "station_id": "MAN_FMP"
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
-          },
-          {
-            "label": ["SCL", "FMP"],
-            "station_id": "SCL_FMP"
-          },
-          {
-            "label": ["ScAC", "GS"],
-            "station_id": "SCO_GS_CTR"
-          },
-          {
-            "label": ["SCL", "GS"],
-            "station_id": "SCL_GS_CTR"
+            "label": ["LAC", "GS"],
+            "station_id": "LON_GS_CTR"
           }
         ]
       }


### PR DESCRIPTION
### Description

Tidys up KK profile

<img width="779" height="1154" alt="image" src="https://github.com/user-attachments/assets/a3ea7a4f-9d12-4d11-bfac-277cb0d66354" />

<img width="336" height="1156" alt="image" src="https://github.com/user-attachments/assets/5e3b159d-bbed-4880-987f-642488018cf5" />


### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
