### PR TITLE
Add AC North Profile

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -2162,28 +2162,28 @@ id = "LON_NE_CTR"
 prefixes = ["LON"]
 frequency = "128.130"
 facility_type = "CTR"
-profile_id = "EG-North_LAG"
+profile_id = "EG-AC_North"
 
 [[positions]]
 id = "LON_NU_CTR"
 prefixes = ["LON"]
 frequency = "132.860"
 facility_type = "CTR"
-profile_id = "EG-North_LAG"
+profile_id = "EG-AC_North"
 
 [[positions]]
 id = "LON_NW_CTR"
 prefixes = ["LON"]
 frequency = "135.580"
 facility_type = "CTR"
-profile_id = "EG-North_LAG"
+profile_id = "EG-AC_North"
 
 [[positions]]
 id = "LON_N_CTR"
 prefixes = ["LON"]
 frequency = "133.705"
 facility_type = "CTR"
-profile_id = "EG-North_LAG"
+profile_id = "EG-AC_North"
 
 [[positions]]
 id = "LON_O_CTR"

--- a/dataset/EG/profiles/EG-AC_North.json
+++ b/dataset/EG/profiles/EG-AC_North.json
@@ -8,7 +8,7 @@
         "rows": 5,
         "keys": [
           {
-            "label": ["EISN", "LIFFY", "SUPER"],
+            "label": ["EISN", "LIFFY", "F355+"],
             "color": "lavender",
             "station_id": "EISN_ES_CTR"
           },
@@ -676,12 +676,12 @@
         "rows": 5,
         "keys": [
           {
-            "label": ["EISN", "LIFFY", "SUPER"],
+            "label": ["EISN", "LIFFY", "F355+"],
             "color": "lavender",
             "station_id": "EISN_ES_CTR"
           },
           {
-            "label": ["EISN", "LIFFY"],
+            "label": ["EISN", "LIFFY", "F245-355"],
             "color": "lavender",
             "station_id": "EISN_E_CTR"
           },
@@ -766,9 +766,9 @@
             "station_id": "EG-Sector-27-32"
           },
           {
-            "label": ["AC", "S28", "DTY N LO"],
+            "label": ["TC", "COWLY"],
             "color": "blush",
-            "station_id": "EG-Sector-28"
+            "station_id": "EG-TC-COWLY"
           },
           {
             "label": ["PC", "NORTH"],
@@ -791,9 +791,9 @@
             "station_id": "EG-Sector-34"
           },
           {
-            "label": ["TC", "COWLY"],
+            "label": ["AC", "S28", "DTY N LO"],
             "color": "blush",
-            "station_id": "EG-TC-COWLY"
+            "station_id": "EG-Sector-28"
           },
           {
             "label": ["PC", "EAST"],

--- a/dataset/EG/profiles/EG-AC_North.json
+++ b/dataset/EG/profiles/EG-AC_North.json
@@ -119,7 +119,7 @@
                   "station_id": "EGVV_E_CTR"
                 },
                 {
-                  "label": ["MIL", "N"],
+                  "label": ["MIL", "W"],
                   "color": "azure",
                   "station_id": "EGVV_W_CTR"
                 },

--- a/dataset/EG/profiles/EG-AC_North.json
+++ b/dataset/EG/profiles/EG-AC_North.json
@@ -1,0 +1,890 @@
+{
+  "id": "EG-AC_North",
+  "type": "Tabbed",
+  "tabs": [
+    {
+      "label": ["1", "Main"],
+      "page": {
+        "rows": 5,
+        "keys": [
+          {
+            "label": ["EISN", "LIFFY", "SUPER"],
+            "color": "lavender",
+            "station_id": "EISN_ES_CTR"
+          },
+          {
+            "label": ["EISN", "LIFFY"],
+            "color": "lavender",
+            "station_id": "EISN_E_CTR"
+          },
+          {
+            "label": ["EIDW", "UN"],
+            "color": "lavender",
+            "station_id": "EIDW_UN_CTR"
+          },
+          {
+            "label": ["EIDW", "US"],
+            "color": "lavender",
+            "station_id": "EIDW_US_CTR"
+          },
+          {
+            "label": ["AC", "W"],
+            "color": "blush",
+            "station_id": "LON_W_CTR"
+          },
+          {
+            "label": ["ScAC", "RAT"],
+            "color": "azure",
+            "station_id": "EG-Rathlin"
+          },
+          {
+            "label": ["SCL", "ANT"],
+            "color": "azure",
+            "station_id": "EG-Antrim"
+          },
+          {
+            "label": ["AC", "LKS"],
+            "color": "blush",
+            "station_id": "LON_NW_CTR"
+          },
+          {
+            "label": ["PC", "W"],
+            "color": "blush",
+            "station_id": "MAN_W_CTR"
+          },
+          {
+            "label": ["MIL"],
+            "color": "azure",
+            "page": {
+                "rows": 5,
+                "keys": [
+                    {
+                        "label": ["EGOV", "APC"],
+                        "color": "azure",
+                        "station_id": "EGOV_APP"
+                    },
+                    {
+                        "label": ["EGOS", "APC"],
+                        "color": "azure",
+                        "station_id": "EGOS_APP"
+                    },
+                    {
+                        "label": ["EGXE", "APC"],
+                        "color": "azure",
+                        "station_id": "EGXE_APP"
+                    },
+                    {
+                        "label": ["EGXZ", "APC"],
+                        "color": "azure",
+                        "station_id": "EGXZ_APP"
+                    },
+                    {
+                        "label": ["EGXW", "APC"],
+                        "color": "azure",
+                        "station_id": "EGXW_APP"
+                    },
+                    {
+                        "label": ["EGYD", "APC"],
+                        "color": "azure",
+                        "station_id": "EGYD_APP"
+                    },
+                    {
+                        "label": ["EGXC", "APC"],
+                        "color": "azure",
+                        "station_id": "EGXC_APP"
+                    },
+                    {
+                        "label": ["EGXT", "APC"],
+                        "color": "azure",
+                        "station_id": "EGXT_APP"
+                    },
+                    {
+                        "label": ["EGYM", "APC"],
+                        "color": "azure",
+                        "station_id": "EGYM_APP"
+                    },
+                    {
+                        "label": ["EGUL", "APC"],
+                        "color": "azure",
+                        "station_id": "EGUL_APP"
+                    },
+                    {
+                        "label": ["MIL", "N"],
+                        "color": "azure",
+                        "station_id": "EGVV_N_CTR"
+                    },
+                    {
+                        "label": ["MIL", "E"],
+                        "color": "azure",
+                        "station_id": "EGVV_E_CTR"
+                    },
+                    {
+                        "label": ["MIL", "N"],
+                        "color": "azure",
+                        "station_id": "EGVV_W_CTR"
+                    },
+                    {
+                        "label": []
+                    },
+                    {
+                        "label": []
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["ScAC", "BDS"],
+            "color": "azure",
+            "station_id": "EG-Borders"
+          },
+          {
+            "label": ["SCL", "GAL"],
+            "color": "azure",
+            "station_id": "EG-Galloway"
+          },
+          {
+            "label": ["AC", "DTY"],
+            "color": "blush",
+            "station_id": "LON_M_CTR"
+          },
+          {
+            "label": ["PC", "SE"],
+            "color": "blush",
+            "station_id": "MAN_SE_CTR"
+          },
+          {
+            "label": ["TC", "MIDS"],
+            "color": "blush",
+            "station_id": "LTC_M_CTR"
+          },
+          {
+            "label": ["ScAC", "S"],
+            "color": "azure",
+            "station_id": "SCO_S_CTR"
+          },
+          {
+            "label": ["SCL", "TLA"],
+            "color": "azure",
+            "station_id": "EG-Talla"
+          },
+          {
+            "label": ["AC", "NSEA"],
+            "color": "blush",
+            "station_id": "LON_NE_CTR"
+          },
+          {
+            "label": ["PC", "NE"],
+            "color": "blush",
+            "station_id": "MAN_NE_CTR"
+          },
+          {
+            "label": ["AC", "GS"],
+            "color": "mint",
+            "station_id": "LON_GS_CTR"
+          },
+          {
+            "label": ["MAAS", "DELTA"],
+            "color": "lavender"
+          },
+          {
+            "label": ["EHAA", "W"],
+            "color": "lavender",
+            "station_id": "EHAA_W"
+          },
+          {
+            "label": ["AC", "CLN"],
+            "color": "blush",
+            "station_id": "LON_E_CTR"
+          },
+          {
+            "label": ["TC", "EAST"],
+            "color": "blush",
+            "station_id": "LTC_E_CTR"
+          },
+          {
+            "label": ["FIS"],
+            "color": "blush",
+            "station_id": "EGTT_I_CTR"
+          }
+        ]
+      }
+    },
+    {
+      "label": ["2", "AD"],
+      "page": {
+        "rows": 5,
+        "keys": [
+          {
+            "label": ["CC", "INT", "S"],
+            "color": "azure",
+            "station_id": "EGCC_S_APP"
+          },
+          {
+            "label": ["GP", "RAD"],
+            "color": "azure",
+            "station_id": "EGGP_APP"
+          },
+          {
+            "label": ["BB", "RAD"],
+            "color": "azure",
+            "station_id": "EGBB_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["NT", "RAD"],
+            "color": "azure",
+            "station_id": "EGNT_APP"
+          },
+          {
+            "label": ["NM", "RAD"],
+            "color": "azure",
+            "station_id": "EGNM_APP"
+          },
+          {
+            "label": ["NX", "RAD"],
+            "color": "azure",
+            "station_id": "EGNX_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["EGCC"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["GMP"],
+                        "color": "azure",
+                        "station_id": "EGCC_DEL"
+                    },
+                    {
+                        "label": ["GMC"],
+                        "color": "azure",
+                        "station_id": "EGCC_GND"
+                    },
+                    {
+                        "label": ["AIR 1"],
+                        "color": "azure",
+                        "station_id": "EGCC_N_TWR"
+                    },
+                    {
+                        "label": ["AIR 2"],
+                        "color": "azure",
+                        "station_id": "EGVV_W_CTR"
+                    },
+                    {
+                        "label": ["INT N"],
+                        "color": "azure",
+                        "station_id": "EGCC_N_APP"
+                    },
+                    {
+                        "label": ["FIN"],
+                        "color": "azure",
+                        "station_id": "EGCC_F_APP"
+                    },
+                    {
+                        "label": ["INT S"],
+                        "color": "azure",
+                        "station_id": "EGCC_S_APP"
+                    },
+                    {
+                        "label": []
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGGP"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["GMC"],
+                        "color": "azure",
+                        "station_id": "EGGP_GND"
+                    },
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGGP_TWR"
+                    },
+                    {
+                        "label": ["RAD 1"],
+                        "color": "azure",
+                        "station_id": "EGGP_APP"
+                    },
+                    {
+                        "label": ["RAD 2"],
+                        "color": "azure",
+                        "station_id": "EGGP_F_APP"
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGCB"],
+            "color": "azure",
+            "station_id": "EGCB_I_TWR"
+          },
+          {
+            "label": ["EGNS"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGNS_TWR"
+                    },
+                    {
+                        "label": ["RAD 1/", "APC"],
+                        "color": "azure",
+                        "station_id": "EGNS_APP"
+                    },
+                    {
+                        "label": ["RAD 2"],
+                        "color": "azure",
+                        "station_id": "EGNS_F_APP"
+                    },
+                    {
+                        "label": []
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGBB"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["GMP"],
+                        "color": "azure",
+                        "station_id": "EGBB_DEL"
+                    },
+                    {
+                        "label": ["GMC"],
+                        "color": "azure",
+                        "station_id": "EGBB_GND"
+                    },
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGBB_TWR"
+                    },
+                    {
+                        "label": []
+                    },
+                    {
+                        "label": ["INT"],
+                        "color": "azure",
+                        "station_id": "EGBB_APP"
+                    },
+                    {
+                        "label": ["FIN"],
+                        "color": "azure",
+                        "station_id": "EGBB_F_APP"
+                    },
+                    {
+                        "label": []
+                    },
+                    {
+                        "label": []
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGNT"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["GMC"],
+                        "color": "azure",
+                        "station_id": "EGNT_GND"
+                    },
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGNT_TWR"
+                    },
+                    {
+                        "label": ["RAD"],
+                        "color": "azure",
+                        "station_id": "EGNT_APP"
+                    },
+                    {
+                        "label": ["FIN"],
+                        "color": "azure",
+                        "station_id": "EGNT_F_APP"
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGNR"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGNR_TWR"
+                    },
+                    {
+                        "label": ["RAD"],
+                        "color": "azure",
+                        "station_id": "EGNR_APP"
+                    },
+                    {
+                        "label": ["FIN"],
+                        "color": "azure",
+                        "station_id": "EGNR_F_APP"
+                    },
+                    {
+                        "label": []
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGNH"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGNH_TWR"
+                    },
+                    {
+                        "label": ["APC"],
+                        "color": "azure",
+                        "station_id": "EGNH_A_APP"
+                    },
+                    {
+                        "label": []
+                    },
+                    {
+                        "label": []
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGNO"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGNO_TWR"
+                    },
+                    {
+                        "label": ["RAD"],
+                        "color": "azure",
+                        "station_id": "EGNO_APP"
+                    },
+                    {
+                        "label": ["T/D"],
+                        "color": "azure",
+                        "station_id": "EGNO_P_APP"
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGNX"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["GMC"],
+                        "color": "azure",
+                        "station_id": "EGNX_GND"
+                    },
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGNX_TWR"
+                    },
+                    {
+                        "label": ["RAD 1"],
+                        "color": "azure",
+                        "station_id": "EGNX_APP"
+                    },
+                    {
+                        "label": ["RAD 2"],
+                        "color": "azure",
+                        "station_id": "EGNX_F_APP"
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGNV"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGNV_TWR"
+                    },
+                    {
+                        "label": ["RAD"],
+                        "color": "azure",
+                        "station_id": "EGNV_APP"
+                    },
+                    {
+                        "label": ["DIR"],
+                        "color": "azure",
+                        "station_id": "EGNV_F_APP"
+                    },
+                    {
+                        "label": []
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGNM"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["GMP"],
+                        "color": "azure",
+                        "station_id": "EGNM_DEL"
+                    },
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGNM_TWR"
+                    },
+                    {
+                        "label": ["RAD"],
+                        "color": "azure",
+                        "station_id": "EGNM_APP"
+                    },
+                    {
+                        "label": ["DIR"],
+                        "color": "azure",
+                        "station_id": "EGNM_F_APP"
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGNJ"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGNJ_TWR"
+                    },
+                    {
+                        "label": ["RAD"],
+                        "color": "azure",
+                        "station_id": "EGNJ_APP"
+                    },
+                    {
+                        "label": []
+                    },
+                    {
+                        "label": []
+                    }
+                ]
+            }
+          },
+          {
+            "label": ["EGSH"],
+            "color": "azure",
+            "page": {
+                "rows": 4,
+                "keys": [
+                    {
+                        "label": ["TWR"],
+                        "color": "azure",
+                        "station_id": "EGSH_TWR"
+                    },
+                    {
+                        "label": ["RAD"],
+                        "color": "azure",
+                        "station_id": "EGSH_APP"
+                    },
+                    {
+                        "label": ["DIR"],
+                        "color": "azure",
+                        "station_id": "EGSH_F_APP"
+                    },
+                    {
+                        "label": []
+                    }
+                ]
+            }
+          },
+          {
+              "label": []
+          }
+        ]
+      }
+    },
+    {
+      "label": ["3", "Event"],
+      "page": {
+        "rows": 5,
+        "keys": [
+          {
+            "label": ["EISN", "LIFFY", "SUPER"],
+            "color": "lavender",
+            "station_id": "EISN_ES_CTR"
+          },
+          {
+            "label": ["EISN", "LIFFY"],
+            "color": "lavender",
+            "station_id": "EISN_E_CTR"
+          },
+          {
+            "label": ["EIDW", "UN"],
+            "color": "lavender",
+            "station_id": "EIDW_UN_CTR"
+          },
+          {
+            "label": ["EIDW", "US"],
+            "color": "lavender",
+            "station_id": "EIDW_US_CTR"
+          },
+          {
+            "label": ["PC", "IOM"],
+            "color": "blush",
+            "station_id": "EG-MPC-IoM"
+          },
+          {
+            "label": ["ScAC", "RAT"],
+            "color": "azure",
+            "station_id": "EG-Rathlin"
+          },
+          {
+            "label": ["SCL", "ANT"],
+            "color": "azure",
+            "station_id": "EG-Antrim"
+          },
+          {
+            "label": ["AC", "S35", "BCN"],
+            "color": "blush",
+            "station_id": "EG-Sector-35"
+          },
+          {
+            "label": ["AC", "S5", "BCN LO"],
+            "color": "blush",
+            "station_id": "EG-Sector-05"
+          },
+          {
+            "label": ["PC", "WAL"],
+            "color": "blush",
+            "station_id": "EG-MPC-Wallasey"
+          },
+          {
+            "label": ["ScAC", "SOL", "F255-355"],
+            "color": "azure",
+            "station_id": "EG-Solway"
+          },
+          {
+            "label": ["SCL", "GAL"],
+            "color": "azure",
+            "station_id": "EG-Galloway"
+          },
+          {
+            "label": ["AC", "S4", "LKS"],
+            "color": "blush",
+            "station_id": "EG-Sector-04"
+          },
+          {
+            "label": ["AC", "S3/7", "LKS"],
+            "color": "blush",
+            "station_id": "LON_NW_CTR"
+          },
+          {
+            "label": ["PC", "S29"],
+            "color": "blush",
+            "station_id": "EG-Sector-29"
+          },
+          {
+            "label": ["ScAC", "PEN", "F255-355"],
+            "color": "azure",
+            "station_id": "EG-Pennine"
+          },
+          {
+            "label": ["SCL", "TLA"],
+            "color": "azure",
+            "station_id": "EG-Talla"
+          },
+          {
+            "label": ["AC", "S27/32", "DTY S"],
+            "color": "blush",
+            "station_id": "EG-Sector-27-32"
+          },
+          {
+            "label": ["AC", "S28", "DTY N LO"],
+            "color": "blush",
+            "station_id": "EG-Sector-28"
+          },
+          {
+            "label": ["PC", "NORTH"],
+            "color": "blush",
+            "station_id": "EG-MPC-North"
+          },
+          {
+            "label": ["ScAC", "BDS", "F355+"],
+            "color": "azure",
+            "station_id": "EG-Borders"
+          },
+          {
+            "label": ["SCL", "TAY"],
+            "color": "azure",
+            "station_id": "EG-Tay"
+          },
+          {
+            "label": ["AC", "S34", "DTY N"],
+            "color": "blush",
+            "station_id": "EG-Sector-34"
+          },
+          {
+            "label": ["TC", "COWLY"],
+            "color": "blush",
+            "station_id": "EG-TC-COWLY"
+          },
+          {
+            "label": ["PC", "EAST"],
+            "color": "blush",
+            "station_id": "EG-MPC-East"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": ["AC", "NSEA"],
+            "color": "blush",
+            "station_id": "LON_NE_CTR"
+          },
+          {
+            "label": ["TC", "WELIN"],
+            "color": "blush",
+            "station_id": "EG-TC-WELIN"
+          },
+          {
+            "label": ["PC", "STAFA"],
+            "color": "blush",
+            "station_id": "EG-MPC-Stafa"
+          },
+          {
+            "label": ["MAAS", "DELTA"],
+            "color": "lavender"
+          },
+          {
+            "label": ["EHAA", "W"],
+            "color": "lavender",
+            "station_id": "EHAA_W"
+          },
+          {
+            "label": ["AC", "S12", "CLN"],
+            "color": "blush",
+            "station_id": "EG-Sector-12"
+          },
+          {
+            "label": ["TC", "REDFA"],
+            "color": "blush",
+            "station_id": "EG-TC-REDFA"
+          },
+          {
+            "label": ["PC", "TRENT"],
+            "color": "blush",
+            "station_id": "EG-MPC-Trent"
+          }
+        ]
+      }
+    },
+    {
+      "label": ["4", "SUP"],
+      "page": {
+        "rows": 3,
+        "keys": [
+          {
+            "label": ["UK", "FMP"],
+            "color": "mint",
+            "station_id": "UK_FMP"
+          },
+          {
+            "label": ["LTC", "FMP"],
+            "color": "mint",
+            "station_id": "LTC_FMP"
+          },
+          {
+            "label": ["UK", "FMP", "2"],
+            "color": "mint",
+            "station_id": "UK_A_FMP"
+          },
+          {
+            "label": ["UK", "FMP", "3"],
+            "color": "mint",
+            "station_id": "UK_B_FMP"
+          },
+          {
+            "label": ["LAC", "GS"],
+            "color": "mint",
+            "station_id": "LON_GS_CTR"
+          },
+          {
+            "label": ["LTC", "GS"],
+            "color": "mint",
+            "station_id": "LTC_GS_CTR"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dataset/EG/profiles/EG-AC_North.json
+++ b/dataset/EG/profiles/EG-AC_North.json
@@ -56,80 +56,80 @@
             "label": ["MIL"],
             "color": "azure",
             "page": {
-                "rows": 5,
-                "keys": [
-                    {
-                        "label": ["EGOV", "APC"],
-                        "color": "azure",
-                        "station_id": "EGOV_APP"
-                    },
-                    {
-                        "label": ["EGOS", "APC"],
-                        "color": "azure",
-                        "station_id": "EGOS_APP"
-                    },
-                    {
-                        "label": ["EGXE", "APC"],
-                        "color": "azure",
-                        "station_id": "EGXE_APP"
-                    },
-                    {
-                        "label": ["EGXZ", "APC"],
-                        "color": "azure",
-                        "station_id": "EGXZ_APP"
-                    },
-                    {
-                        "label": ["EGXW", "APC"],
-                        "color": "azure",
-                        "station_id": "EGXW_APP"
-                    },
-                    {
-                        "label": ["EGYD", "APC"],
-                        "color": "azure",
-                        "station_id": "EGYD_APP"
-                    },
-                    {
-                        "label": ["EGXC", "APC"],
-                        "color": "azure",
-                        "station_id": "EGXC_APP"
-                    },
-                    {
-                        "label": ["EGXT", "APC"],
-                        "color": "azure",
-                        "station_id": "EGXT_APP"
-                    },
-                    {
-                        "label": ["EGYM", "APC"],
-                        "color": "azure",
-                        "station_id": "EGYM_APP"
-                    },
-                    {
-                        "label": ["EGUL", "APC"],
-                        "color": "azure",
-                        "station_id": "EGUL_APP"
-                    },
-                    {
-                        "label": ["MIL", "N"],
-                        "color": "azure",
-                        "station_id": "EGVV_N_CTR"
-                    },
-                    {
-                        "label": ["MIL", "E"],
-                        "color": "azure",
-                        "station_id": "EGVV_E_CTR"
-                    },
-                    {
-                        "label": ["MIL", "N"],
-                        "color": "azure",
-                        "station_id": "EGVV_W_CTR"
-                    },
-                    {
-                        "label": []
-                    },
-                    {
-                        "label": []
-                    }
-                ]
+              "rows": 5,
+              "keys": [
+                {
+                  "label": ["EGOV", "APC"],
+                  "color": "azure",
+                  "station_id": "EGOV_APP"
+                },
+                {
+                  "label": ["EGOS", "APC"],
+                  "color": "azure",
+                  "station_id": "EGOS_APP"
+                },
+                {
+                  "label": ["EGXE", "APC"],
+                  "color": "azure",
+                  "station_id": "EGXE_APP"
+                },
+                {
+                  "label": ["EGXZ", "APC"],
+                  "color": "azure",
+                  "station_id": "EGXZ_APP"
+                },
+                {
+                  "label": ["EGXW", "APC"],
+                  "color": "azure",
+                  "station_id": "EGXW_APP"
+                },
+                {
+                  "label": ["EGYD", "APC"],
+                  "color": "azure",
+                  "station_id": "EGYD_APP"
+                },
+                {
+                  "label": ["EGXC", "APC"],
+                  "color": "azure",
+                  "station_id": "EGXC_APP"
+                },
+                {
+                  "label": ["EGXT", "APC"],
+                  "color": "azure",
+                  "station_id": "EGXT_APP"
+                },
+                {
+                  "label": ["EGYM", "APC"],
+                  "color": "azure",
+                  "station_id": "EGYM_APP"
+                },
+                {
+                  "label": ["EGUL", "APC"],
+                  "color": "azure",
+                  "station_id": "EGUL_APP"
+                },
+                {
+                  "label": ["MIL", "N"],
+                  "color": "azure",
+                  "station_id": "EGVV_N_CTR"
+                },
+                {
+                  "label": ["MIL", "E"],
+                  "color": "azure",
+                  "station_id": "EGVV_E_CTR"
+                },
+                {
+                  "label": ["MIL", "N"],
+                  "color": "azure",
+                  "station_id": "EGVV_W_CTR"
+                },
+                {
+                  "label": []
+                },
+                {
+                  "label": []
+                }
+              ]
             }
           },
           {
@@ -275,76 +275,76 @@
             "label": ["EGCC"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["GMP"],
-                        "color": "azure",
-                        "station_id": "EGCC_DEL"
-                    },
-                    {
-                        "label": ["GMC"],
-                        "color": "azure",
-                        "station_id": "EGCC_GND"
-                    },
-                    {
-                        "label": ["AIR 1"],
-                        "color": "azure",
-                        "station_id": "EGCC_N_TWR"
-                    },
-                    {
-                        "label": ["AIR 2"],
-                        "color": "azure",
-                        "station_id": "EGVV_W_CTR"
-                    },
-                    {
-                        "label": ["INT N"],
-                        "color": "azure",
-                        "station_id": "EGCC_N_APP"
-                    },
-                    {
-                        "label": ["FIN"],
-                        "color": "azure",
-                        "station_id": "EGCC_F_APP"
-                    },
-                    {
-                        "label": ["INT S"],
-                        "color": "azure",
-                        "station_id": "EGCC_S_APP"
-                    },
-                    {
-                        "label": []
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["GMP"],
+                  "color": "azure",
+                  "station_id": "EGCC_DEL"
+                },
+                {
+                  "label": ["GMC"],
+                  "color": "azure",
+                  "station_id": "EGCC_GND"
+                },
+                {
+                  "label": ["AIR 1"],
+                  "color": "azure",
+                  "station_id": "EGCC_N_TWR"
+                },
+                {
+                  "label": ["AIR 2"],
+                  "color": "azure",
+                  "station_id": "EGVV_W_CTR"
+                },
+                {
+                  "label": ["INT N"],
+                  "color": "azure",
+                  "station_id": "EGCC_N_APP"
+                },
+                {
+                  "label": ["FIN"],
+                  "color": "azure",
+                  "station_id": "EGCC_F_APP"
+                },
+                {
+                  "label": ["INT S"],
+                  "color": "azure",
+                  "station_id": "EGCC_S_APP"
+                },
+                {
+                  "label": []
+                }
+              ]
             }
           },
           {
             "label": ["EGGP"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["GMC"],
-                        "color": "azure",
-                        "station_id": "EGGP_GND"
-                    },
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGGP_TWR"
-                    },
-                    {
-                        "label": ["RAD 1"],
-                        "color": "azure",
-                        "station_id": "EGGP_APP"
-                    },
-                    {
-                        "label": ["RAD 2"],
-                        "color": "azure",
-                        "station_id": "EGGP_F_APP"
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["GMC"],
+                  "color": "azure",
+                  "station_id": "EGGP_GND"
+                },
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGGP_TWR"
+                },
+                {
+                  "label": ["RAD 1"],
+                  "color": "azure",
+                  "station_id": "EGGP_APP"
+                },
+                {
+                  "label": ["RAD 2"],
+                  "color": "azure",
+                  "station_id": "EGGP_F_APP"
+                }
+              ]
             }
           },
           {
@@ -356,316 +356,316 @@
             "label": ["EGNS"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGNS_TWR"
-                    },
-                    {
-                        "label": ["RAD 1/", "APC"],
-                        "color": "azure",
-                        "station_id": "EGNS_APP"
-                    },
-                    {
-                        "label": ["RAD 2"],
-                        "color": "azure",
-                        "station_id": "EGNS_F_APP"
-                    },
-                    {
-                        "label": []
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGNS_TWR"
+                },
+                {
+                  "label": ["RAD 1/", "APC"],
+                  "color": "azure",
+                  "station_id": "EGNS_APP"
+                },
+                {
+                  "label": ["RAD 2"],
+                  "color": "azure",
+                  "station_id": "EGNS_F_APP"
+                },
+                {
+                  "label": []
+                }
+              ]
             }
           },
           {
             "label": ["EGBB"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["GMP"],
-                        "color": "azure",
-                        "station_id": "EGBB_DEL"
-                    },
-                    {
-                        "label": ["GMC"],
-                        "color": "azure",
-                        "station_id": "EGBB_GND"
-                    },
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGBB_TWR"
-                    },
-                    {
-                        "label": []
-                    },
-                    {
-                        "label": ["INT"],
-                        "color": "azure",
-                        "station_id": "EGBB_APP"
-                    },
-                    {
-                        "label": ["FIN"],
-                        "color": "azure",
-                        "station_id": "EGBB_F_APP"
-                    },
-                    {
-                        "label": []
-                    },
-                    {
-                        "label": []
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["GMP"],
+                  "color": "azure",
+                  "station_id": "EGBB_DEL"
+                },
+                {
+                  "label": ["GMC"],
+                  "color": "azure",
+                  "station_id": "EGBB_GND"
+                },
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGBB_TWR"
+                },
+                {
+                  "label": []
+                },
+                {
+                  "label": ["INT"],
+                  "color": "azure",
+                  "station_id": "EGBB_APP"
+                },
+                {
+                  "label": ["FIN"],
+                  "color": "azure",
+                  "station_id": "EGBB_F_APP"
+                },
+                {
+                  "label": []
+                },
+                {
+                  "label": []
+                }
+              ]
             }
           },
           {
             "label": ["EGNT"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["GMC"],
-                        "color": "azure",
-                        "station_id": "EGNT_GND"
-                    },
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGNT_TWR"
-                    },
-                    {
-                        "label": ["RAD"],
-                        "color": "azure",
-                        "station_id": "EGNT_APP"
-                    },
-                    {
-                        "label": ["FIN"],
-                        "color": "azure",
-                        "station_id": "EGNT_F_APP"
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["GMC"],
+                  "color": "azure",
+                  "station_id": "EGNT_GND"
+                },
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGNT_TWR"
+                },
+                {
+                  "label": ["RAD"],
+                  "color": "azure",
+                  "station_id": "EGNT_APP"
+                },
+                {
+                  "label": ["FIN"],
+                  "color": "azure",
+                  "station_id": "EGNT_F_APP"
+                }
+              ]
             }
           },
           {
             "label": ["EGNR"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGNR_TWR"
-                    },
-                    {
-                        "label": ["RAD"],
-                        "color": "azure",
-                        "station_id": "EGNR_APP"
-                    },
-                    {
-                        "label": ["FIN"],
-                        "color": "azure",
-                        "station_id": "EGNR_F_APP"
-                    },
-                    {
-                        "label": []
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGNR_TWR"
+                },
+                {
+                  "label": ["RAD"],
+                  "color": "azure",
+                  "station_id": "EGNR_APP"
+                },
+                {
+                  "label": ["FIN"],
+                  "color": "azure",
+                  "station_id": "EGNR_F_APP"
+                },
+                {
+                  "label": []
+                }
+              ]
             }
           },
           {
             "label": ["EGNH"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGNH_TWR"
-                    },
-                    {
-                        "label": ["APC"],
-                        "color": "azure",
-                        "station_id": "EGNH_A_APP"
-                    },
-                    {
-                        "label": []
-                    },
-                    {
-                        "label": []
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGNH_TWR"
+                },
+                {
+                  "label": ["APC"],
+                  "color": "azure",
+                  "station_id": "EGNH_A_APP"
+                },
+                {
+                  "label": []
+                },
+                {
+                  "label": []
+                }
+              ]
             }
           },
           {
             "label": ["EGNO"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGNO_TWR"
-                    },
-                    {
-                        "label": ["RAD"],
-                        "color": "azure",
-                        "station_id": "EGNO_APP"
-                    },
-                    {
-                        "label": ["T/D"],
-                        "color": "azure",
-                        "station_id": "EGNO_P_APP"
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGNO_TWR"
+                },
+                {
+                  "label": ["RAD"],
+                  "color": "azure",
+                  "station_id": "EGNO_APP"
+                },
+                {
+                  "label": ["T/D"],
+                  "color": "azure",
+                  "station_id": "EGNO_P_APP"
+                }
+              ]
             }
           },
           {
             "label": ["EGNX"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["GMC"],
-                        "color": "azure",
-                        "station_id": "EGNX_GND"
-                    },
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGNX_TWR"
-                    },
-                    {
-                        "label": ["RAD 1"],
-                        "color": "azure",
-                        "station_id": "EGNX_APP"
-                    },
-                    {
-                        "label": ["RAD 2"],
-                        "color": "azure",
-                        "station_id": "EGNX_F_APP"
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["GMC"],
+                  "color": "azure",
+                  "station_id": "EGNX_GND"
+                },
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGNX_TWR"
+                },
+                {
+                  "label": ["RAD 1"],
+                  "color": "azure",
+                  "station_id": "EGNX_APP"
+                },
+                {
+                  "label": ["RAD 2"],
+                  "color": "azure",
+                  "station_id": "EGNX_F_APP"
+                }
+              ]
             }
           },
           {
             "label": ["EGNV"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGNV_TWR"
-                    },
-                    {
-                        "label": ["RAD"],
-                        "color": "azure",
-                        "station_id": "EGNV_APP"
-                    },
-                    {
-                        "label": ["DIR"],
-                        "color": "azure",
-                        "station_id": "EGNV_F_APP"
-                    },
-                    {
-                        "label": []
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGNV_TWR"
+                },
+                {
+                  "label": ["RAD"],
+                  "color": "azure",
+                  "station_id": "EGNV_APP"
+                },
+                {
+                  "label": ["DIR"],
+                  "color": "azure",
+                  "station_id": "EGNV_F_APP"
+                },
+                {
+                  "label": []
+                }
+              ]
             }
           },
           {
             "label": ["EGNM"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["GMP"],
-                        "color": "azure",
-                        "station_id": "EGNM_DEL"
-                    },
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGNM_TWR"
-                    },
-                    {
-                        "label": ["RAD"],
-                        "color": "azure",
-                        "station_id": "EGNM_APP"
-                    },
-                    {
-                        "label": ["DIR"],
-                        "color": "azure",
-                        "station_id": "EGNM_F_APP"
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["GMP"],
+                  "color": "azure",
+                  "station_id": "EGNM_DEL"
+                },
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGNM_TWR"
+                },
+                {
+                  "label": ["RAD"],
+                  "color": "azure",
+                  "station_id": "EGNM_APP"
+                },
+                {
+                  "label": ["DIR"],
+                  "color": "azure",
+                  "station_id": "EGNM_F_APP"
+                }
+              ]
             }
           },
           {
             "label": ["EGNJ"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGNJ_TWR"
-                    },
-                    {
-                        "label": ["RAD"],
-                        "color": "azure",
-                        "station_id": "EGNJ_APP"
-                    },
-                    {
-                        "label": []
-                    },
-                    {
-                        "label": []
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGNJ_TWR"
+                },
+                {
+                  "label": ["RAD"],
+                  "color": "azure",
+                  "station_id": "EGNJ_APP"
+                },
+                {
+                  "label": []
+                },
+                {
+                  "label": []
+                }
+              ]
             }
           },
           {
             "label": ["EGSH"],
             "color": "azure",
             "page": {
-                "rows": 4,
-                "keys": [
-                    {
-                        "label": ["TWR"],
-                        "color": "azure",
-                        "station_id": "EGSH_TWR"
-                    },
-                    {
-                        "label": ["RAD"],
-                        "color": "azure",
-                        "station_id": "EGSH_APP"
-                    },
-                    {
-                        "label": ["DIR"],
-                        "color": "azure",
-                        "station_id": "EGSH_F_APP"
-                    },
-                    {
-                        "label": []
-                    }
-                ]
+              "rows": 4,
+              "keys": [
+                {
+                  "label": ["TWR"],
+                  "color": "azure",
+                  "station_id": "EGSH_TWR"
+                },
+                {
+                  "label": ["RAD"],
+                  "color": "azure",
+                  "station_id": "EGSH_APP"
+                },
+                {
+                  "label": ["DIR"],
+                  "color": "azure",
+                  "station_id": "EGSH_F_APP"
+                },
+                {
+                  "label": []
+                }
+              ]
             }
           },
           {
-              "label": []
+            "label": []
           }
         ]
       }

