### PR TITLE
EG - Set default call sources

### DIFF
--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -3284,6 +3284,7 @@ prefixes = ["LXGB"]
 frequency = "123.300"
 facility_type = "APP"
 profile_id = "LXGB"
+default_call_sources = ["LXGB_APP"]
 
 [[positions]]
 id = "LXGB_P_APP"
@@ -3291,6 +3292,7 @@ prefixes = ["LXGB"]
 frequency = "130.400"
 facility_type = "APP"
 profile_id = "LXGB"
+default_call_sources = ["LXGB_P_APP"]
 
 [[positions]]
 id = "LXGB_TWR"
@@ -3298,6 +3300,7 @@ prefixes = ["LXGB"]
 frequency = "131.200"
 facility_type = "TWR"
 profile_id = "LXGB"
+default_call_sources = ["LXGB_TWR"]
 
 [[positions]]
 id = "ISLAND_CTR"
@@ -3305,6 +3308,7 @@ prefixes = ["ISLAND"]
 frequency = "131.500"
 facility_type = "CTR"
 profile_id = "ISLAND"
+default_call_sources = ["ISLAND_CTR"]
 
 [[positions]]
 id = "EGYP_APP"
@@ -3312,6 +3316,7 @@ prefixes = ["EGYP"]
 frequency = "118.500"
 facility_type = "APP"
 profile_id = "ISLAND"
+default_call_sources = ["EGYP_APP"]
 
 [[positions]]
 id = "EGYP_P_APP"
@@ -3319,6 +3324,7 @@ prefixes = ["EGYP"]
 frequency = "125.950"
 facility_type = "APP"
 profile_id = "ISLAND"
+default_call_sources = ["EGYP_P_APP"]
 
 [[positions]]
 id = "EGYP_TWR"
@@ -3326,6 +3332,7 @@ prefixes = ["EGYP"]
 frequency = "133.350"
 facility_type = "TWR"
 profile_id = "ISLAND"
+default_call_sources = ["EGYP_TWR"]
 
 [[positions]]
 id = "EGYP_GND"
@@ -3333,6 +3340,7 @@ prefixes = ["EGYP"]
 frequency = "130.300"
 facility_type = "GND"
 profile_id = "ISLAND"
+default_call_sources = ["EGYP_GND"]
 
 [[positions]]
 id = "SFAL_I_TWR"
@@ -3340,3 +3348,4 @@ prefixes = ["SFAL"]
 frequency = "118.100"
 facility_type = "TWR"
 profile_id = "ISLAND"
+default_call_sources = ["SFAL_I_TWR"]

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -3192,6 +3192,7 @@ prefixes = ["UK"]
 frequency = "199.998"
 facility_type = "FMP"
 profile_id = "EG-FMP"
+default_call_sources = ["UK_FMP"]
 
 [[positions]]
 id = "UK_A_FMP"
@@ -3199,6 +3200,7 @@ prefixes = ["UK"]
 frequency = "199.998"
 facility_type = "FMP"
 profile_id = "EG-FMP"
+default_call_sources = ["UK_A_FMP"]
 
 [[positions]]
 id = "UK_B_FMP"
@@ -3206,6 +3208,7 @@ prefixes = ["UK"]
 frequency = "199.998"
 facility_type = "FMP"
 profile_id = "EG-FMP"
+default_call_sources = ["UK_B_FMP"]
 
 [[positions]]
 id = "MAN_FMP"
@@ -3213,6 +3216,7 @@ prefixes = ["MAN"]
 frequency = "199.998"
 facility_type = "FMP"
 profile_id = "EG-FMP"
+default_call_sources = ["MAN_FMP"]
 
 [[positions]]
 id = "LTC_FMP"
@@ -3220,6 +3224,7 @@ prefixes = ["LTC"]
 frequency = "199.998"
 facility_type = "FMP"
 profile_id = "EG-FMP"
+default_call_sources = ["LTC_FMP"]
 
 [[positions]]
 id = "SCL_FMP"
@@ -3227,6 +3232,7 @@ prefixes = ["SCL"]
 frequency = "199.998"
 facility_type = "FMP"
 profile_id = "EG-FMP"
+default_call_sources = ["SCL_FMP"]
 
 [[positions]]
 id = "LON_GS_CTR"
@@ -3234,6 +3240,7 @@ prefixes = ["LON"]
 frequency = "199.998"
 facility_type = "CTR"
 profile_id = "EG-FMP"
+default_call_sources = ["LON_GS_CTR"]
 
 [[positions]]
 id = "LTC_GS_CTR"
@@ -3241,6 +3248,7 @@ prefixes = ["LTC"]
 frequency = "199.998"
 facility_type = "CTR"
 profile_id = "EG-FMP"
+default_call_sources = ["LTC_GS_CTR"]
 
 [[positions]]
 id = "SCO_GS_CTR"
@@ -3248,6 +3256,7 @@ prefixes = ["SCO"]
 frequency = "199.998"
 facility_type = "CTR"
 profile_id = "EG-FMP"
+default_call_sources = ["SCO_GS_CTR"]
 
 [[positions]]
 id = "SCL_GS_CTR"
@@ -3255,6 +3264,7 @@ prefixes = ["SCL"]
 frequency = "199.998"
 facility_type = "CTR"
 profile_id = "EG-FMP"
+default_call_sources = ["SCL_GS_CTR"]
 
 [[positions]]
 id = "MAN_GS_CTR"
@@ -3262,6 +3272,7 @@ prefixes = ["MAN"]
 frequency = "199.998"
 facility_type = "CTR"
 profile_id = "EG-FMP"
+default_call_sources = ["MAN_GS_CTR"]
 
 #######################
 # Non-domestic owned

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -67,6 +67,7 @@ prefixes = ["EGBB"]
 frequency = "123.980"
 facility_type = "APP"
 profile_id = "EGBB"
+default_call_sources = ["EGBB_APP"]
 
 [[positions]]
 id = "EGBB_F_APP"
@@ -74,6 +75,7 @@ prefixes = ["EGBB"]
 frequency = "131.005"
 facility_type = "APP"
 profile_id = "EGBB"
+default_call_sources = ["EGBB_F_APP"]
 
 [[positions]]
 id = "EGBB_TWR"
@@ -81,6 +83,7 @@ prefixes = ["EGBB"]
 frequency = "118.305"
 facility_type = "TWR"
 profile_id = "EGBB"
+default_call_sources = ["EGBB_TWR"]
 
 [[positions]]
 id = "EGBB_GND"
