### PR TITLE
Update PRC sectorisation for VHHK

### DIFF
--- a/dataset/RCAA/profiles/RCAA.json
+++ b/dataset/RCAA/profiles/RCAA.json
@@ -375,10 +375,6 @@
             "station_id": "MNL_N_CTR"
           },
           {
-            "label": ["ZSHA", "CTR"],
-            "station_id": "ZSHA_CTR"
-          },
-          {
             "label": ["ZSSS", "S_CTR"],
             "station_id": "ZSSS_S_CTR"
           },
@@ -393,6 +389,9 @@
           {
             "label": ["ZGGG", "CTR"],
             "station_id": "ZGGG_CTR"
+          },
+          {
+            "label": []
           },
           {
             "label": []

--- a/dataset/VH/positions.json
+++ b/dataset/VH/positions.json
@@ -328,13 +328,6 @@
       "profile_id": "VHHK"
     },
     {
-      "id": "ZBBB_FSS",
-      "prefixes": ["PRC"],
-      "frequency": "133.075",
-      "facility_type": "FSS",
-      "profile_id": "VHHK"
-    },
-    {
       "id": "ZSSS_S_CTR",
       "prefixes": ["ZSSS"],
       "frequency": "120.900",
@@ -349,23 +342,9 @@
       "profile_id": "VHHK"
     },
     {
-      "id": "ZSHA_CTR",
-      "prefixes": ["ZSHA"],
-      "frequency": "124.550",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
       "id": "ZSAM_CTR",
       "prefixes": ["ZSAM"],
       "frequency": "125.700",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "ZJSA_CTR",
-      "prefixes": ["ZJSA"],
-      "frequency": "120.500",
       "facility_type": "CTR",
       "profile_id": "VHHK"
     },
@@ -380,13 +359,6 @@
       "id": "ZJSY_O_CTR",
       "prefixes": ["ZJSY"],
       "frequency": "130.200",
-      "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "ZGZU_CTR",
-      "prefixes": ["ZGZU"],
-      "frequency": "132.750",
       "facility_type": "CTR",
       "profile_id": "VHHK"
     },
@@ -423,13 +395,6 @@
       "prefixes": ["ZGGG"],
       "frequency": "128.350",
       "facility_type": "CTR",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "ZGGG_APP",
-      "prefixes": ["ZGGG"],
-      "frequency": "126.550",
-      "facility_type": "APP",
       "profile_id": "VHHK"
     }
   ]

--- a/dataset/VH/positions.json
+++ b/dataset/VH/positions.json
@@ -356,6 +356,13 @@
       "profile_id": "VHHK"
     },
     {
+      "id": "ZJSY_N_CTR",
+      "prefixes": ["ZJSY"],
+      "frequency": "134.450",
+      "facility_type": "CTR",
+      "profile_id": "VHHK"
+    },
+    {
       "id": "ZJSY_O_CTR",
       "prefixes": ["ZJSY"],
       "frequency": "130.200",
@@ -363,9 +370,58 @@
       "profile_id": "VHHK"
     },
     {
+      "id": "ZJSY_CTR",
+      "prefixes": ["ZJSY"],
+      "frequency": "120.500",
+      "facility_type": "CTR",
+      "profile_id": "VHHK"
+    },
+    {
+      "id": "ZGNN_S_CTR",
+      "prefixes": ["ZGNN"],
+      "frequency": "133.950",
+      "facility_type": "CTR",
+      "profile_id": "VHHK"
+    },
+    {
       "id": "ZGNN_CTR",
       "prefixes": ["ZGNN"],
-      "frequency": "132.700",
+      "frequency": "133.600",
+      "facility_type": "CTR",
+      "profile_id": "VHHK"
+    },
+    {
+      "id": "ZGGG_S_CTR",
+      "prefixes": ["ZGGG"],
+      "frequency": "124.450",
+      "facility_type": "CTR",
+      "profile_id": "VHHK"
+    },
+    {
+      "id": "ZGGG_S1_CTR",
+      "prefixes": ["ZGGG"],
+      "frequency": "125.350",
+      "facility_type": "CTR",
+      "profile_id": "VHHK"
+    },
+    {
+      "id": "ZGGG_E_CTR",
+      "prefixes": ["ZGGG"],
+      "frequency": "133.475",
+      "facility_type": "CTR",
+      "profile_id": "VHHK"
+    },
+    {
+      "id": "ZGGG_E1_CTR",
+      "prefixes": ["ZGGG"],
+      "frequency": "133.975",
+      "facility_type": "CTR",
+      "profile_id": "VHHK"
+    },
+    {
+      "id": "ZGGG_CTR",
+      "prefixes": ["ZGGG"],
+      "frequency": "118.950",
       "facility_type": "CTR",
       "profile_id": "VHHK"
     },