--- a/dataset/EG/profiles/EG-AC_North.json
+++ b/dataset/EG/profiles/EG-AC_North.json
@@ -801,7 +801,9 @@
             "station_id": "EG-MPC-Trent"
           },
           {
-            "label": []
+            "label": ["ScAC", "HUM"],
+            "color": "azure",
+            "station_id": "EG-Humber"
           },
           {
             "label": []

--- a/dataset/EG/profiles/EG-AC_North.json
+++ b/dataset/EG/profiles/EG-AC_North.json
@@ -278,37 +278,37 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["GMP"],
+                  "label": ["CC", "GMP"],
                   "color": "azure",
                   "station_id": "EGCC_DEL"
                 },
                 {
-                  "label": ["GMC"],
+                  "label": ["CC", "GMC"],
                   "color": "azure",
                   "station_id": "EGCC_GND"
                 },
                 {
-                  "label": ["AIR 1"],
+                  "label": ["CC", "AIR 1"],
                   "color": "azure",
                   "station_id": "EGCC_N_TWR"
                 },
                 {
-                  "label": ["AIR 2"],
+                  "label": ["CC", "AIR 2"],
                   "color": "azure",
                   "station_id": "EGVV_W_CTR"
                 },
                 {
-                  "label": ["INT N"],
+                  "label": ["CC", "INT N"],
                   "color": "azure",
                   "station_id": "EGCC_N_APP"
                 },
                 {
-                  "label": ["FIN"],
+                  "label": ["CC", "FIN"],
                   "color": "azure",
                   "station_id": "EGCC_F_APP"
                 },
                 {
-                  "label": ["INT S"],
+                  "label": ["CC", "INT S"],
                   "color": "azure",
                   "station_id": "EGCC_S_APP"
                 },