@@ -88,6 +91,7 @@ prefixes = ["EGBB"]
 frequency = "121.805"
 facility_type = "GND"
 profile_id = "EGBB"
+default_call_sources = ["EGBB_GND"]
 
 [[positions]]
 id = "EGBB_DEL"
@@ -95,6 +99,7 @@ prefixes = ["EGBB"]
 frequency = "121.930"
 facility_type = "DEL"
 profile_id = "EGBB"
+default_call_sources = ["EGBB_DEL"]
 
 [[positions]]
 id = "EGBJ_A_APP"
@@ -1033,6 +1038,7 @@ prefixes = ["EGNX"]
 frequency = "126.180"
 facility_type = "APP"
 profile_id = "EGNX"
+default_call_sources = ["EGNX_APP"]
 
 [[positions]]
 id = "EGNX_F_APP"
@@ -1040,6 +1046,7 @@ prefixes = ["EGNX"]
 frequency = "120.130"
 facility_type = "APP"
 profile_id = "EGNX"
+default_call_sources = ["EGNX_F_APP"]
 
 [[positions]]
 id = "EGNX_TWR"
@@ -1047,6 +1054,7 @@ prefixes = ["EGNX"]
 frequency = "124.005"
 facility_type = "TWR"
 profile_id = "EGNX"
+default_call_sources = ["EGNX_TWR"]
 
 [[positions]]
 id = "EGNX_GND"
@@ -1054,6 +1062,7 @@ prefixes = ["EGNX"]
 frequency = "121.905"
 facility_type = "GND"
 profile_id = "EGNX"
+default_call_sources = ["EGNX_GND"]
 
 [[positions]]
 id = "EGOE_TWR"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -2228,6 +2228,7 @@ prefixes = ["LON"]
 frequency = "127.105"
 facility_type = "CTR"
 profile_id = "EG-Central_LAG"
+default_call_sources = ["LON_E_CTR", "LON_D_CTR"]
 
 [[positions]]
 id = "LON_DK_CTR"
@@ -2249,6 +2250,7 @@ prefixes = ["LON"]
 frequency = "134.905"
 facility_type = "CTR"
 profile_id = "EG-AC_South"
+default_call_sources = ["LON_D_CTR"]
 
 [[positions]]
 id = "LON_EN_CTR"
@@ -2270,6 +2272,7 @@ prefixes = ["LON"]
 frequency = "118.480"
 facility_type = "CTR"
 profile_id = "EG-TC_EAST_AC_CLN"
+default_call_sources = ["LON_E_CTR"]
 
 [[positions]]
 id = "LON_HW_CTR"
@@ -2284,6 +2287,7 @@ prefixes = ["LON"]
 frequency = "134.440"
 facility_type = "CTR"
 profile_id = "EG-AC_South"
+default_call_sources = ["LON_H_CTR"]
 
 [[positions]]
 id = "LON_ME_CTR"
@@ -2312,6 +2316,7 @@ prefixes = ["LON"]
 frequency = "120.025"
 facility_type = "CTR"
 profile_id = "EG-TC_MIDS_AC_DTY"
+default_call_sources = ["LON_M_CTR"]
 
 [[positions]]
 id = "LON_NE_CTR"
@@ -2319,6 +2324,7 @@ prefixes = ["LON"]
 frequency = "128.130"
 facility_type = "CTR"
 profile_id = "EG-AC_North"
+default_call_sources = ["LON_NE_CTR"]
 
 [[positions]]
 id = "LON_NU_CTR"
@@ -2333,6 +2339,7 @@ prefixes = ["LON"]
 frequency = "135.580"
 facility_type = "CTR"
 profile_id = "EG-AC_North"
+default_call_sources = ["LON_NW_CTR"]
 
 [[positions]]
 id = "LON_N_CTR"
@@ -2340,6 +2347,7 @@ prefixes = ["LON"]
 frequency = "133.705"
 facility_type = "CTR"
 profile_id = "EG-AC_North"
+default_call_sources = ["LON_NW_CTR", "LON_NE_CTR"]
 
 [[positions]]
 id = "LON_O_CTR"
@@ -2382,6 +2390,7 @@ prefixes = ["LON"]
 frequency = "129.430"
 facility_type = "CTR"
 profile_id = "EG-AC_South"
+default_call_sources = ["LON_D_CTR", "LON_H_CTR"]
 
 [[positions]]
 id = "LON_WB_CTR"
@@ -2417,6 +2426,7 @@ prefixes = ["LON"]
 frequency = "126.080"
 facility_type = "CTR"
 profile_id = "EG-AC_West"
+default_call_sources = ["LON_W_CTR"]
 
 #######################
 # London Terminal
@@ -2427,6 +2437,7 @@ prefixes = ["LTC"]
 frequency = "135.805"
 facility_type = "CTR"
 profile_id = "EG-TC_BBX"
+default_call_sources = [ "LTC_SE_CTR", "LTC_NE_CTR", "LTC_NW_CTR", "LTC_SW_CTR" ]
 
 [[positions]]
 id = "LTC_ED_CTR"
@@ -2462,6 +2473,7 @@ prefixes = ["LTC"]
 frequency = "121.230"
 facility_type = "CTR"
 profile_id = "EG-TC_EAST_AC_CLN"
+default_call_sources = ["LTC_E_CTR"]
 
 [[positions]]
 id = "LTC_MC_CTR"
@@ -2483,6 +2495,7 @@ prefixes = ["LTC"]
 frequency = "121.030"
 facility_type = "CTR"
 profile_id = "EG-TC_MIDS_AC_DTY"
+default_call_sources = ["LTC_M_CTR"]
 
 [[positions]]
 id = "LTC_N2_CTR"
@@ -2497,6 +2510,7 @@ prefixes = ["LTC"]
 frequency = "118.825"
 facility_type = "CTR"
 profile_id = "EG-TC_N"
+default_call_sources = ["LTC_NE_CTR"]
 
 [[positions]]
 id = "LTC_NL_CTR"
@@ -2511,6 +2525,7 @@ prefixes = ["LTC"]
 frequency = "121.280"
 facility_type = "CTR"
 profile_id = "EG-TC_N"
+default_call_sources = ["LTC_NW_CTR"]
 
 [[positions]]
 id = "LTC_N_CTR"
@@ -2518,6 +2533,7 @@ prefixes = ["LTC"]
 frequency = "119.780"
 facility_type = "CTR"
 profile_id = "EG-TC_N"
+default_call_sources = ["LTC_NE_CTR", "LTC_NW_CTR"]
 
 [[positions]]
 id = "LTC_SE_CTR"