@@ -388,13 +444,6 @@
       "prefixes": ["ZGJD"],
       "frequency": "120.350",
       "facility_type": "APP",
-      "profile_id": "VHHK"
-    },
-    {
-      "id": "ZGGG_CTR",
-      "prefixes": ["ZGGG"],
-      "frequency": "128.350",
-      "facility_type": "CTR",
       "profile_id": "VHHK"
     }
   ]

--- a/dataset/VH/profiles/VHHK.json
+++ b/dataset/VH/profiles/VHHK.json
@@ -441,34 +441,6 @@
             "station_id": "MNL_CTR"
           },
           {
-            "label": ["ZGZU"],
-            "station_id": "ZGZU_CTR"
-          },
-          {
-            "label": ["ZJSA"],
-            "station_id": "ZJSA_CTR"
-          },
-          {
-            "label": ["ZSHA"],
-            "station_id": "ZSHA_CTR"
-          },
-          {
-            "label": ["ASEA"],
-            "station_id": "ASEA_FSS"
-          },
-          {
-            "label": ["PRC"],
-            "station_id": "ZBBB_FSS"
-          },
-          {
-            "label": ["RCTP-L"],
-            "station_id": "ALR"
-          },
-          {
-            "label": ["RPHI-N"],
-            "station_id": "MNL_N_CTR"
-          },
-          {
             "label": ["ZGGG"],
             "station_id": "ZGGG_CTR"
           },