@@ -325,22 +325,22 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["GMC"],
+                  "label": ["GP", "GMC"],
                   "color": "azure",
                   "station_id": "EGGP_GND"
                 },
                 {
-                  "label": ["TWR"],
+                  "label": ["GP", "TWR"],
                   "color": "azure",
                   "station_id": "EGGP_TWR"
                 },
                 {
-                  "label": ["RAD 1"],
+                  "label": ["GP", "RAD 1"],
                   "color": "azure",
                   "station_id": "EGGP_APP"
                 },
                 {
-                  "label": ["RAD 2"],
+                  "label": ["GP", "RAD 2"],
                   "color": "azure",
                   "station_id": "EGGP_F_APP"
                 }
@@ -359,17 +359,17 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["TWR"],
+                  "label": ["NS", "TWR"],
                   "color": "azure",
                   "station_id": "EGNS_TWR"
                 },
                 {
-                  "label": ["RAD 1/", "APC"],
+                  "label": ["NS", "RAD 1/", "APC"],
                   "color": "azure",
                   "station_id": "EGNS_APP"
                 },
                 {
-                  "label": ["RAD 2"],
+                  "label": ["NS", "RAD 2"],
                   "color": "azure",
                   "station_id": "EGNS_F_APP"
                 },
@@ -386,17 +386,17 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["GMP"],
+                  "label": ["BB", "GMP"],
                   "color": "azure",
                   "station_id": "EGBB_DEL"
                 },
                 {
-                  "label": ["GMC"],
+                  "label": ["BB", "GMC"],
                   "color": "azure",
                   "station_id": "EGBB_GND"
                 },
                 {
-                  "label": ["TWR"],
+                  "label": ["BB", "TWR"],
                   "color": "azure",
                   "station_id": "EGBB_TWR"
                 },