@@ -2525,6 +2541,7 @@ prefixes = ["LTC"]
 frequency = "120.530"
 facility_type = "CTR"
 profile_id = "EG-TC_S"
+default_call_sources = ["LTC_SE_CTR"]
 
 [[positions]]
 id = "LTC_SW_CTR"
@@ -2532,6 +2549,7 @@ prefixes = ["LTC"]
 frequency = "133.180"
 facility_type = "CTR"
 profile_id = "EG-TC_S"
+default_call_sources = ["LTC_SW_CTR"]
 
 [[positions]]
 id = "LTC_S_CTR"
@@ -2539,6 +2557,7 @@ prefixes = ["LTC"]
 frequency = "134.125"
 facility_type = "CTR"
 profile_id = "EG-TC_S"
+default_call_sources = ["LTC_SE_CTR", "LTC_SW_CTR"]
 
 #######################
 # Scottish Area
@@ -2694,7 +2713,7 @@ prefixes = ["SCL"]
 frequency = "124.930"
 facility_type = "CTR"
 profile_id = "EGPX2"
-default_call_sources = ["SCL_TMA_CTR", "SCL_ANT_CTR"]
+default_call_sources = ["SCL_GAL_CTR", "SCL_TLA_CTR", "SCL_ANT_CTR"]
 
 [[positions]]
 id = "SCL_ANT_CTR"
@@ -2710,7 +2729,7 @@ prefixes = ["SCL"]
 frequency = "126.300"
 facility_type = "CTR"
 profile_id = "EGPX2"
-default_call_sources = ["SCL_TMA_CTR"]
+default_call_sources = ["SCL_TLA_CTR", "SCL_GAL_CTR"]
 
 [[positions]]
 id = "SCL_TLA_CTR"
@@ -2744,6 +2763,7 @@ prefixes = ["MAN"]
 frequency = "133.200"
 facility_type = "CTR"
 profile_id = "EG-North_LAG"
+default_call_sources = ["MAN_SE_CTR", "MAN_W_CTR", "MAN_NE_CTR"]
 
 [[positions]]
 id = "MAN_E_CTR"
@@ -2751,6 +2771,7 @@ prefixes = ["MAN"]
 frequency = "133.800"
 facility_type = "CTR"
 profile_id = "EG-North_LAG"
+default_call_sources = ["MAN_SE_CTR", "MAN_NE_CTR"]
 
 [[positions]]
 id = "MAN_M_CTR"
@@ -2765,6 +2786,7 @@ prefixes = ["MAN"]
 frequency = "135.715"
 facility_type = "CTR"
 profile_id = "EG-North_LAG"
+default_call_sources = ["MAN_NE_CTR"]
 
 [[positions]]
 id = "MAN_SE_CTR"
@@ -2772,6 +2794,7 @@ prefixes = ["MAN"]
 frequency = "134.430"
 facility_type = "CTR"
 profile_id = "EG-North_LAG"
+default_call_sources = ["MAN_SE_CTR"]
 
 [[positions]]
 id = "MAN_TE_CTR"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -59,6 +59,7 @@ prefixes = ["EGAE"]
 frequency = "123.630"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGAE_A_APP"]
 
 [[positions]]
 id = "EGAE_TWR"
@@ -66,6 +67,7 @@ prefixes = ["EGAE"]
 frequency = "134.155"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGAE_TWR"]
 
 [[positions]]
 id = "EGBB_APP"
@@ -1214,6 +1216,7 @@ prefixes = ["EGPA"]
 frequency = "118.305"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPA_A_APP"]
 
 [[positions]]
 id = "EGPA_TWR"
@@ -1221,6 +1224,7 @@ prefixes = ["EGPA"]
 frequency = "118.305"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPA_TWR"]
 
 [[positions]]
 id = "EGPB_APP"
@@ -1228,6 +1232,7 @@ prefixes = ["EGPB"]
 frequency = "131.300"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPB_APP"]
 
 [[positions]]
 id = "EGPB_TWR"
@@ -1235,6 +1240,7 @@ prefixes = ["EGPB"]
 frequency = "118.255"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPB_TWR"]
 
 [[positions]]
 id = "EGPC_A_APP"
@@ -1242,6 +1248,7 @@ prefixes = ["EGPC"]
 frequency = "119.705"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPC_A_APP"]
 
 [[positions]]
 id = "EGPC_TWR"
@@ -1249,6 +1256,7 @@ prefixes = ["EGPC"]
 frequency = "119.705"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPC_TWR"]
 
 [[positions]]
 id = "EGPD_APP"
@@ -1256,6 +1264,7 @@ prefixes = ["EGPD"]
 frequency = "119.055"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPD_APP"]
 
 [[positions]]
 id = "EGPD_F_APP"
@@ -1263,6 +1272,7 @@ prefixes = ["EGPD"]
 frequency = "128.305"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPD_F_APP"]
 
 [[positions]]
 id = "EGPD_H_APP"
@@ -1270,6 +1280,7 @@ prefixes = ["EGPD"]
 frequency = "134.100"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPD_H_APP"]
 
 [[positions]]
 id = "EGPD_TWR"
@@ -1277,6 +1288,7 @@ prefixes = ["EGPD"]
 frequency = "118.105"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPD_TWR"]
 
 [[positions]]
 id = "EGPD_GND"
@@ -1284,6 +1296,7 @@ prefixes = ["EGPD"]
 frequency = "121.705"
 facility_type = "GND"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPD_GND"]
 
 [[positions]]
 id = "EGPE_APP"
@@ -1291,6 +1304,7 @@ prefixes = ["EGPE"]
 frequency = "122.605"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPE_APP"]
 
 [[positions]]
 id = "EGPE_TWR"
@@ -1298,6 +1312,7 @@ prefixes = ["EGPE"]
 frequency = "118.405"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPE_TWR"]
 
 [[positions]]
 id = "EGPF_APP"
@@ -1401,6 +1416,7 @@ prefixes = ["EGPL"]
 frequency = "119.205"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPL_A_APP"]
 
 [[positions]]
 id = "EGPL_TWR"
@@ -1408,6 +1424,7 @@ prefixes = ["EGPL"]
 frequency = "119.205"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPL_TWR"]
 
 [[positions]]
 id = "EGPN_A_APP"
@@ -1415,6 +1432,7 @@ prefixes = ["EGPN"]
 frequency = "122.905"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPN_A_APP"]
 
 [[positions]]
 id = "EGPN_TWR"