@@ -481,18 +453,19 @@
             "station_id": "ZSSS_CTR"
           },
           {
-            "label": []
+            "label": ["ASEA"],
+            "station_id": "ASEA_FSS"
           },
           {
             "label": []
           },
           {
-            "label": ["RCTP-E"],
-            "station_id": "AER"
+            "label": ["RCTP-L"],
+            "station_id": "ALR"
           },
           {
-            "label": ["RPHI-NW"],
-            "station_id": "MNL_NW_CTR"
+            "label": ["RPHI-N"],
+            "station_id": "MNL_N_CTR"
           },
           {
             "label": ["ZGNN"],
@@ -513,11 +486,12 @@
             "label": []
           },
           {
-            "label": ["RCTP-N"],
-            "station_id": "ANR"
+            "label": ["RCTP-E"],
+            "station_id": "AER"
           },
           {
-            "label": []
+            "label": ["RPHI-NW"],
+            "station_id": "MNL_NW_CTR"
           },
           {
             "label": ["ZGJD"],
@@ -537,8 +511,8 @@
             "label": []
           },
           {
-            "label": ["RCTP-S"],
-            "station_id": "ASR"
+            "label": ["RCTP-N"],
+            "station_id": "ANR"
           },
           {
             "label": []
@@ -560,7 +534,8 @@
             "label": []
           },
           {
-            "label": []
+            "label": ["RCTP-S"],
+            "station_id": "ASR"
           },
           {
             "label": []
@@ -568,6 +543,27 @@
           {
             "label": ["ZGZJ"],
             "station_id": "ZGZJ_APP"
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
+          },
+          {
+            "label": []
           },
           {
             "label": []

--- a/dataset/VH/profiles/VHHK.json
+++ b/dataset/VH/profiles/VHHK.json
@@ -444,9 +444,13 @@
             "label": ["ZGGG"],
             "station_id": "ZGGG_CTR"
           },
+           {
+            "label": ["ZGJD"],
+            "station_id": "ZGJD_APP"
+          },
           {
-            "label": ["ZJSY-L"],
-            "station_id": "ZJSY_L_CTR"
+            "label": ["ZJSY"],
+            "station_id": "ZJSY_CTR"
           },
           {
             "label": ["ZSSS"],
@@ -457,9 +461,6 @@
             "station_id": "ASEA_FSS"
           },
           {
-            "label": []
-          },
-          {
             "label": ["RCTP-L"],
             "station_id": "ALR"
           },
@@ -468,19 +469,20 @@
             "station_id": "MNL_N_CTR"
           },
           {
-            "label": ["ZGNN"],
-            "station_id": "ZGNN_CTR"
+            "label": ["ZGGG-S"],
+            "station_id": "ZGGG_S_CTR"
           },
           {
-            "label": ["ZJSY-O"],
-            "station_id": "ZJSY_O_CTR"
+            "label": ["ZGOW"],
+            "station_id": "ZGOW_APP"
+          },
+          {
+            "label": ["ZJSY-N"],
+            "station_id": "ZJSY_N_CTR"
           },
           {
             "label": ["ZSSS-S"],
             "station_id": "ZSSS_S_CTR"
-          },
-          {
-            "label": []
           },
           {
             "label": []
@@ -494,18 +496,20 @@
             "station_id": "MNL_NW_CTR"
           },
           {
-            "label": ["ZGJD"],
-            "station_id": "ZGJD_APP"
+            "label": ["ZGGG-S1"],
+            "station_id": "ZGGG_S1_CTR"
+          },
+           {
+            "label": ["ZGZJ"],
+            "station_id": "ZGZJ_APP"
           },
           {
-            "label": []
+            "label": ["ZJSY-L"],
+            "station_id": "ZJSY_L_CTR"
           },
           {
             "label": ["ZSAM"],
             "station_id": "ZSAM_CTR"
-          },
-          {
-            "label": []
           },
           {
             "label": []
@@ -517,15 +521,16 @@
           {
             "label": []
           },
-          {
-            "label": ["ZGOW"],
-            "station_id": "ZGOW_APP"
+           {
+            "label": ["ZGGG-E"],
+            "station_id": "ZGGG_E_CTR"
           },
           {
             "label": []
           },
-          {
-            "label": []
+           {
+            "label": ["ZJSY-O"],
+            "station_id": "ZJSY_O_CTR"
           },
           {
             "label": []
@@ -537,18 +542,12 @@
             "label": ["RCTP-S"],
             "station_id": "ASR"
           },
-          {
+           {
             "label": []
           },
           {
-            "label": ["ZGZJ"],
-            "station_id": "ZGZJ_APP"
-          },
-          {
-            "label": []
-          },
-          {
-            "label": []
+            "label": ["ZGGG-E1"],
+            "station_id": "ZGGG_E1_CTR"
           },
           {
             "label": []
@@ -569,7 +568,8 @@
             "label": []
           },
           {
-            "label": []
+            "label": ["ZGNN"],
+            "station_id": "ZGNN_CTR"
           },
           {
             "label": []
@@ -590,7 +590,8 @@
             "label": []
           },
           {
-            "label": []
+            "label": ["ZGNN-S"],
+            "station_id": "ZGNN_S_CTR"
           },
           {
             "label": []
@@ -605,6 +606,12 @@
             "label": []
           },
           {
+            "label": []
+          },
+          {
+            "label": []
+          },
+           {
             "label": []
           },
           {

--- a/dataset/VH/profiles/VHHK.json
+++ b/dataset/VH/profiles/VHHK.json
@@ -444,7 +444,7 @@
             "label": ["ZGGG"],
             "station_id": "ZGGG_CTR"
           },
-           {
+          {
             "label": ["ZGJD"],
             "station_id": "ZGJD_APP"
           },
@@ -499,7 +499,7 @@
             "label": ["ZGGG-S1"],
             "station_id": "ZGGG_S1_CTR"
           },
-           {
+          {
             "label": ["ZGZJ"],
             "station_id": "ZGZJ_APP"
           },
@@ -521,14 +521,14 @@
           {
             "label": []
           },
-           {
+          {
             "label": ["ZGGG-E"],
             "station_id": "ZGGG_E_CTR"
           },
           {
             "label": []
           },
-           {
+          {
             "label": ["ZJSY-O"],
             "station_id": "ZJSY_O_CTR"
           },
@@ -542,7 +542,7 @@
             "label": ["RCTP-S"],
             "station_id": "ASR"
           },
-           {
+          {
             "label": []
           },
           {
@@ -611,7 +611,7 @@
           {
             "label": []
           },
-           {
+          {
             "label": []
           },
           {

--- a/dataset/VH/stations.json
+++ b/dataset/VH/stations.json
@@ -204,10 +204,6 @@
       "controlled_by": ["ASEA_FSS"]
     },
     {
-      "id": "ZBBB_FSS",
-      "controlled_by": ["ZBBB_FSS"]
-    },
-    {
       "id": "ZSSS_S_CTR",
       "parent_id": "ZSSS_CTR",
       "controlled_by": ["ZSSS_S_CTR"]
@@ -218,17 +214,9 @@
       "controlled_by": ["ZSSS_CTR"]
     },
     {
-      "id": "ZSHA_CTR",
-      "controlled_by": ["ZSHA_CTR"]
-    },
-    {
       "id": "ZSAM_CTR",
       "parent_id": "ZSHA_CTR",
       "controlled_by": ["ZSAM_CTR"]
-    },
-    {
-      "id": "ZJSA_CTR",
-      "controlled_by": ["ZJSA_CTR"]
     },
     {
       "id": "ZJSY_L_CTR",
@@ -239,10 +227,6 @@
       "id": "ZJSY_O_CTR",
       "parent_id": "ZJSA_CTR",
       "controlled_by": ["ZJSY_O_CTR"]
-    },
-    {
-      "id": "ZGZU_CTR",
-      "controlled_by": ["ZGZU_CTR"]
     },
     {
       "id": "ZGNN_CTR",
@@ -273,11 +257,6 @@
       "id": "ZGGG_CTR",
       "parent_id": "ZGZU_CTR",
       "controlled_by": ["ZGGG_CTR"]
-    },
-    {
-      "id": "ZGGG_APP",
-      "parent_id": "ZGGG_CTR",
-      "controlled_by": ["ZGGG_APP"]
     }
   ]
 }

--- a/dataset/VH/stations.json
+++ b/dataset/VH/stations.json
@@ -210,27 +210,22 @@
     },
     {
       "id": "ZSSS_CTR",
-      "parent_id": "ZSHA_CTR",
       "controlled_by": ["ZSSS_CTR"]
     },
     {
       "id": "ZSAM_CTR",
-      "parent_id": "ZSHA_CTR",
       "controlled_by": ["ZSAM_CTR"]
     },
     {
       "id": "ZJSY_L_CTR",
-      "parent_id": "ZJSA_CTR",
       "controlled_by": ["ZJSY_L_CTR"]
     },
     {
       "id": "ZJSY_O_CTR",
-      "parent_id": "ZJSA_CTR",
       "controlled_by": ["ZJSY_O_CTR"]
     },
     {
       "id": "ZGNN_CTR",
-      "parent_id": "ZGZU_CTR",
       "controlled_by": ["ZGNN_CTR"]
     },
     {
@@ -243,9 +238,7 @@
       "controlled_by": [
         "ZGOW_APP",
         "ZGGG_CTR",
-        "ZGZU_CTR",
-        "ZSAM_CTR",
-        "ZSHA_CTR"
+        "ZSAM_CTR"
       ]
     },
     {
@@ -255,7 +248,6 @@
     },
     {
       "id": "ZGGG_CTR",
-      "parent_id": "ZGZU_CTR",
       "controlled_by": ["ZGGG_CTR"]
     }
   ]

--- a/dataset/VH/stations.json
+++ b/dataset/VH/stations.json
@@ -218,15 +218,55 @@
     },
     {
       "id": "ZJSY_L_CTR",
+      "parent_id": "ZJSY_CTR",
       "controlled_by": ["ZJSY_L_CTR"]
     },
     {
+      "id": "ZJSY_N_CTR",
+      "parent_id": "ZJSY_L_CTR",
+      "controlled_by": ["ZJSY_N_CTR"]
+    },
+    {
       "id": "ZJSY_O_CTR",
+      "parent_id": "ZJSY_CTR",
       "controlled_by": ["ZJSY_O_CTR"]
+    },
+    {
+      "id": "ZJSY_CTR",
+      "controlled_by": ["ZJSY_CTR"]
+    },
+    {
+      "id": "ZGNN_S_CTR",
+      "parent_id": "ZGNN_CTR",
+      "controlled_by": ["ZGNN_S_CTR"]
     },
     {
       "id": "ZGNN_CTR",
       "controlled_by": ["ZGNN_CTR"]
+    },
+    {
+      "id": "ZGGG_S_CTR",
+      "parent_id": "ZGGG_CTR",
+      "controlled_by": ["ZGGG_S_CTR"]
+    },
+    {
+      "id": "ZGGG_S1_CTR",
+      "parent_id": "ZGGG_S_CTR",
+      "controlled_by": ["ZGGG_S1_CTR"]
+    },
+    {
+      "id": "ZGGG_E_CTR",
+      "parent_id": "ZGGG_CTR",
+      "controlled_by": ["ZGGG_E_CTR"]
+    },
+    {
+      "id": "ZGGG_E1_CTR",
+      "parent_id": "ZGGG_E_CTR",
+      "controlled_by": ["ZGGG_E1_CTR"]
+    },
+    {
+      "id": "ZGGG_CTR",
+      "controlled_by": ["ZGGG_CTR"]
     },
     {
       "id": "ZGZJ_APP",
@@ -241,10 +281,6 @@
       "id": "ZGJD_APP",
       "parent_id": "ZGGG_CTR",
       "controlled_by": ["ZGJD_APP"]
-    },
-    {
-      "id": "ZGGG_CTR",
-      "controlled_by": ["ZGGG_CTR"]
     }
   ]
 }

--- a/dataset/VH/stations.json
+++ b/dataset/VH/stations.json
@@ -218,15 +218,55 @@
     },
     {
       "id": "ZJSY_L_CTR",
+      "parent_id": "ZJSY_CTR",
       "controlled_by": ["ZJSY_L_CTR"]
     },
     {
+      "id": "ZJSY_N_CTR",
+      "parent_id": "ZJSY_L_CTR",
+      "controlled_by": ["ZJSY_N_CTR"]
+    },
+    {
       "id": "ZJSY_O_CTR",
+      "parent_id": "ZJSY_CTR",
       "controlled_by": ["ZJSY_O_CTR"]
+    },
+    {
+      "id": "ZJSY_CTR",
+      "controlled_by": ["ZJSY_CTR"]
+    },
+    {
+      "id": "ZGNN_S_CTR",
+      "parent_id": "ZGNN_CTR",
+      "controlled_by": ["ZGNN_S_CTR"]
     },
     {
       "id": "ZGNN_CTR",
       "controlled_by": ["ZGNN_CTR"]
+    },
+    {
+      "id": "ZGGG_S_CTR",
+      "parent_id": "ZGGG_CTR",
+      "controlled_by": ["ZGGG_S_CTR"]
+    },
+    {
+      "id": "ZGGG_S1_CTR",
+      "parent_id": "ZGGG_S_CTR",
+      "controlled_by": ["ZGGG_S1_CTR"]
+    },
+    {
+      "id": "ZGGG_E_CTR",
+      "parent_id": "ZGGG_CTR",
+      "controlled_by": ["ZGGG_E_CTR"]
+    },
+    {
+      "id": "ZGGG_E1_CTR",
+      "parent_id": "ZGGG_E_CTR",
+      "controlled_by": ["ZGGG_E1_CTR"]
+    },
+    {
+      "id": "ZGGG_CTR",
+      "controlled_by": ["ZGGG_CTR"]
     },
     {
       "id": "ZGZJ_APP",
@@ -245,10 +285,6 @@
       "id": "ZGJD_APP",
       "parent_id": "ZGGG_CTR",
       "controlled_by": ["ZGJD_APP"]
-    },
-    {
-      "id": "ZGGG_CTR",
-      "controlled_by": ["ZGGG_CTR"]
     }
   ]
 }


### PR DESCRIPTION
### Description

- Updated PRC positions within VHHK profile

### AIRAC dependency

- [ ] This change is **AIRAC-dependent** and should only go live after a specific AIRAC cycle takes effect.

<!-- If checked, add the appropriate airac/XXYY label to this PR (e.g., airac/2604).
     The merge check will block until that cycle's effective date, then pass automatically.
     You can enable auto-merge now -- the PR will merge on its own once the gate opens and CI passes. -->

### Checklist

- [X] Dataset files are in the correct `dataset/{FIR}/` directory.
- [X] I have verified the data is correct.
- [ ] If adding a new FIR: CODEOWNERS entry added and maintainer team noted in PR description.
- [ ] If contributing from a fork: "Allow edits by maintainers" is enabled.