@@ -404,12 +404,12 @@
                   "label": []
                 },
                 {
-                  "label": ["INT"],
+                  "label": ["BB", "INT"],
                   "color": "azure",
                   "station_id": "EGBB_APP"
                 },
                 {
-                  "label": ["FIN"],
+                  "label": ["BB", "FIN"],
                   "color": "azure",
                   "station_id": "EGBB_F_APP"
                 },
@@ -429,22 +429,22 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["GMC"],
+                  "label": ["NT", "GMC"],
                   "color": "azure",
                   "station_id": "EGNT_GND"
                 },
                 {
-                  "label": ["TWR"],
+                  "label": ["NT", "TWR"],
                   "color": "azure",
                   "station_id": "EGNT_TWR"
                 },
                 {
-                  "label": ["RAD"],
+                  "label": ["NT", "RAD"],
                   "color": "azure",
                   "station_id": "EGNT_APP"
                 },
                 {
-                  "label": ["FIN"],
+                  "label": ["NT", "FIN"],
                   "color": "azure",
                   "station_id": "EGNT_F_APP"
                 }
@@ -458,17 +458,17 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["TWR"],
+                  "label": ["NR", "TWR"],
                   "color": "azure",
                   "station_id": "EGNR_TWR"
                 },
                 {
-                  "label": ["RAD"],
+                  "label": ["NR", "RAD"],
                   "color": "azure",
                   "station_id": "EGNR_APP"
                 },
                 {
-                  "label": ["FIN"],
+                  "label": ["NR", "FIN"],
                   "color": "azure",
                   "station_id": "EGNR_F_APP"
                 },