@@ -1422,6 +1440,7 @@ prefixes = ["EGPN"]
 frequency = "122.905"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPN_TWR"]
 
 [[positions]]
 id = "EGPO_A_APP"
@@ -1429,6 +1448,7 @@ prefixes = ["EGPO"]
 frequency = "119.480"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPO_A_APP"]
 
 [[positions]]
 id = "EGPO_TWR"
@@ -1436,6 +1456,7 @@ prefixes = ["EGPO"]
 frequency = "119.480"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPO_TWR"]
 
 [[positions]]
 id = "EGPX_I_CTR"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -1350,6 +1350,7 @@ prefixes = ["EGPX"]
 frequency = "119.875"
 facility_type = "CTR"
 profile_id = "EG-UK_ALL"
+default_call_sources = ["EGPX_I_CTR"]
 
 [[positions]]
 id = "EGQL_A_APP"
@@ -1560,6 +1561,7 @@ prefixes = ["EGTT"]
 frequency = "124.600"
 facility_type = "CTR"
 profile_id = "EG-UK_ALL"
+default_call_sources = ["EGTT_I_CTR"]
 
 [[positions]]
 id = "EGTT_WR_CTR"
@@ -1567,6 +1569,7 @@ prefixes = ["EGTT"]
 frequency = "132.300"
 facility_type = "CTR"
 profile_id = "EG-AC_West"
+default_call_sources = ["EGTT_WR_CTR"]
 
 [[positions]]
 id = "EGUB_APP"
@@ -2778,6 +2781,7 @@ prefixes = ["EGCB"]
 frequency = "120.255"
 facility_type = "TWR"
 profile_id = "EG-AFIS_AGCS"
+default_call_sources = ["EGCB_I_TWR"]
 
 [[positions]]
 id = "EGCF_R_TWR"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -352,6 +352,7 @@ prefixes = ["EGGW"]
 frequency = "129.550"
 facility_type = "APP"
 profile_id = "ESSEX"
+default_call_sources = ["EGGW_APP"]
 
 [[positions]]
 id = "EGGW_F_APP"
@@ -359,6 +360,7 @@ prefixes = ["EGGW"]
 frequency = "128.750"
 facility_type = "APP"
 profile_id = "ESSEX"
+default_call_sources = ["EGGW_F_APP"]
 
 [[positions]]
 id = "EGGW_TWR"
@@ -366,6 +368,7 @@ prefixes = ["EGGW"]
 frequency = "132.555"
 facility_type = "TWR"
 profile_id = "ESSEX"
+default_call_sources = ["EGGW_TWR"]
 
 [[positions]]
 id = "EGGW_GND"
@@ -373,6 +376,7 @@ prefixes = ["EGGW"]
 frequency = "121.755"
 facility_type = "GND"
 profile_id = "ESSEX"
+default_call_sources = ["EGGW_GND"]
 
 [[positions]]
 id = "EGGW_DEL"
@@ -380,6 +384,7 @@ prefixes = ["EGGW"]
 frequency = "121.885"
 facility_type = "DEL"
 profile_id = "ESSEX"
+default_call_sources = ["EGGW_DEL"]
 
 [[positions]]
 id = "EGHC_TWR"
@@ -609,6 +614,7 @@ prefixes = ["EGKB"]
 frequency = "129.405"
 facility_type = "APP"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGKB_A_APP"]
 
 [[positions]]
 id = "EGKB_TWR"
@@ -616,6 +622,7 @@ prefixes = ["EGKB"]
 frequency = "134.805"
 facility_type = "TWR"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGKB_TWR"]
 
 [[positions]]
 id = "EGKB_GND"
@@ -623,6 +630,7 @@ prefixes = ["EGKB"]
 frequency = "121.630"
 facility_type = "GND"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGKB_GND"]
 
 [[positions]]
 id = "EGKK_APP"
@@ -630,6 +638,7 @@ prefixes = ["EGKK"]
 frequency = "126.825"
 facility_type = "APP"
 profile_id = "EGKK"
+default_call_sources = ["EGKK_APP"]
 
 [[positions]]
 id = "EGKK_F_APP"
@@ -637,6 +646,7 @@ prefixes = ["EGKK"]
 frequency = "118.950"
 facility_type = "APP"
 profile_id = "EGKK"
+default_call_sources = ["EGKK_F_APP"]
 
 [[positions]]
 id = "EGKK_TWR"
@@ -644,6 +654,7 @@ prefixes = ["EGKK"]
 frequency = "124.230"
 facility_type = "TWR"
 profile_id = "EGKK"
+default_call_sources = ["EGKK_TWR"]
 
 [[positions]]
 id = "EGKK_N_GND"
@@ -651,6 +662,7 @@ prefixes = ["EGKK"]
 frequency = "121.540"
 facility_type = "GND"
 profile_id = "EGKK"
+default_call_sources = ["EGKK_N_GND"]
 
 [[positions]]
 id = "EGKK_S_GND"
@@ -658,6 +670,7 @@ prefixes = ["EGKK"]
 frequency = "121.805"
 facility_type = "GND"
 profile_id = "EGKK"
+default_call_sources = ["EGKK_S_GND"]
 
 [[positions]]
 id = "EGKK_DEL"
@@ -665,6 +678,7 @@ prefixes = ["EGKK"]
 frequency = "121.955"
 facility_type = "DEL"
 profile_id = "EGKK"
+default_call_sources = ["EGKK_DEL"]
 
 [[positions]]
 id = "EGKK_A_DEL"
@@ -672,6 +686,7 @@ prefixes = ["EGKK"]
 frequency = "199.998"
 facility_type = "DEL"
 profile_id = "EGKK"
+default_call_sources = ["EGKK_A_DEL"]
 
 [[positions]]
 id = "EGKK_P_GND"
@@ -679,6 +694,7 @@ prefixes = ["EGKK"]
 frequency = "134.230"
 facility_type = "GND"
 profile_id = "EGKK"
+default_call_sources = ["EGKK_P_GND"]
 
 [[positions]]
 id = "EGKR_TWR"
@@ -686,6 +702,7 @@ prefixes = ["EGKR"]
 frequency = "119.605"
 facility_type = "TWR"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGKR_TWR"]
 
 [[positions]]
 id = "THAMES_APP"
@@ -693,6 +710,7 @@ prefixes = ["THAMES"]
 frequency = "132.700"
 facility_type = "APP"
 profile_id = "EG-South_LAG"
+default_call_sources = ["THAMES_APP"]
 
 [[positions]]
 id = "EGLC_APP"
