### PR TITLE
Add AC West to Birmingham (EGBB)

### DIFF
--- a/dataset/EG/profiles/EGBB.json
+++ b/dataset/EG/profiles/EGBB.json
@@ -74,7 +74,7 @@
           },
           {
             "label": ["AC","W"],
-            "station_id": "LON_W_CTR"
+            "station_id": "EG-Sector-23"
           },
           {
             "label": []

--- a/dataset/EG/profiles/EGBB.json
+++ b/dataset/EG/profiles/EGBB.json
@@ -73,7 +73,8 @@
             "label": []
           },
           {
-            "label": []
+            "label": ["AC","W"],
+            "station_id": "LON_W_CTR"
           },
           {
             "label": []

--- a/dataset/EG/profiles/EGBB.json
+++ b/dataset/EG/profiles/EGBB.json
@@ -73,7 +73,7 @@
             "label": []
           },
           {
-            "label": ["AC","W"],
+            "label": ["AC", "W"],
             "station_id": "EG-Sector-23"
           },
           {


### PR DESCRIPTION
### Description

Adds AC West to BB as requested by @hazzas-99 

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [x] Dataset files are in the correct `dataset/{FIR}/` directory.
- [x] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [x] If contributing from a fork: "Allow edits by maintainers" is enabled.