@@ -485,12 +485,12 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["TWR"],
+                  "label": ["NH", "TWR"],
                   "color": "azure",
                   "station_id": "EGNH_TWR"
                 },
                 {
-                  "label": ["APC"],
+                  "label": ["NH", "APC"],
                   "color": "azure",
                   "station_id": "EGNH_A_APP"
                 },
@@ -510,17 +510,17 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["TWR"],
+                  "label": ["NO", "TWR"],
                   "color": "azure",
                   "station_id": "EGNO_TWR"
                 },
                 {
-                  "label": ["RAD"],
+                  "label": ["NO", "RAD"],
                   "color": "azure",
                   "station_id": "EGNO_APP"
                 },
                 {
-                  "label": ["T/D"],
+                  "label": ["NO", "T/D"],
                   "color": "azure",
                   "station_id": "EGNO_P_APP"
                 }
@@ -534,22 +534,22 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["GMC"],
+                  "label": ["NX", "GMC"],
                   "color": "azure",
                   "station_id": "EGNX_GND"
                 },
                 {
-                  "label": ["TWR"],
+                  "label": ["NX", "TWR"],
                   "color": "azure",
                   "station_id": "EGNX_TWR"
                 },
                 {
-                  "label": ["RAD 1"],
+                  "label": ["NX", "RAD 1"],
                   "color": "azure",
                   "station_id": "EGNX_APP"
                 },
                 {
-                  "label": ["RAD 2"],
+                  "label": ["NX", "RAD 2"],
                   "color": "azure",
                   "station_id": "EGNX_F_APP"
                 }