@@ -700,6 +718,7 @@ prefixes = ["EGLC"]
 frequency = "128.025"
 facility_type = "APP"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGLC_APP"]
 
 [[positions]]
 id = "EGLC_TWR"
@@ -707,6 +726,7 @@ prefixes = ["EGLC"]
 frequency = "118.080"
 facility_type = "TWR"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGLC_TWR"]
 
 [[positions]]
 id = "EGLC_GND"
@@ -714,6 +734,7 @@ prefixes = ["EGLC"]
 frequency = "121.830"
 facility_type = "GND"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGLC_GND"]
 
 [[positions]]
 id = "EGLF_APP"
@@ -721,6 +742,7 @@ prefixes = ["EGLF"]
 frequency = "134.355"
 facility_type = "APP"
 profile_id = "EGLF"
+default_call_sources = ["EGLF_APP"]
 
 [[positions]]
 id = "EGLF_F_APP"
@@ -728,6 +750,7 @@ prefixes = ["EGLF"]
 frequency = "130.055"
 facility_type = "APP"
 profile_id = "EGLF"
+default_call_sources = ["EGLF_F_APP"]
 
 [[positions]]
 id = "EGLF_L_APP"
@@ -735,6 +758,7 @@ prefixes = ["EGLF"]
 frequency = "125.250"
 facility_type = "APP"
 profile_id = "EGLF"
+default_call_sources = ["EGLF_L_APP"]
 
 [[positions]]
 id = "EGLF_TWR"
@@ -742,6 +766,7 @@ prefixes = ["EGLF"]
 frequency = "122.780"
 facility_type = "TWR"
 profile_id = "EGLF"
+default_call_sources = ["EGLF_TWR"]
 
 [[positions]]
 id = "EGLF_GND"
@@ -749,6 +774,7 @@ prefixes = ["EGLF"]
 frequency = "121.815"
 facility_type = "GND"
 profile_id = "EGLF"
+default_call_sources = ["EGLF_GND"]
 
 [[positions]]
 id = "EGLL_F_APP"
@@ -756,6 +782,7 @@ prefixes = ["EGLL"]
 frequency = "120.400"
 facility_type = "APP"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_F_APP"]
 
 [[positions]]
 id = "EGLL_N_APP"
@@ -763,6 +790,7 @@ prefixes = ["EGLL"]
 frequency = "119.730"
 facility_type = "APP"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_N_APP"]
 
 [[positions]]
 id = "EGLL_S_APP"
@@ -770,6 +798,7 @@ prefixes = ["EGLL"]
 frequency = "134.980"
 facility_type = "APP"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_S_APP"]
 
 [[positions]]
 id = "EGLL_N_TWR"
@@ -777,6 +806,7 @@ prefixes = ["EGLL"]
 frequency = "118.705"
 facility_type = "TWR"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_N_TWR"]
 
 [[positions]]
 id = "EGLL_S_TWR"
@@ -784,6 +814,7 @@ prefixes = ["EGLL"]
 frequency = "118.505"
 facility_type = "TWR"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_S_TWR"]
 
 [[positions]]
 id = "EGLL_1_GND"
@@ -791,6 +822,7 @@ prefixes = ["EGLL"]
 frequency = "121.905"
 facility_type = "GND"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_1_GND"]
 
 [[positions]]
 id = "EGLL_2_GND"
@@ -798,6 +830,7 @@ prefixes = ["EGLL"]
 frequency = "121.705"
 facility_type = "GND"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_2_GND"]
 
 [[positions]]
 id = "EGLL_3_GND"
@@ -805,6 +838,7 @@ prefixes = ["EGLL"]
 frequency = "121.855"
 facility_type = "GND"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_3_GND"]
 
 [[positions]]
 id = "EGLL_DEL"
@@ -812,6 +846,7 @@ prefixes = ["EGLL"]
 frequency = "121.980"
 facility_type = "DEL"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_DEL"]
 
 [[positions]]
 id = "EGLL_A_DEL"
@@ -819,6 +854,7 @@ prefixes = ["EGLL"]
 frequency = "199.998"
 facility_type = "DEL"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_A_DEL"]
 
 [[positions]]
 id = "EGLL_P_GND"
@@ -826,6 +862,7 @@ prefixes = ["EGLL"]
 frequency = "124.480"
 facility_type = "GND"
 profile_id = "EGLL"
+default_call_sources = ["EGLL_P_GND"]
 
 [[positions]]
 id = "EGLW_TWR"
@@ -833,6 +870,7 @@ prefixes = ["EGLW"]
 frequency = "134.280"
 facility_type = "TWR"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGLW_TWR"]
 
 [[positions]]
 id = "EGMC_APP"
@@ -840,6 +878,7 @@ prefixes = ["EGMC"]
 frequency = "128.965"
 facility_type = "APP"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGMC_APP"]
 
 [[positions]]
 id = "EGMC_L_APP"
@@ -847,6 +886,7 @@ prefixes = ["EGMC"]
 frequency = "130.780"
 facility_type = "APP"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGMC_L_APP"]
 
 [[positions]]
 id = "EGMC_TWR"
@@ -854,6 +894,7 @@ prefixes = ["EGMC"]
 frequency = "127.730"
 facility_type = "TWR"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGMC_TWR"]
 
 [[positions]]
 id = "EGMD_A_APP"
@@ -1412,6 +1453,7 @@ prefixes = ["EGSC"]
 frequency = "120.965"
 facility_type = "APP"
 profile_id = "ESSEX"
+default_call_sources = ["EGSC_APP"]
 
 [[positions]]
 id = "EGSC_A_APP"
@@ -1419,6 +1461,7 @@ prefixes = ["EGSC"]
 frequency = "120.965"
 facility_type = "APP"
 profile_id = "ESSEX"
+default_call_sources = ["EGSC_A_APP"]
 
 [[positions]]
 id = "EGSC_TWR"
@@ -1426,6 +1469,7 @@ prefixes = ["EGSC"]
 frequency = "125.905"
 facility_type = "TWR"
 profile_id = "ESSEX"
+default_call_sources = ["EGSC_TWR"]
 
 [[positions]]
 id = "EGSH_APP"
@@ -1454,6 +1498,7 @@ prefixes = ["ESSEX"]
 frequency = "120.625"
 facility_type = "APP"
 profile_id = "ESSEX"
+default_call_sources = ["ESSEX_APP"]
 
 [[positions]]
 id = "EGSS_APP"
