### PR TITLE
Add SAVF to Island profile

### DIFF
--- a/dataset/EG/profiles/ISLAND.json
+++ b/dataset/EG/profiles/ISLAND.json
@@ -9,14 +9,17 @@
         "keys": [
           {
             "label": ["Comodoro", "Centro", "SAVF-S"],
+            "color": "steel",
             "station_id": "SAVF_S_CTR"
           },
           {
             "label": ["Comodoro", "Centro", "SAVF-BBx"],
+            "color": "steel",
             "station_id": "SAVF_CTR"
           },
           {
             "label": ["Stanley", "Info"],
+            "color": "lavender",
             "station_id": "SFAL_I_TWR"
           },
 
@@ -31,6 +34,7 @@
           },
           {
             "label": ["ISLAND", "RAD"],
+            "color": "mint",
             "station_id": "ISLAND_CTR"
           },
           {
@@ -38,18 +42,22 @@
           },
           {
             "label": ["YP", "GMC"],
+            "color": "lilac",
             "station_id": "EGYP_GND"
           },
           {
             "label": ["YP", "RAD"],
+            "color": "lagoon",
             "station_id": "EGYP_APP"
           },
           {
             "label": ["YP", "T/D"],
+            "color": "lagoon",
             "station_id": "EGYP_P_APP"
           },
           {
             "label": ["YP", "AIR"],
+            "color": "lavender",
             "station_id": "EGYP_TWR"
           }
         ]

--- a/dataset/EG/profiles/ISLAND.json
+++ b/dataset/EG/profiles/ISLAND.json
@@ -8,10 +8,12 @@
         "rows": 3,
         "keys": [
           {
-            "label": ["Comodoro", "Centro", "(INOP)"]
+            "label": ["Comodoro", "Centro", "SAVF-S"],
+            "station_id": "SAVF_S_CTR"
           },
           {
-            "label": []
+            "label": ["Comodoro", "Centro", "SAVF-BBx"],
+            "station_id": "SAVF_CTR"
           },
           {
             "label": ["Stanley", "Info"],


### PR DESCRIPTION
Adds SAVF `station_id` to Island profile. New button required as the SA area stations do not inherit.

Additionally adds colours to better distinguish items.

<img width="1487" height="1053" alt="image" src="https://github.com/user-attachments/assets/9887a89e-b5c7-4662-bca3-d3f4e5449cb6" />