@@ -563,17 +563,17 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["TWR"],
+                  "label": ["NV", "TWR"],
                   "color": "azure",
                   "station_id": "EGNV_TWR"
                 },
                 {
-                  "label": ["RAD"],
+                  "label": ["NV", "RAD"],
                   "color": "azure",
                   "station_id": "EGNV_APP"
                 },
                 {
-                  "label": ["DIR"],
+                  "label": ["NV", "DIR"],
                   "color": "azure",
                   "station_id": "EGNV_F_APP"
                 },
@@ -590,22 +590,22 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["GMP"],
+                  "label": ["NM", "GMP"],
                   "color": "azure",
                   "station_id": "EGNM_DEL"
                 },
                 {
-                  "label": ["TWR"],
+                  "label": ["NM", "TWR"],
                   "color": "azure",
                   "station_id": "EGNM_TWR"
                 },
                 {
-                  "label": ["RAD"],
+                  "label": ["NM", "RAD"],
                   "color": "azure",
                   "station_id": "EGNM_APP"
                 },
                 {
-                  "label": ["DIR"],
+                  "label": ["NM", "DIR"],
                   "color": "azure",
                   "station_id": "EGNM_F_APP"
                 }
@@ -619,12 +619,12 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["TWR"],
+                  "label": ["NJ", "TWR"],
                   "color": "azure",
                   "station_id": "EGNJ_TWR"
                 },
                 {
-                  "label": ["RAD"],
+                  "label": ["NJ", "RAD"],
                   "color": "azure",
                   "station_id": "EGNJ_APP"
                 },