@@ -1461,6 +1506,7 @@ prefixes = ["EGSS"]
 frequency = "120.625"
 facility_type = "APP"
 profile_id = "ESSEX"
+default_call_sources = ["EGSS_APP"]
 
 [[positions]]
 id = "EGSS_F_APP"
@@ -1468,6 +1514,7 @@ prefixes = ["EGSS"]
 frequency = "136.200"
 facility_type = "APP"
 profile_id = "ESSEX"
+default_call_sources = ["EGSS_F_APP"]
 
 [[positions]]
 id = "EGSS_TWR"
@@ -1475,6 +1522,7 @@ prefixes = ["EGSS"]
 frequency = "123.805"
 facility_type = "TWR"
 profile_id = "ESSEX"
+default_call_sources = ["EGSS_TWR"]
 
 [[positions]]
 id = "EGSS_GND"
@@ -1482,6 +1530,7 @@ prefixes = ["EGSS"]
 frequency = "121.730"
 facility_type = "GND"
 profile_id = "ESSEX"
+default_call_sources = ["EGSS_GND"]
 
 [[positions]]
 id = "EGSS_DEL"
@@ -1489,6 +1538,7 @@ prefixes = ["EGSS"]
 frequency = "121.955"
 facility_type = "DEL"
 profile_id = "ESSEX"
+default_call_sources = ["EGSS_DEL"]
 
 [[positions]]
 id = "EGSY_TWR"
@@ -1857,6 +1907,7 @@ prefixes = ["EGWU"]
 frequency = "126.450"
 facility_type = "APP"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGWU_APP"]
 
 [[positions]]
 id = "EGWU_F_APP"
@@ -1864,6 +1915,7 @@ prefixes = ["EGWU"]
 frequency = "130.350"
 facility_type = "APP"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGWU_F_APP"]
 
 [[positions]]
 id = "EGWU_P_APP"
@@ -1871,6 +1923,7 @@ prefixes = ["EGWU"]
 frequency = "125.875"
 facility_type = "APP"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGWU_P_APP"]
 
 [[positions]]
 id = "EGWU_TWR"
@@ -1878,6 +1931,7 @@ prefixes = ["EGWU"]
 frequency = "120.675"
 facility_type = "TWR"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGWU_TWR"]
 
 [[positions]]
 id = "EGWU_GND"
@@ -1885,6 +1939,7 @@ prefixes = ["EGWU"]
 frequency = "121.575"
 facility_type = "GND"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGWU_GND"]
 
 [[positions]]
 id = "EGXC_APP"
@@ -3132,6 +3187,7 @@ prefixes = ["EGSU"]
 frequency = "122.080"
 facility_type = "TWR"
 profile_id = "EG-AFIS_AGCS"
+default_call_sources = ["EGSU_I_TWR"]
 
 [[positions]]
 id = "EGSV_R_TWR"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -499,6 +499,7 @@ prefixes = ["EGJA"]
 frequency = "125.355"
 facility_type = "TWR"
 profile_id = "EGJJ"
+default_call_sources = ["EGJA_TWR"]
 
 [[positions]]
 id = "EGJA_GND"
@@ -506,6 +507,7 @@ prefixes = ["EGJA"]
 frequency = "130.505"
 facility_type = "GND"
 profile_id = "EGJJ"
+default_call_sources = ["EGJA_GND"]
 
 [[positions]]
 id = "EGJB_APP"
@@ -513,6 +515,7 @@ prefixes = ["EGJB"]
 frequency = "128.655"
 facility_type = "APP"
 profile_id = "EGJJ"
+default_call_sources = ["EGJB_APP"]
 
 [[positions]]
 id = "EGJB_F_APP"
@@ -520,6 +523,7 @@ prefixes = ["EGJB"]
 frequency = "124.505"
 facility_type = "APP"
 profile_id = "EGJJ"
+default_call_sources = ["EGJB_F_APP"]
 
 [[positions]]
 id = "EGJB_TWR"
@@ -527,6 +531,7 @@ prefixes = ["EGJB"]
 frequency = "119.955"
 facility_type = "TWR"
 profile_id = "EGJJ"
+default_call_sources = ["EGJB_TWR"]
 
 [[positions]]
 id = "EGJB_GND"
@@ -534,6 +539,7 @@ prefixes = ["EGJB"]
 frequency = "121.805"
 facility_type = "GND"
 profile_id = "EGJJ"
+default_call_sources = ["EGJB_GND"]
 
 [[positions]]
 id = "EGJJ_APP"
@@ -541,6 +547,7 @@ prefixes = ["EGJJ"]
 frequency = "120.305"
 facility_type = "APP"
 profile_id = "EGJJ"
+default_call_sources = ["EGJJ_APP"]
 
 [[positions]]
 id = "EGJJ_C_APP"
@@ -548,6 +555,7 @@ prefixes = ["EGJJ"]
 frequency = "125.205"
 facility_type = "APP"
 profile_id = "EGJJ"
+default_call_sources = ["EGJJ_C_APP"]
 
 [[positions]]
 id = "EGJJ_F_APP"
@@ -555,6 +563,7 @@ prefixes = ["EGJJ"]
 frequency = "118.555"
 facility_type = "APP"
 profile_id = "EGJJ"
+default_call_sources = ["EGJJ_F_APP"]
 
 [[positions]]
 id = "EGJJ_S_APP"
@@ -562,6 +571,7 @@ prefixes = ["EGJJ"]
 frequency = "120.455"
 facility_type = "APP"
 profile_id = "EGJJ"
+default_call_sources = ["EGJJ_S_APP"]
 
 [[positions]]
 id = "EGJJ_TWR"
@@ -569,6 +579,7 @@ prefixes = ["EGJJ"]
 frequency = "119.455"
 facility_type = "TWR"
 profile_id = "EGJJ"
+default_call_sources = ["EGJJ_TWR"]
 
 [[positions]]
 id = "EGJJ_GND"
@@ -576,6 +587,7 @@ prefixes = ["EGJJ"]
 frequency = "121.905"
 facility_type = "GND"
 profile_id = "EGJJ"
+default_call_sources = ["EGJJ_GND"]
 
 [[positions]]
 id = "EGKA_APP"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -4,6 +4,7 @@ prefixes = ["EGAA"]
 frequency = "133.130"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGAA_APP"]
 
 [[positions]]
 id = "EGAA_F_APP"
@@ -11,6 +12,7 @@ prefixes = ["EGAA"]
 frequency = "120.905"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGAA_F_APP"]
 
 [[positions]]
 id = "EGAA_TWR"
@@ -18,6 +20,7 @@ prefixes = ["EGAA"]
 frequency = "118.305"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGAA_TWR"]
 
 [[positions]]
 id = "EGAA_GND"
@@ -25,6 +28,7 @@ prefixes = ["EGAA"]
 frequency = "121.755"
 facility_type = "GND"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGAA_GND"]
 
 [[positions]]
 id = "EGAC_APP"
@@ -32,6 +36,7 @@ prefixes = ["EGAC"]
 frequency = "130.855"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGAC_APP"]
 
 [[positions]]
 id = "EGAC_F_APP"
@@ -46,6 +51,7 @@ prefixes = ["EGAC"]
 frequency = "122.830"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGAC_TWR"]
 
 [[positions]]
 id = "EGAE_A_APP"
@@ -1299,6 +1305,7 @@ prefixes = ["EGPF"]
 frequency = "119.105"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPF_APP"]
 
 [[positions]]
 id = "EGPF_F_APP"
@@ -1306,6 +1313,7 @@ prefixes = ["EGPF"]
 frequency = "128.755"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPF_F_APP"]
 
 [[positions]]
 id = "EGPF_TWR"
@@ -1313,6 +1321,7 @@ prefixes = ["EGPF"]
 frequency = "118.805"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPF_TWR"]
 
 [[positions]]
 id = "EGPF_GND"
@@ -1320,6 +1329,7 @@ prefixes = ["EGPF"]
 frequency = "121.705"
 facility_type = "GND"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPF_GND"]
 
 [[positions]]
 id = "EGPH_APP"
@@ -1327,6 +1337,7 @@ prefixes = ["EGPH"]
 frequency = "121.205"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPH_APP"]
 
 [[positions]]
 id = "EGPH_F_APP"
@@ -1334,6 +1345,7 @@ prefixes = ["EGPH"]
 frequency = "128.980"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPH_F_APP"]
 
 [[positions]]
 id = "EGPH_TWR"
@@ -1341,6 +1353,7 @@ prefixes = ["EGPH"]
 frequency = "118.705"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPH_TWR"]
 
 [[positions]]
 id = "EGPH_GND"
@@ -1348,6 +1361,7 @@ prefixes = ["EGPH"]
 frequency = "121.755"
 facility_type = "GND"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPH_GND"]
 
 [[positions]]
 id = "EGPH_DEL"
@@ -1355,6 +1369,7 @@ prefixes = ["EGPH"]
 frequency = "121.980"
 facility_type = "DEL"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPH_DEL"]
 
 [[positions]]
 id = "EGPK_APP"
@@ -1362,6 +1377,7 @@ prefixes = ["EGPK"]
 frequency = "129.450"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPK_APP"]
 
 [[positions]]
 id = "EGPK_F_APP"
@@ -1369,6 +1385,7 @@ prefixes = ["EGPK"]
 frequency = "124.630"
 facility_type = "APP"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPK_F_APP"]
 
 [[positions]]
 id = "EGPK_TWR"
@@ -1376,6 +1393,7 @@ prefixes = ["EGPK"]
 frequency = "118.155"
 facility_type = "TWR"
 profile_id = "EG-Scottish"
+default_call_sources = ["EGPK_TWR"]
 
 [[positions]]
 id = "EGPL_A_APP"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -121,6 +121,7 @@ prefixes = ["EGCC"]
 frequency = "121.355"
 facility_type = "APP"
 profile_id = "EGCC"
+default_call_sources = ["EGCC_F_APP"]
 
 [[positions]]
 id = "EGCC_N_APP"
@@ -128,6 +129,7 @@ prefixes = ["EGCC"]
 frequency = "135.005"
 facility_type = "APP"
 profile_id = "EGCC"
+default_call_sources = ["EGCC_N_APP"]
 
 [[positions]]
 id = "EGCC_S_APP"
@@ -135,6 +137,7 @@ prefixes = ["EGCC"]
 frequency = "118.580"
 facility_type = "APP"
 profile_id = "EGCC"
+default_call_sources = ["EGCC_S_APP"]
 
 [[positions]]
 id = "EGCC_N_TWR"
@@ -142,6 +145,7 @@ prefixes = ["EGCC"]
 frequency = "118.630"
 facility_type = "TWR"
 profile_id = "EGCC"
+default_call_sources = ["EGCC_N_TWR"]
 
 [[positions]]
 id = "EGCC_S_TWR"
@@ -149,6 +153,7 @@ prefixes = ["EGCC"]
 frequency = "119.405"
 facility_type = "TWR"
 profile_id = "EGCC"
+default_call_sources = ["EGCC_S_TWR"]
 
 [[positions]]
 id = "EGCC_GND"
@@ -156,6 +161,7 @@ prefixes = ["EGCC"]
 frequency = "121.855"
 facility_type = "GND"
 profile_id = "EGCC"
+default_call_sources = ["EGCC_GND"]
 
 [[positions]]
 id = "EGCC_DEL"
@@ -163,6 +169,7 @@ prefixes = ["EGCC"]
 frequency = "121.705"
 facility_type = "DEL"
 profile_id = "EGCC"
+default_call_sources = ["EGCC_DEL"]
 
 [[positions]]
 id = "EGCC_A_DEL"
@@ -170,6 +177,7 @@ prefixes = ["EGCC"]
 frequency = "199.998"
 facility_type = "DEL"
 profile_id = "EGCC"
+default_call_sources = ["EGCC_A_DEL"]
 
 [[positions]]
 id = "EGCC_P_GND"
@@ -177,6 +185,7 @@ prefixes = ["EGCC"]
 frequency = "130.650"
 facility_type = "GND"
 profile_id = "EGCC"
+default_call_sources = ["EGCC_P_GND"]
 
 [[positions]]
 id = "EGDI_TWR"
@@ -324,6 +333,7 @@ prefixes = ["EGGP"]
 frequency = "119.855"
 facility_type = "APP"
 profile_id = "EG-North_LAG"
+default_call_sources = ["EGGP_APP"]
 
 [[positions]]
 id = "EGGP_F_APP"
@@ -331,6 +341,7 @@ prefixes = ["EGGP"]
 frequency = "118.455"
 facility_type = "APP"
 profile_id = "EG-North_LAG"
+default_call_sources = ["EGGP_F_APP"]
 
 [[positions]]
 id = "EGGP_TWR"
@@ -916,6 +927,7 @@ prefixes = ["EGNH"]
 frequency = "119.955"
 facility_type = "APP"
 profile_id = "EG-North_LAG"