@@ -644,17 +644,17 @@
               "rows": 4,
               "keys": [
                 {
-                  "label": ["TWR"],
+                  "label": ["SH", "TWR"],
                   "color": "azure",
                   "station_id": "EGSH_TWR"
                 },
                 {
-                  "label": ["RAD"],
+                  "label": ["SH", "RAD"],
                   "color": "azure",
                   "station_id": "EGSH_APP"
                 },
                 {
-                  "label": ["DIR"],
+                  "label": ["SH", "DIR"],
                   "color": "azure",
                   "station_id": "EGSH_F_APP"
                 },

--- a/dataset/EG/profiles/EG-AC_North.json
+++ b/dataset/EG/profiles/EG-AC_North.json
@@ -771,9 +771,9 @@
             "station_id": "EG-TC-COWLY"
           },
           {
-            "label": ["PC", "NORTH"],
+            "label": ["PC", "STAFA"],
             "color": "blush",
-            "station_id": "EG-MPC-North"
+            "station_id": "EG-MPC-Stafa"
           },
           {
             "label": ["ScAC", "BDS", "F355+"],
@@ -796,9 +796,9 @@
             "station_id": "EG-Sector-28"
           },
           {
-            "label": ["PC", "EAST"],
+            "label": ["PC", "TRENT"],
             "color": "blush",
-            "station_id": "EG-MPC-East"
+            "station_id": "EG-MPC-Trent"
           },
           {
             "label": []
@@ -817,9 +817,9 @@
             "station_id": "EG-TC-WELIN"
           },
           {
-            "label": ["PC", "STAFA"],
+            "label": ["PC", "NORTH"],
             "color": "blush",
-            "station_id": "EG-MPC-Stafa"
+            "station_id": "EG-MPC-North"
           },
           {
             "label": ["MAAS", "DELTA"],
@@ -841,9 +841,9 @@
             "station_id": "EG-TC-REDFA"
           },
           {
-            "label": ["PC", "TRENT"],
+            "label": ["PC", "EAST"],
             "color": "blush",
-            "station_id": "EG-MPC-Trent"
+            "station_id": "EG-MPC-East"
           }
         ]
       }