+default_call_sources = ["EGNH_A_APP"]
 
 [[positions]]
 id = "EGNH_TWR"
@@ -944,6 +956,7 @@ prefixes = ["EGNM"]
 frequency = "134.580"
 facility_type = "APP"
 profile_id = "EG-North_LAG"
+default_call_sources = ["EGNM_APP"]
 
 [[positions]]
 id = "EGNM_F_APP"
@@ -951,6 +964,7 @@ prefixes = ["EGNM"]
 frequency = "125.380"
 facility_type = "APP"
 profile_id = "EG-North_LAG"
+default_call_sources = ["EGNM_F_APP"]
 
 [[positions]]
 id = "EGNM_TWR"
@@ -958,6 +972,7 @@ prefixes = ["EGNM"]
 frequency = "120.305"
 facility_type = "TWR"
 profile_id = "EG-North_LAG"
+default_call_sources = ["EGNM_TWR"]
 
 [[positions]]
 id = "EGNM_DEL"
@@ -965,6 +980,7 @@ prefixes = ["EGNM"]
 frequency = "121.805"
 facility_type = "DEL"
 profile_id = "EG-North_LAG"
+default_call_sources = ["EGNM_DEL"]
 
 [[positions]]
 id = "EGNO_APP"
@@ -972,6 +988,7 @@ prefixes = ["EGNO"]
 frequency = "129.530"
 facility_type = "APP"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGNO_APP"]
 
 [[positions]]
 id = "EGNO_P_APP"
@@ -993,6 +1010,7 @@ prefixes = ["EGNR"]
 frequency = "120.055"
 facility_type = "APP"
 profile_id = "EG-North_LAG"
+default_call_sources = ["EGNR_APP"]
 
 [[positions]]
 id = "EGNR_F_APP"
@@ -1000,6 +1018,7 @@ prefixes = ["EGNR"]
 frequency = "130.015"
 facility_type = "APP"
 profile_id = "EG-North_LAG"
+default_call_sources = ["EGNR_F_APP"]
 
 [[positions]]
 id = "EGNR_TWR"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -438,6 +438,7 @@ prefixes = ["SOLENT"]
 frequency = "120.230"
 facility_type = "APP"
 profile_id = "EG-South_LAG"
+default_call_sources = ["SOLENT_APP"]
 
 [[positions]]
 id = "EGHH_APP"
@@ -445,6 +446,7 @@ prefixes = ["EGHH"]
 frequency = "119.480"
 facility_type = "APP"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGHH_APP"]
 
 [[positions]]
 id = "EGHH_F_APP"
@@ -452,6 +454,7 @@ prefixes = ["EGHH"]
 frequency = "118.655"
 facility_type = "APP"
 profile_id = "EG-South_LAG"
+default_call_sources = ["EGHH_F_APP"]
 
 [[positions]]
 id = "EGHH_TWR"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -2190,6 +2190,7 @@ prefixes = ["STHRN"]
 frequency = "134.035"
 facility_type = "APP"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["STHRN_APP"]
 
 #######################
 # London Area

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -1740,6 +1740,7 @@ prefixes = ["EGVV"]
 frequency = "135.150"
 facility_type = "CTR"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGVV_A_CTR"]
 
 [[positions]]
 id = "EGVV_CTR"
@@ -1747,6 +1748,7 @@ prefixes = ["EGVV"]
 frequency = "133.900"
 facility_type = "CTR"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGVV_CTR"]
 
 [[positions]]
 id = "EGVV_C_CTR"
@@ -1754,6 +1756,7 @@ prefixes = ["EGVV"]
 frequency = "128.700"
 facility_type = "CTR"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGVV_C_CTR"]
 
 [[positions]]
 id = "EGVV_D_CTR"
@@ -1761,6 +1764,7 @@ prefixes = ["EGVV"]
 frequency = "199.900"
 facility_type = "CTR"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGVV_D_CTR"]
 
 [[positions]]
 id = "EGVV_E_CTR"
@@ -1768,6 +1772,7 @@ prefixes = ["EGVV"]
 frequency = "133.325"
 facility_type = "CTR"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGVV_E_CTR"]
 
 [[positions]]
 id = "EGVV_F_CTR"
@@ -1775,6 +1780,7 @@ prefixes = ["EGVV"]
 frequency = "135.075"
 facility_type = "CTR"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGVV_F_CTR"]
 
 [[positions]]
 id = "EGVV_N_CTR"
@@ -1782,6 +1788,7 @@ prefixes = ["EGVV"]
 frequency = "136.375"
 facility_type = "CTR"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGVV_N_CTR"]
 
 [[positions]]
 id = "EGVV_Q_CTR"
@@ -1789,6 +1796,7 @@ prefixes = ["EGVV"]
 frequency = "134.300"
 facility_type = "CTR"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGVV_Q_CTR"]
 
 [[positions]]
 id = "EGVV_W_CTR"
@@ -1796,6 +1804,7 @@ prefixes = ["EGVV"]
 frequency = "127.450"
 facility_type = "CTR"
 profile_id = "EG-Swanwick_Military"
+default_call_sources = ["EGVV_W_CTR"]
 
 [[positions]]
 id = "EGWC_APP"

--- a/dataset/EG/positions.toml
+++ b/dataset/EG/positions.toml
@@ -2438,7 +2438,7 @@ prefixes = ["LTC"]
 frequency = "135.805"
 facility_type = "CTR"
 profile_id = "EG-TC_BBX"
-default_call_sources = [ "LTC_SE_CTR", "LTC_NE_CTR", "LTC_NW_CTR", "LTC_SW_CTR" ]
+default_call_sources = ["LTC_SE_CTR", "LTC_NE_CTR", "LTC_NW_CTR", "LTC_SW_CTR"]
 
 [[positions]]
 id = "LTC_ED_CTR"

--- a/dataset/EG/stations.toml
+++ b/dataset/EG/stations.toml
@@ -1286,6 +1286,11 @@ id = "EGLD_I_TWR"
 controlled_by = ["EGLD_I_TWR"]
 
 [[stations]]
+id = "EGLF_GND"
+parent_id = "EGLF_TWR"
+controlled_by = ["EGLF_GND"]
+
+[[stations]]
 id = "EGLF_TWR"
 parent_id = "EGLF_APP"
 controlled_by = ["EGLF_TWR"]


### PR DESCRIPTION
Sets default call sources for all currently defined AD positions, and Gibraltar/Falklands positions.
Also sets default sources for standard splits based on heaviest traffic day-to-day subsector (list from @hazzas-99). 