--- a/dataset/EG/profiles/EG-AC_North.json
+++ b/dataset/EG/profiles/EG-AC_North.json
@@ -13,7 +13,7 @@
             "station_id": "EISN_ES_CTR"
           },
           {
-            "label": ["EISN", "LIFFY"],
+            "label": ["EISN", "LIFFY", "F245-355"],
             "color": "lavender",
             "station_id": "EISN_E_CTR"
           },

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -960,6 +960,10 @@ parent_id = "EGBB_APP"
 controlled_by = ["EGBB_F_APP"]
 
 [[stations]]
+id = "EGCB_I_TWR"
+controlled_by = ["EGCB_I_TWR"]
+
+[[stations]]
 id = "EGCC_DEL"
 parent_id = "EGCC_GND"
 controlled_by = ["EGCC_DEL"]


### PR DESCRIPTION
### Description

<!-- What does this PR change and why? -->
Adds AC North Profile

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.

## Page 1

<img width="1000" height="753" alt="image" src="https://github.com/user-attachments/assets/582ffef8-844c-4062-9568-292e755c25d8" />

## Mil Page

<img width="1000" height="753" alt="image" src="https://github.com/user-attachments/assets/8f675251-9f19-465b-af6b-56b50ecac491" />

## Page 2

<img width="1000" height="753" alt="image" src="https://github.com/user-attachments/assets/f67d2558-2d05-4bb0-8341-2db22e617ed4" />

## Page 2 Aerodrome (e.g. EGCC)

<img width="1000" height="753" alt="image" src="https://github.com/user-attachments/assets/c8dc9686-7513-45d2-af72-7e03bea5cef7" />

## Page 3

<img width="1000" height="753" alt="image" src="https://github.com/user-attachments/assets/f081f136-a0c9-48b1-8715-ebc230e3c36b" />

## Page 4

<img width="1000" height="753" alt="image" src="https://github.com/user-attachments/assets/82765b92-cae2-409c-a695-75ccccbf8474" />
